### PR TITLE
Adds Support for Uploading Local Girder Files

### DIFF
--- a/plugin_tests/dataone_package_test.py
+++ b/plugin_tests/dataone_package_test.py
@@ -6,7 +6,7 @@ from girder.models.model_base import ValidationException
 from d1_client.mnclient_2_0 import MemberNodeClient_2_0
 from d1_common.types import dataoneTypes
 import uuid
-
+import datetime
 
 def setUpModule():
 
@@ -17,3 +17,51 @@ def setUpModule():
 def tearDownModule():
 
     base.stopServer()
+
+
+class TestDataONEUpload(base.TestCase):
+
+    def test_generate_public_access_policy(self):
+        from server.dataone_package import generate_public_access_policy
+        access_policy = generate_public_access_policy()
+        assert(access_policy)
+
+    def test_populate_sys_meta(self):
+        # Test that populate_sys_meta has the correct default values
+        from server.dataone_package import populate_sys_meta
+
+        pid = str(uuid.uuid4())
+        format_id = 'text/csv'
+        size=256
+        md5='12345'
+        now = datetime.datetime.now()
+        sys_meta = populate_sys_meta(pid, format_id, size, md5, now)
+        assert(sys_meta.checksum.algorithm == 'MD5')
+        assert(sys_meta.dateUploaded == now)
+        assert(sys_meta.dateSysMetadataModified == now)
+        assert(sys_meta.formatId == format_id)
+        assert(sys_meta.size == size)
+
+    def test_generate_system_metadata(self):
+        # Test that the generate_system_metadata is giving the right state
+
+        from server.dataone_package import generate_system_metadata
+
+        pid = str(uuid.uuid4())
+        format_id = 'text/csv'
+        file_object='12345'
+
+        metadata = generate_system_metadata(pid, format_id, file_object)
+        assert(metadata.size == len(file_object))
+        assert (metadata.formatId == format_id)
+        assert (metadata.checksum.algorithm == 'MD5')
+
+    def test_create_resource_map(self):
+
+        from server.dataone_package import create_resource_map
+
+        resmap_pid = str(uuid.uuid4())
+        eml_pid = str(uuid.uuid4())
+        file_pids = ['1234', '4321']
+        res_map = create_resource_map(resmap_pid, eml_pid, file_pids)
+        assert(len(res_map))

--- a/plugin_tests/dataone_upload_test.py
+++ b/plugin_tests/dataone_upload_test.py
@@ -28,16 +28,17 @@ class TestDataONEUpload(base.TestCase):
         member_node='https://dev.nceas.ucsb.edu/knb/d1/mn/'
         header = {"headers": {
             "Authorization": "Bearer TOKEN"}}
-        print(type(header))
         client = create_client(member_node, header)
         self.assertIsNotNone(client)
 
 
-    def test_upload_failure(self):
-        # Test that we're throwing exceptions when uploading fails
+    def test_create_upload_eml(self):
+        # Test for create_upload_eml that will generate metadata and attempt to upload it.
+        # Note that the upload should not go thorugh, and we should catch an exception
+
         from server.dataone_upload import upload_file
         from server.dataone_upload import create_client
-        from server.dataone_upload import generate_system_metadata
+        from server.dataone_upload import create_upload_eml
 
         member_node = 'https://dev.nceas.ucsb.edu/knb/d1/mn/'
         header = {"headers": {
@@ -45,7 +46,30 @@ class TestDataONEUpload(base.TestCase):
         client = create_client(member_node, header)
         pid = str(uuid.uuid4())
         object = 'test data'
+        tale = {'title': 'test_title'}
+        user = {'lastName': 'test_last_name'}
 
-        sys_meta = generate_system_metadata(pid, 'text/csv', object)
+        self.assertRaises(ValidationException, create_upload_eml, tale, client, user)
 
-        self.assertRaises(ValidationException, upload_file, client, pid, object, sys_meta)
+    def test_create_upload_resmap(self):
+        # Test for create_upload_eml that will generate metadata and attempt to upload it.
+        # Note that the upload should not go thorugh, and we should catch an exception
+
+        from server.dataone_upload import create_upload_resmap
+        from server.dataone_upload import create_client
+        from server.dataone_upload import create_upload_eml
+
+        member_node = 'https://dev.nceas.ucsb.edu/knb/d1/mn/'
+        header = {"headers": {
+            "Authorization": "Bearer TOKEN"}}
+        client = create_client(member_node, header)
+        res_pid = str(uuid.uuid4())
+        eml_pid = str(uuid.uuid4())
+        obj_pids =['12345', '54321']
+
+        self.assertRaises(ValidationException,
+                          create_upload_resmap,
+                          res_pid,
+                          eml_pid,
+                          obj_pids,
+                          client)

--- a/server/dataone_register.py
+++ b/server/dataone_register.py
@@ -149,8 +149,6 @@ def find_initial_pid(path):
             r'^http[s]?://cn.dataone.org/cn/d1/v[\d]/\w+/', '', path)
     elif re.search('https:\/\/cn-stage-2.test.dataone.org\/cn\/v2\/resolve\/', path):
         return re.sub('https:\/\/cn-stage-2.test.dataone.org\/cn\/v2\/resolve\/', '', path)
-
-
     elif doi is not None:
         return 'doi:{}'.format(doi.group())
     else:

--- a/server/dataone_utils.py
+++ b/server/dataone_utils.py
@@ -83,7 +83,10 @@ def check_pid(pid):
 
 def filter_input_items(item_ids, user):
     """
-    Take a list of item ids and determine whether the file is linked to DataONE.
+    Take a list of item ids and determine whether the file is linked to DataONE. If it is, then
+    it stores its pid in the dict.
+
+    If the file is on the filesystem, the model.File describing the file is added to the dict.
 
     :param item_ids: A list of items to be processed
     :param user: The user that is requesting the package creation


### PR DESCRIPTION
Extends the endpoint to support files that are on the Girder file system. Also added some additional tests (which will still fail).

This corresponds to issue #77