### PR TITLE
Add new fields for Tales: iframe and format

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -258,6 +258,17 @@ def load(info):
     info['apiRoot'].wholetale = wholeTale()
     info['apiRoot'].instance = Instance()
     info['apiRoot'].tale = Tale()
+
+    from girder.plugins.wholetale.models.tale import Tale as TaleModel
+    from girder.plugins.wholetale.models.tale import _currentTaleFormat
+    q = {
+        '$or': [
+            {'format': {'$exists': False}},
+            {'format': {'$lt': _currentTaleFormat}}
+        ]}
+    for obj in TaleModel().find(q):
+        TaleModel().save(obj, validate=True)
+
     info['apiRoot'].recipe = Recipe()
     info['apiRoot'].dataset = Dataset()
     image = Image()

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -11,6 +11,9 @@ from girder.models.model_base import \
 from girder.constants import AccessType
 
 
+_currentTaleFormat = 1
+
+
 class Tale(AccessControlledModel):
 
     def initialize(self):
@@ -25,15 +28,19 @@ class Tale(AccessControlledModel):
         })
         self.modifiableFields = {
             'title', 'description', 'public', 'config', 'updated', 'authors',
-            'category', 'icon', 'illustration'
+            'category', 'icon', 'iframe', 'illustration'
         }
         self.exposeFields(
             level=AccessType.READ,
-            fields=({'_id', 'folderId', 'imageId', 'creatorId', 'created'} |
-                    self.modifiableFields))
+            fields=({'_id', 'folderId', 'imageId', 'creatorId', 'created',
+                     'format'} | self.modifiableFields))
         self.exposeFields(level=AccessType.ADMIN, fields={'published'})
 
     def validate(self, tale):
+        if 'iframe' not in tale:
+            tale['iframe'] = False
+        if 'format' not in tale:
+            tale['format'] = _currentTaleFormat
         return tale
 
     def setPublished(self, tale, publish, save=False):
@@ -94,6 +101,7 @@ class Tale(AccessControlledModel):
             'creatorId': creatorId,
             'description': description,
             'folderId': ObjectId(folder['_id']),
+            'format': _currentTaleFormat,
             'created': now,
             'icon': icon,
             'imageId': ObjectId(image['_id']),

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -82,7 +82,8 @@ class Tale(AccessControlledModel):
 
     def createTale(self, image, folder, creator=None, save=True, title=None,
                    description=None, public=None, config=None, published=False,
-                   authors=None, icon=None, category=None, illustration=None):
+                   authors=None, icon=None, category=None, illustration=None,
+                   iframe=False):
         if creator is None:
             creatorId = None
         else:
@@ -104,6 +105,7 @@ class Tale(AccessControlledModel):
             'format': _currentTaleFormat,
             'created': now,
             'icon': icon,
+            'iframe': iframe,
             'imageId': ObjectId(image['_id']),
             'illustration': illustration,
             'title': title,

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -11,6 +11,9 @@ from girder.models.model_base import \
 from girder.constants import AccessType
 
 
+# Whenever the Tale object schema is modified (e.g. fields are added or
+# removed) increase `_currentTaleFormat` to retroactively apply those
+# changes to existing Tales.
 _currentTaleFormat = 1
 
 

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -155,7 +155,8 @@ class Tale(Resource):
                                      'images/demo-graph2.jpg')),
                 authors=tale.get('authors', default_author),
                 category=tale.get('category', 'science'),
-                published=False
+                published=False,
+                iframe=bool(tale.get('iframe', False))
             )
 
     @access.user(scope=TokenScope.DATA_OWN)

--- a/server/schema/tale.py
+++ b/server/schema/tale.py
@@ -33,6 +33,10 @@ taleModel = {
             "type": "string",
             "description": "ID of a data folder used by the Tale"
         },
+        "format": {
+            "type": "integer",
+            "description": "Tale format specification"
+        },
         "public": {
             "type": "boolean",
             "description": "If set to true the Tale is accessible by anyone.",
@@ -74,6 +78,10 @@ taleModel = {
         "illustration": {
             "type": "string",
             "description": "A URL to an image depicturing the content of the Tale"
+        },
+        "iframe": {
+            "type": "boolean",
+            "description": "If 'true', the tale can be embedded in an iframe"
         },
         "icon": {
             "type": "string",


### PR DESCRIPTION
This PR introduces new fields for the Tale model:

1. `iframe` - if set to True, it should indicate that the Tale can be embedded in an iframe.
1. `format` - specifies the current format of the Tale model. It can be used to automatically add or remove keywords from existing objects upon girder start, provided that `validate()` method of the Tale model was updated accordingly.