### PR TITLE
If the root collection is not public, requests in util.path.lookUpPat…

### DIFF
--- a/server/utils.py
+++ b/server/utils.py
@@ -3,7 +3,7 @@ from girder.utility.model_importer import ModelImporter
 
 def getOrCreateRootFolder(name):
     collection = ModelImporter.model('collection').createCollection(
-        name, public=False, reuseExisting=True)
+        name, public=True, reuseExisting=True)
     folder = ModelImporter.model('folder').createFolder(
         collection, name, parentType='collection', public=True, reuseExisting=True)
     return folder


### PR DESCRIPTION
…h fail. Maybe we should change lookUpPath, but it would not be what, e.g., happens in my shell prompt. That said, on my shell prompt I would not be able to access a file unless all parents to the root have +x, but girder would happily show me a folder that I have access to even if I have no access to the parents. Anyway...