### PR TITLE
Remove verification steps in register and listFiles endpoints

### DIFF
--- a/server/dataone_register.py
+++ b/server/dataone_register.py
@@ -318,17 +318,6 @@ def get_package_list(path, package=None, isChild=False):
     data = extract_data_docs(docs)
     children = extract_resource_docs(docs)
 
-    # Verify what's in Solr is matching.
-    verify_results(package_pid, docs)
-
-    # Find the primary/documenting metadata so we can later on find the
-    # folder name
-    # TODO: Grabs the resmap a second time, fix this
-    documenting = get_documenting_identifiers(package_pid)
-
-    # Stop now if multiple objects document others
-    check_multiple_maps(documenting)
-
     # Determine the folder name. This is usually the title of the metadata file
     # in the package but when there are multiple metadata files in the package,
     # we need to figure out which one is the 'main' or 'documenting' one.

--- a/server/rest/harvester.py
+++ b/server/rest/harvester.py
@@ -9,13 +9,10 @@ from girder.constants import TokenScope
 from girder.utility.model_importer import ModelImporter
 from ..dataone_register import \
     D1_BASE, \
-    get_documenting_identifiers, \
     extract_metadata_docs, \
     get_documents, \
     extract_data_docs, \
     extract_resource_docs, \
-    verify_results, \
-    check_multiple_maps, \
     check_multiple_metadata
 
 

--- a/server/rest/harvester.py
+++ b/server/rest/harvester.py
@@ -52,17 +52,6 @@ def register_DataONE_resource(parent, parentType, progress, user, pid, name=None
     data = extract_data_docs(docs)
     children = extract_resource_docs(docs)
 
-    # Verify what's in Solr is matching
-    verify_results(pid, docs)
-
-    # Find the primary/documenting metadata so we can later on find the
-    # folder name
-    # TODO: Grabs the resmap a second time, fix this
-    documenting = get_documenting_identifiers(pid)
-
-    # Stop now if multiple objects document others
-    check_multiple_maps(documenting)
-
     # Add in URLs to resolve each metadata/data object by
     for i in range(len(metadata)):
         metadata[i]['url'] = \


### PR DESCRIPTION
The verification steps are really not necessary and slow down registration and listing of files in dataone packages. Some casual benchmarking reveals a ~ 7x performance increase