### PR TITLE
Add Endpoint for Publishing a Tale+Data

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -6,5 +6,7 @@ add_python_test(tale PLUGIN wholetale)
 add_python_test(instance PLUGIN wholetale)
 add_python_test(dataone_register PLUGIN wholetale)
 add_python_test(dataone_upload PLUGIN wholetale)
+add_python_test(dataone_utils PLUGIN wholetale)
+add_python_test(dataone_package PLUGIN wholetale)
 add_python_style_test(python_static_analysis_wholetale
                       "${PROJECT_SOURCE_DIR}/plugins/wholetale/server")

--- a/plugin_tests/dataone_package_test.py
+++ b/plugin_tests/dataone_package_test.py
@@ -1,0 +1,19 @@
+from tests import base
+from girder.api.rest import RestException
+from girder.constants import ROOT_DIR
+from girder.models.model_base import ValidationException
+
+from d1_client.mnclient_2_0 import MemberNodeClient_2_0
+from d1_common.types import dataoneTypes
+import uuid
+
+
+def setUpModule():
+
+    base.enabledPlugins.append('wholetale')
+    base.startServer()
+
+
+def tearDownModule():
+
+    base.stopServer()

--- a/plugin_tests/dataone_upload_test.py
+++ b/plugin_tests/dataone_upload_test.py
@@ -3,7 +3,7 @@ from girder.api.rest import RestException
 from girder.constants import ROOT_DIR
 from girder.models.model_base import ValidationException
 
-from d1_client.mnclient_2_0 import *
+from d1_client.mnclient_2_0 import MemberNodeClient_2_0
 from d1_common.types import dataoneTypes
 import uuid
 
@@ -32,20 +32,6 @@ class TestDataONEUpload(base.TestCase):
         client = create_client(member_node, header)
         self.assertIsNotNone(client)
 
-    def test_check_pid(self):
-        # Test that the pid gets converted to a string if its a number
-        from server.dataone_upload import check_pid
-
-        # The most common case will be a uuid
-        pid = uuid.uuid4()
-        pid = check_pid(pid)
-
-        self.assertTrue(isinstance(pid, str))
-
-        # Check that it works if numbers are accidentally used
-        pid = 1234
-        pid = check_pid(pid)
-        self.assertTrue(isinstance(pid, str))
 
     def test_upload_failure(self):
         # Test that we're throwing exceptions when uploading fails

--- a/plugin_tests/dataone_utils_test.py
+++ b/plugin_tests/dataone_utils_test.py
@@ -1,0 +1,38 @@
+import uuid
+
+from tests import base
+from girder.api.rest import RestException
+from girder.constants import ROOT_DIR
+from girder.models.model_base import ValidationException
+
+from d1_client.mnclient_2_0 import MemberNodeClient_2_0
+from d1_common.types import dataoneTypes
+
+
+def setUpModule():
+
+    base.enabledPlugins.append('wholetale')
+    base.startServer()
+
+
+def tearDownModule():
+
+    base.stopServer()
+
+
+class TestDataONEUtils(base.TestCase):
+
+    def test_check_pid(self):
+        # Test that the pid gets converted to a string if its a number
+        from server.dataone_upload import check_pid
+
+        # The most common case will be a uuid
+        pid = uuid.uuid4()
+        pid = check_pid(pid)
+
+        self.assertTrue(isinstance(pid, str))
+
+        # Check that it works if numbers are accidentally used
+        pid = 1234
+        pid = check_pid(pid)
+        self.assertTrue(isinstance(pid, str))

--- a/server/dataone_package.py
+++ b/server/dataone_package.py
@@ -1,0 +1,193 @@
+import datetime
+import hashlib
+
+from girder import logger
+from girder.models.file import File
+from .dataone_utils import check_pid
+
+from d1_common.types import dataoneTypes
+from d1_common import const as d1_const
+from d1_common.resource_map import createSimpleResourceMap
+
+
+def create_resource_map(resmap_pid, metadata_pid, file_pids):
+    """
+    Creates a resource map for the package.
+
+    :param resmap_pid: The pid od the resource map
+    :param metadata_pid: The pid of the science metadata
+    :param file_pids: The pids for each file in the package
+    :type resmap_pid: str
+    :type metadata_pid: str
+    :type file_pids: list
+    :return: The resource map for the package
+    :rtype: bytes
+    """
+
+    logger.debug('Entered create_resource_map')
+    res_map = createSimpleResourceMap(resmap_pid, metadata_pid, file_pids)
+    # createSimpleResourceMap returns type d1_common.resource_map.ResourceMap
+
+    logger.debug('Leaving create_resource_map')
+    return res_map.serialize()
+
+
+def create_minimum_eml(tale, user):
+    """
+    Creates a bare minimum EML record for a package. This includes the title,
+    creator, and contact.
+
+    :param tale: The tale that is being packaged.
+    :param user: The user that hit the endpoint
+    :type tale: wholetale.models.tale
+    :type user: girder.models.user
+    :return: The EML as as string of bytes
+    :rtype: bytes
+    """
+    logger.debug('Entered create_minimum_eml')
+
+    top = '<?xml version="1.0" encoding="UTF-8"?>'
+    namespace = '<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" ' \
+                'xmlns:stmml="http://www.xml-cml.org/schema/stmml-1.1" xmlns:' \
+                'xsi="http://www.w3.org/2001/XMLSchema-instance" packageId="' \
+                'doi:10.18739/A20Q25" system="https://arcticdata.io" xsi:' \
+                'schemaLocation="eml://ecoinformatics.org/eml-2.1.1 eml.xsd">'
+
+    dataset = '<dataset>\n'
+    title = '<title>{0}</title>\n'.format(str(tale.get('title', '')))
+
+    individual_name = '<individualName>\n<surName>\n{0}\n</surName>\n</individualName>'.format(
+        str(user.get('lastName', '')))
+
+    creator = '<creator>\n{0}\n</creator>\n'.format(individual_name)
+    contact = '<contact>\n{0}\n</contact>\n'.format(individual_name)
+    dataset_close = '</dataset>\n'
+    eml_close = '</eml:eml>'
+
+    # Append the above xml together to form the EML document
+    xml = top+namespace+dataset+title+creator+contact+dataset_close+eml_close
+
+    logger.debug('Leaving create_minimum_eml')
+    return xml.encode("utf-8")
+
+
+def get_file_md5(file_object, md5):
+    """
+    Computes the md5 of a file on the Girder Filesystem.
+
+    :param file_object: The file object that will be hashed
+    :param md5: The md5 object which will generate and hold the hash
+    :type file_object: girder.models.file
+    :type md5: md5
+    :return: Returns an updated md5 object. Returns None if it fails
+    :rtype: md5
+    """
+
+    assetstore = File().getAssetstoreAdapter(file_object)
+
+    try:
+        handle = assetstore.open(file_object)
+
+        while True:
+            buf = handle.read(8192)
+            if not buf:
+                break
+            md5.update(buf)
+
+    except Exception as e:
+        logger.debug('Error: {}'.format(e))
+        handle.close()
+        return None
+    handle.close()
+    return md5
+
+
+def generate_system_metadata(pid, format_id, file_object, is_file=False):
+    """
+    Generates a metadata document describing the file_object
+    :param pid: The pid that the object will have
+    :param format_id: The format of the object (e.g text/csv)
+    :param file_object: The object that is being described
+    :param is_file: A bool set to true if file_object is a girder file
+    :type pid: str
+    :type format_id: str
+    :type file_object: unicode
+    :type is_file: Bool
+    :return: The metadata describing file_object
+    :rtype: d1_common.types.generated.dataoneTypes_v2_0.SystemMetadata
+    """
+
+    logger.debug('Entered generate_system_metadata')
+    md5 = hashlib.md5()
+    if is_file:
+        md5 = get_file_md5(file_object, md5)
+        size = file_object['size']
+    else:
+        # Check that the file_object is unicode, attempt to convert it if it's a str
+        if not isinstance(file_object, bytes):
+            logger.debug('Warning: file_object is not unicode')
+            if isinstance(file_object, str):
+                logger.debug('file_object detected to be a string. Attempting conversion')
+                file_object = file_object.encode("utf-8")
+            else:
+                raise ValueError('Supplied file_object is not unicode')
+        md5.update(file_object)
+        size = len(file_object)
+
+    md5 = md5.hexdigest()
+    now = datetime.datetime.now()
+    sys_meta = populate_sys_meta(pid, format_id, size, md5, now)
+    logger.debug('Leaving generate_system_metadata')
+    return sys_meta
+
+
+def populate_sys_meta(pid, format_id, size, md5, now):
+    """
+    Fills out the system metadata object with the needed properties
+    :param pid: The pid of the system metadata document
+    :param format_id: The format of the document being described
+    :param size: The size of the document that is being described
+    :param md5: The md5 hash of the document being described
+    :param now: The current date & time
+    :type pid: str
+    :type format_id: str
+    :type size: int
+    :type md5: str
+    :type now: datetime
+    :return: The populated system metadata document
+    """
+
+    logger.debug('Entered generate_sys_meta')
+    pid = check_pid(pid)
+    sys_meta = dataoneTypes.systemMetadata()
+    sys_meta.identifier = pid
+    sys_meta.formatId = format_id
+    sys_meta.size = size
+    sys_meta.rightsHolder = 'http://orcid.org/0000-0000-0000-0000'
+
+    sys_meta.checksum = dataoneTypes.checksum(str(md5))
+    sys_meta.checksum.algorithm = 'MD5'
+    sys_meta.dateUploaded = now
+    sys_meta.dateSysMetadataModified = now
+    sys_meta.accessPolicy = generate_public_access_policy()
+    logger.debug('Leaving generate_sys_meta')
+    return sys_meta
+
+
+def generate_public_access_policy():
+    """
+    Creates the access policy for the object. Note that the permission is set to 'read'.
+
+    :return: The access policy
+    :rtype: d1_common.types.generated.dataoneTypes_v1.AccessPolicy
+    """
+
+    logger.debug('Entering generate_public_access_policy')
+    access_policy = dataoneTypes.accessPolicy()
+    access_rule = dataoneTypes.AccessRule()
+    access_rule.subject.append(d1_const.SUBJECT_PUBLIC)
+    permission = dataoneTypes.Permission('read')
+    access_rule.permission.append(permission)
+    access_policy.append(access_rule)
+    logger.debug('Leaving generate_public_access_policy')
+    return access_policy

--- a/server/dataone_upload.py
+++ b/server/dataone_upload.py
@@ -1,19 +1,25 @@
-import hashlib
-import datetime
+import uuid
 
 from girder import logger
 from girder.models.model_base import ValidationException
 
+from .dataone_package import create_minimum_eml
+from .dataone_package import generate_system_metadata
+from .dataone_package import create_resource_map
+from .dataone_utils import check_pid
+from .dataone_utils import filter_input_items
+
 from d1_client.mnclient_2_0 import MemberNodeClient_2_0
-from d1_common.types import dataoneTypes
-from d1_common import const as d1_const
+from d1_common.types.exceptions import DataONEException
 
 
 def create_client(repoName, auth_token):
     """
     Creates and returns a member node client
+
     :param repoName: The url of the member node repository
     :param auth_token: The auth token for the user that is using the client
+    Should be of the form {"headers": { "Authorization": "Bearer <TOKEN>}}
     :type repoName: str
     :type auth_token: dict
     :return: A client for communicating with a DataONE node
@@ -21,103 +27,6 @@ def create_client(repoName, auth_token):
     """
 
     return MemberNodeClient_2_0(repoName, **auth_token)
-
-
-def check_pid(pid):
-    """
-    Check that a pid is of type str. Pids are generated as uuid4, and this
-    check is done to make sure the programmer has converted it to a str before
-    attempting to use it with the DataONE client.
-
-    :param pid: The pid that is being checked
-    :type pid: str, int
-    :return: Returns the pid as a str, or just the pid if it was already a str
-    :rtype: str
-    """
-    logger.debug('Entered check_pid')
-    if not isinstance(pid, str):
-        logger.debug('Warning: PID was passed to upload_file that is not a str')
-        logger.debug('Leaving check_pid')
-        return str(pid)
-    else:
-        logger.debug('Leaving check_pid')
-        return pid
-
-
-def generate_system_metadata(pid, format_id, science_object):
-    """
-    Generates a system metadata document.
-    :param pid: The pid that the object will have
-    :param format_id: The format of the object (e.g text/csv)
-    :param science_object: The object that is being described
-    :type pid: str
-    :type format_id: str
-    :type science_object: unicode
-    :return:
-    """
-
-    logger.debug('Entered generate_system_metadata')
-    # Check that the science_object is unicode, attempt to convert it if it's a str
-    if not isinstance(science_object, bytes):
-        logger.debug('ERROR: science_object is not unicode')
-        if isinstance(science_object, str):
-            logger.debug('science_object detected to be a string. Attempting conversion')
-            science_object = science_object.encode("utf-8")
-        else:
-            raise ValueError('Supplied science_object is not unicode')
-
-    size = len(science_object)
-    md5 = hashlib.md5()
-    md5.update(science_object)
-    md5 = md5.hexdigest()
-    now = datetime.datetime.now()
-    sys_meta = populate_sys_meta(pid, format_id, size, md5, now)
-    logger.debug('Leaving generate_system_metadata')
-    return sys_meta
-
-
-def populate_sys_meta(pid, format_id, size, md5, now):
-    """
-    Fills out the system metadata object with the needed properties
-    :param pid: The pid of the system metadata document
-    :param format_id: The format of the document being described
-    :param size: The size of the document that is being described
-    :param md5: The md5 hash of the document being described
-    :param now: The current date & time
-    :return: The populated system metadata document
-    """
-
-    logger.debug('Entered generate_sys_meta')
-    pid = check_pid(pid)
-    sys_meta = dataoneTypes.systemMetadata()
-    sys_meta.identifier = pid
-    sys_meta.formatId = format_id
-    sys_meta.size = size
-    sys_meta.rightsHolder = 'http://orcid.org/0000-0000-0000-0000'
-
-    sys_meta.checksum = dataoneTypes.checksum(str(md5))
-    sys_meta.checksum.algorithm = 'MD5'
-    sys_meta.dateUploaded = now
-    sys_meta.dateSysMetadataModified = now
-    sys_meta.accessPolicy = generate_public_access_policy()
-    logger.debug('Leaving generate_sys_meta')
-    return sys_meta
-
-
-def generate_public_access_policy():
-    """
-    Creates the access policy for the object. Note that the permission is set to 'read'.
-    """
-
-    logger.debug('Entering generate_public_access_policy')
-    access_policy = dataoneTypes.accessPolicy()
-    access_rule = dataoneTypes.AccessRule()
-    access_rule.subject.append(d1_const.SUBJECT_PUBLIC)
-    permission = dataoneTypes.Permission('read')
-    access_rule.permission.append(permission)
-    access_policy.append(access_rule)
-    logger.debug('Leaving generate_public_access_policy')
-    return access_policy
 
 
 def upload_file(client, pid, object, system_metadata):
@@ -132,7 +41,7 @@ def upload_file(client, pid, object, system_metadata):
     :type client: MemberNodeClient_2_0
     :type pid: str
     :type object: str
-    :type system_metadata: pyxb
+    :type system_metadata: d1_common.types.generated.dataoneTypes_v2_0.SystemMetadata
     """
 
     logger.debug('Entered upload_file')
@@ -143,3 +52,131 @@ def upload_file(client, pid, object, system_metadata):
 
     except Exception as e:
         raise ValidationException('Error uploading file to DataONE {0}'.format(str(e)))
+
+
+def create_upload_eml(tale, client, user):
+    """
+    Creates the EML document along with its metadata document. Once created, they are
+    then uploaded to DataONE.
+
+    :param tale: The tale that is being uploaded
+    :param client: The client to DataONE
+    :param user: The user that is requesting this action
+    :type tale: wholetale.models.tale
+    :type client: MemberNodeClient_2_0
+    :type user: girder.models.user
+    :return: pid of the EML document
+    :rtype: str
+    """
+
+    logger.debug('Entered create_upload_eml')
+    # Create the EML metadata
+    eml_doc = create_minimum_eml(tale, user)
+    eml_pid = str(uuid.uuid4())
+
+    # Create the metadata describing the EML document
+    meta = generate_system_metadata(pid=eml_pid,
+                                    format_id='eml://ecoinformatics.org/eml-2.1.1',
+                                    file_object=eml_doc)
+
+    # meta is type d1_common.types.generated.dataoneTypes_v2_0.SystemMetadata
+    # Upload the EML document with its metadata
+    # upload_file(client=client, pid=eml_pid, document=eml_doc, system_metadata=meta)
+    logger.debug('Leaving create_upload_eml')
+    return eml_pid
+
+
+def create_upload_resmap(res_pid, metadata_pid, obj_pids, client):
+    """
+    Create the resource map, create its metadata, and then upload them to DataONE
+
+    :param res_pid: The pid for the resource map
+    :param metadata_pid: The pid for the metadata document
+    :param obj_pids: A list of the pids for each object that was uploaded to DataONE;
+     A list of pids that the resource map is documenting.
+    :param client: The client to the DataONE member node
+    :type res_pid: str
+    :type metadata_pid: str
+    :type obj_pids: list
+    :type client: MemberNodeClient_2_0
+    :return: None
+    """
+
+    logger.debug('Entered create_upload_resmap')
+    logger.debug('Resource Map PID {0}'.format(res_pid))
+
+    res_map = create_resource_map(res_pid, metadata_pid, obj_pids)
+
+    meta = generate_system_metadata(res_pid,
+                                    format_id='http://www.openarchives.org/ore/terms',
+                                    file_object=res_map)
+
+    # logger.debug('Uploading resource map')
+    # upload_file(client=client, pid=res_pid, document=res_map, system_metadata=meta)
+
+    logger.debug('Leaving create_upload_resmap')
+
+
+def create_upload_object_metadata(client, file_object):
+    """
+    Creates metadata for a file on the local filesystem and uploads it with the object to DataONE.
+
+    :param client: The client to the DataONE member node
+    :param file_object: The file object that will be uploaded
+    :type client: MemberNodeClient_2_0
+    :type file_object: girder.models.file
+    :return: The pid of the object
+    :rtype: str
+    """
+
+    logger.debug('Entered create_upload_object_metadata')
+    pid = str(uuid.uuid4())
+    file_path = file_object.get('path', None)
+
+    if file_path is not None:
+        meta = generate_system_metadata(pid,
+                                        format_id='http://www.openarchives.org/ore/terms',
+                                        file_object=file_object,
+                                        is_file=True)
+    # upload_file(client=client, pid=pid, document=file_object, system_metadata=meta)
+    logger.debug('Leaving create_upload_object_metadata')
+    return pid
+
+
+def create_upload_package(item_ids, tale, user, repository='https://dev.nceas.ucsb.edu/knb/d1/mn/'):
+    """
+    Called when the createPackage endpoint is hit. It takes a list of item ids, a tale id, and the user.
+
+    :param item_ids: A list of items that contain the files that will be uploaded to DataONE
+    :param tale: The tale that is being packaged
+    :param user: The user that is requesting the upload
+    :param repository: The DataONE member node
+    :type item_ids: list
+    :type tale: girder.models.tale
+    :type user: girder.models.user
+    :type repository: str
+    :return: None
+    """
+
+    logger.debug('Entered create_upload_package')
+    filtered_items = filter_input_items(item_ids, user)
+    dataone_objects = filtered_items['dataone']
+    local_objects = filtered_items['local']
+    local_file_pids = list()
+
+    try:
+        client = create_client(repository, {"headers": {
+            "Authorization": "Bearer <TOKEN>"}})
+
+        # for object in dataone_urls:
+        #    dataone_pids.append(create_upload_object_metadata(client, object))
+
+        for file in local_objects:
+            local_file_pids.append(create_upload_object_metadata(client, file))
+
+        eml_pid = create_upload_eml(tale, client, user)
+        create_upload_resmap(str(uuid.uuid4()), eml_pid, dataone_objects+local_file_pids, client)
+    except DataONEException as e:
+        logger.debug('DataONE Error: {0}'.format(e))
+
+    logger.debug('Leaving create_package')

--- a/server/dataone_utils.py
+++ b/server/dataone_utils.py
@@ -1,0 +1,115 @@
+from girder import logger
+from girder.models.item import Item
+from girder.constants import AccessType
+
+from .dataone_register import find_initial_pid
+
+
+def get_file_item(item_id, user):
+    """
+    Gets the file out of an item.
+
+    :param item_id: The item that has the file inside.
+    :param user: The user that is calling this
+    :type: item_id: str
+    :type user: girder.models.user
+    :return: The file object or None
+    :rtype: girder.models.file
+    """
+
+    logger.debug('Entered get_file_item')
+    doc = Item().load(item_id, level=AccessType.ADMIN, user=user)
+
+    if doc is None:
+        logger.debug('Failed to load Item. Leaving get_file_item')
+        return None
+    child_files = Item().childFiles(doc)
+
+    if bool(child_files):
+        # We follow a rule of there only being one file per item, so return the 0th element
+        logger.debug('Leaving get_file_item')
+        return child_files[0]
+
+    logger.debug('Failed to find a file. Leaving get_file_item')
+    return None
+
+
+def get_dataone_url(item_id, user):
+    """
+    Checks whether the file is linked externally to DataONE. If it is, it
+    will return the url to the object
+
+    :param item_id: The id of the item containing the file in question
+    :param user: The user requesting the information
+    :type item_id: str
+    :type user: girder.models.user
+    :return: The object's path in DataONE, None otherwise
+    :rtype: str, None
+    """
+    logger.debug('Entered check_in_dataone')
+    url = get_file_item(item_id, user).get('linkUrl')
+    if url is not None:
+        # if url.find('cn.dataone.org'): This will not work for dev testing.
+        #  Uncomment this when it is time to implement
+        #    return True
+        if url.find('stage-2.test.dataone'):
+            logger.debug('Leaving check_in_dataone')
+            return url
+
+    logger.debug('Leaving check_in_dataone')
+    return None
+
+
+def check_pid(pid):
+    """
+    Check that a pid is of type str. Pids are generated as uuid4, and this
+    check is done to make sure the programmer has converted it to a str before
+    attempting to use it with the DataONE client.
+
+    :param pid: The pid that is being checked
+    :type pid: str, int
+    :return: Returns the pid as a str, or just the pid if it was already a str
+    :rtype: str
+    """
+    logger.debug('Entered check_pid')
+    if not isinstance(pid, str):
+        logger.debug('Warning: PID was passed to upload_file that is not a str')
+        logger.debug('Leaving check_pid')
+        return str(pid)
+    else:
+        logger.debug('Leaving check_pid')
+        return pid
+
+
+def filter_input_items(item_ids, user):
+    """
+    Take a list of item ids and determine whether the file is linked to DataONE.
+
+    :param item_ids: A list of items to be processed
+    :param user: The user that is requesting the package creation
+    :type item_ids: list
+    :type user: girder.models.user
+    :return: A dictionary of lists
+    :rtype: dict
+    """
+
+    logger.debug('Entered filter_input_items')
+    dataone_objects = list()
+    # globus_objects = list()
+    local_objects = list()
+
+    for item_id in item_ids:
+        url = get_dataone_url(item_id, user)
+        if url is not None:
+            dataone_objects.append(find_initial_pid(url))
+            continue
+
+        # url = get_globus_url(item_id, user)
+        # if url is not None:
+        #     globus_objects.append(url)
+        #    continue
+
+        local_objects.append(get_file_item(item_id, user))
+
+    logger.debug('Leaving filter_input_items')
+    return {'dataone': dataone_objects, 'local': local_objects}


### PR DESCRIPTION
Adds an endpoint, `createPackage`, that takes a list of item ids, the tale, and a data repository.

Internally, it sorts the files into ones that exist remotely on DataONE and ones the exist on the local filesystem.

Files on the local FS have suitable metadata generated for them.

Adds supoprt for handling files on the girder filesystem.

Note that I didn't werite tests for the dataone_package file. There are a number of changes that the file may go through in upcoming commits.

This goes with issue #75 