### PR TITLE
Add Support for Uploading EML &  a Resource Map Describing DataONE Ob…

### DIFF
--- a/server/dataone_package.py
+++ b/server/dataone_package.py
@@ -10,22 +10,23 @@ from d1_common import const as d1_const
 from d1_common.resource_map import createSimpleResourceMap
 
 
-def create_resource_map(resmap_pid, metadata_pid, file_pids):
+def create_resource_map(resmap_pid, eml_pid, file_pids):
     """
     Creates a resource map for the package.
 
     :param resmap_pid: The pid od the resource map
-    :param metadata_pid: The pid of the science metadata
+    :param eml_pid: The pid of the science metadata
     :param file_pids: The pids for each file in the package
     :type resmap_pid: str
-    :type metadata_pid: str
+    :type eml_pid: str
     :type file_pids: list
     :return: The resource map for the package
     :rtype: bytes
     """
 
+    print("FILE_PIDS      ", file_pids)
     logger.debug('Entered create_resource_map')
-    res_map = createSimpleResourceMap(resmap_pid, metadata_pid, file_pids)
+    res_map = createSimpleResourceMap(resmap_pid, eml_pid, file_pids)
     # createSimpleResourceMap returns type d1_common.resource_map.ResourceMap
 
     logger.debug('Leaving create_resource_map')
@@ -44,8 +45,8 @@ def create_minimum_eml(tale, user):
     :return: The EML as as string of bytes
     :rtype: bytes
     """
-    logger.debug('Entered create_minimum_eml')
 
+    logger.debug('Entered create_minimum_eml')
     top = '<?xml version="1.0" encoding="UTF-8"?>'
     namespace = '<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" ' \
                 'xmlns:stmml="http://www.xml-cml.org/schema/stmml-1.1" xmlns:' \

--- a/server/dataone_register.py
+++ b/server/dataone_register.py
@@ -147,6 +147,10 @@ def find_initial_pid(path):
     elif re.search(r'^http[s]?://cn.dataone.org/cn/d1/v[\d]/\w+/', path):
         return re.sub(
             r'^http[s]?://cn.dataone.org/cn/d1/v[\d]/\w+/', '', path)
+    elif re.search('https:\/\/cn-stage-2.test.dataone.org\/cn\/v2\/resolve\/', path):
+        return re.sub('https:\/\/cn-stage-2.test.dataone.org\/cn\/v2\/resolve\/', '', path)
+
+
     elif doi is not None:
         return 'doi:{}'.format(doi.group())
     else:

--- a/server/dataone_utils.py
+++ b/server/dataone_utils.py
@@ -73,7 +73,7 @@ def check_pid(pid):
     """
     logger.debug('Entered check_pid')
     if not isinstance(pid, str):
-        logger.debug('Warning: PID was passed to upload_file that is not a str')
+        logger.debug('Warning: PID was passed that is not a str')
         logger.debug('Leaving check_pid')
         return str(pid)
     else:

--- a/server/rest/repository.py
+++ b/server/rest/repository.py
@@ -4,6 +4,7 @@ import os
 import re
 import requests
 from urllib.parse import urlparse
+from girder import logger
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.constants import TokenScope, AccessType
@@ -209,7 +210,7 @@ class Repository(Resource):
                required=False)
     )
     def createPackage(self, itemIds, taleId, repository):
-
+        logger.debug('Entered createPackage')
         user = self.getCurrentUser()
         tale = self.model('tale',
                           'wholetale').load(taleId,


### PR DESCRIPTION
This commit extends the endpoint to take a list of n DataONE linked files, create an EML document, and add the linked file pids to the resource map, which is then uploaded to a member node.

Note that most of these changes are uncommenting a few lines and changing variable names.