### PR TITLE
Add Support for A Globus/Remote File Descriptor

### DIFF
--- a/plugin_tests/dataone_package_test.py
+++ b/plugin_tests/dataone_package_test.py
@@ -81,7 +81,7 @@ class TestDataONEUpload(base.TestCase):
         user = {'lastName': 'testLastName', 'firstName': 'testFirstName'}
         eml_pid ='123456789'
 
-        eml = create_minimum_eml(tale, user, [], eml_pid)
+        eml = create_minimum_eml(tale, user, [], eml_pid, dict())
 
         root = ET.fromstring(eml)
 
@@ -100,7 +100,7 @@ class TestDataONEUpload(base.TestCase):
         user = {'lastName': 'testLastName', 'firstName': 'testFirstName'}
         eml_pid ='123456789'
 
-        eml = create_minimum_eml(tale, user, [], eml_pid)
+        eml = create_minimum_eml(tale, user, [], eml_pid, dict())
 
         root = ET.fromstring(eml)
         abstract = root.findall('abstract')

--- a/plugin_tests/dataone_package_test.py
+++ b/plugin_tests/dataone_package_test.py
@@ -81,7 +81,7 @@ class TestDataONEUpload(base.TestCase):
         user = {'lastName': 'testLastName', 'firstName': 'testFirstName'}
         eml_pid ='123456789'
 
-        eml = create_minimum_eml(tale, user, [], eml_pid, dict())
+        eml = create_minimum_eml(tale, user, [], eml_pid)
 
         root = ET.fromstring(eml)
 
@@ -100,7 +100,7 @@ class TestDataONEUpload(base.TestCase):
         user = {'lastName': 'testLastName', 'firstName': 'testFirstName'}
         eml_pid ='123456789'
 
-        eml = create_minimum_eml(tale, user, [], eml_pid, dict())
+        eml = create_minimum_eml(tale, user, [], eml_pid)
 
         root = ET.fromstring(eml)
         abstract = root.findall('abstract')

--- a/plugin_tests/dataone_upload_test.py
+++ b/plugin_tests/dataone_upload_test.py
@@ -48,7 +48,7 @@ class TestDataONEUpload(base.TestCase):
         tale = {'title': 'test_title', 'description': 'Test tale description'}
         user = {'lastName': 'testLastName', 'firstName': 'testFirstName'}
 
-        self.assertRaises(ValidationException, create_upload_eml, tale, client, user, [])
+        self.assertRaises(ValidationException, create_upload_eml, tale, client, user, [], dict())
 
     def test_create_upload_resmap(self):
         # Test for create_upload_eml that will generate metadata and attempt to upload it.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ tornado
 celery[redis]
 requests
 redis
+pyxb
 git+https://github.com/DataONEorg/d1_python.git@2.4.2#egg=dataone.common&subdirectory=lib_common/src
 git+https://github.com/DataONEorg/d1_python.git@2.4.2#egg=dataone.libclient&subdirectory=lib_client/src
 git+https://github.com/DataONEorg/d1_python.git@2.4.2#egg=dataone.cli&subdirectory=client_cli/src

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 rdflib
-cryptography
+cryptography==2.1.4
 tornado
 celery[redis]
 requests
-git+https://github.com/DataONEorg/d1_python@2.4.2#egg=d1_python
+redis
+git+https://github.com/DataONEorg/d1_python.git@2.4.2#egg=dataone.common&subdirectory=lib_common/src
+git+https://github.com/DataONEorg/d1_python.git@2.4.2#egg=dataone.libclient&subdirectory=lib_client/src
+git+https://github.com/DataONEorg/d1_python.git@2.4.2#egg=dataone.cli&subdirectory=client_cli/src

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ tornado
 celery[redis]
 requests
 redis
-pyxb
 git+https://github.com/DataONEorg/d1_python.git@2.4.2#egg=dataone.common&subdirectory=lib_common/src
 git+https://github.com/DataONEorg/d1_python.git@2.4.2#egg=dataone.libclient&subdirectory=lib_client/src
 git+https://github.com/DataONEorg/d1_python.git@2.4.2#egg=dataone.cli&subdirectory=client_cli/src

--- a/server/dataone_package.py
+++ b/server/dataone_package.py
@@ -52,9 +52,9 @@ def create_minimum_eml(tale,
     :param user: The user that hit the endpoint
     :param item_ids: A list of the item ids of the objects that are going to be packaged
     :param eml_pid: The PID for the eml document. Assume that this is the package doi
-    :param file_size: We don't have access to remote files here, and all we need is
-     its' size, so pass it in here. If the file is not remote, leave the value to default
-     An example is occasionally needing the size of the object, so throw it
+    :param file_size: We need the size of the json file describing files from Globus, pass
+     it in here. It is optional because sometimes, we won't be registering a package with
+     files from Globus.
     :type tale: wholetale.models.tale
     :type user: girder.models.user
     :type item_ids: list

--- a/server/dataone_package.py
+++ b/server/dataone_package.py
@@ -199,17 +199,17 @@ def create_minimum_eml(tale,
 
     """
     Emulate the behavior of ElementTree.tostring in Python 3.6.0
-     Write the contents to a stream and then return its content. 
-     The Python 3.4 version of ElementTree.tostring doesn't allow for 
-     `xml_declaration` to be set, so make a direct call to 
+     Write the contents to a stream and then return its content.
+     The Python 3.4 version of ElementTree.tostring doesn't allow for
+     `xml_declaration` to be set, so make a direct call to
      ElementTree.write, passing xml_declaration in.
     """
     stream = io.BytesIO()
     ET.ElementTree(ns).write(file_or_filename=stream,
-             encoding='UTF-8',
-             xml_declaration=True,
-             method='xml',
-             short_empty_elements=True)
+                             encoding='UTF-8',
+                             xml_declaration=True,
+                             method='xml',
+                             short_empty_elements=True)
 
     return stream.getvalue()
 

--- a/server/dataone_package.py
+++ b/server/dataone_package.py
@@ -1,4 +1,5 @@
 import hashlib
+import io
 import tempfile
 import xml.etree.cElementTree as ET
 from urllib.request import urlopen
@@ -196,9 +197,21 @@ def create_minimum_eml(tale,
         object_format = 'application/json'
         add_object_record(name, description, file_size, object_format)
 
-    # call decode to get the string representation instead of a byte str
-    xml = ET.tostring(ns, encoding='UTF-8', xml_declaration=True, method='xml').decode()
-    return xml
+    """
+    Emulate the behavior of ElementTree.tostring in Python 3.6.0
+     Write the contents to a stream and then return its content. 
+     The Python 3.4 version of ElementTree.tostring doesn't allow for 
+     `xml_declaration` to be set, so make a direct call to 
+     ElementTree.write, passing xml_declaration in.
+    """
+    stream = io.BytesIO()
+    ET.ElementTree(ns).write(file_or_filename=stream,
+             encoding='UTF-8',
+             xml_declaration=True,
+             method='xml',
+             short_empty_elements=True)
+
+    return stream.getvalue()
 
 
 def compute_md5(file):

--- a/server/dataone_package.py
+++ b/server/dataone_package.py
@@ -1,5 +1,9 @@
 import hashlib
+import tempfile
 import xml.etree.cElementTree as ET
+from urllib.request import urlopen
+from shutil import copyfileobj
+
 
 from girder import logger
 from girder.models.file import File
@@ -9,7 +13,8 @@ from girder.api.rest import RestException
 from .utils import \
     check_pid, \
     get_file_format, \
-    get_tale_description
+    get_tale_description, \
+    get_file_item
 
 from d1_common.types import dataoneTypes
 from d1_common import const as d1_const
@@ -35,7 +40,11 @@ def create_resource_map(resmap_pid, eml_pid, file_pids):
     return res_map.serialize()
 
 
-def create_minimum_eml(tale, user, item_ids, eml_pid):
+def create_minimum_eml(tale,
+                       user,
+                       item_ids,
+                       eml_pid,
+                       external_data):
     """
     Creates a bare minimum EML record for a package.
 
@@ -43,10 +52,12 @@ def create_minimum_eml(tale, user, item_ids, eml_pid):
     :param user: The user that hit the endpoint
     :param item_ids: A lsit of the item ids of the objects that are going to be packaged
     :param eml_pid: The PID for the eml document. Assume that this is the package doi
+    :param external_data: A dict with any parameters needed for a file describing external objects
     :type tale: wholetale.models.tale
     :type user: girder.models.user
     :type item_ids: list
     :type eml_pid: str
+    :type external_data: dict
     :return: The EML as as string of bytes
     :rtype: bytes
     """
@@ -65,6 +76,7 @@ def create_minimum_eml(tale, user, item_ids, eml_pid):
         raise RestException('Unable to find your name or email address. Please ensure '
                             'you have authenticated with DataONE.')
 
+    # Create the namespace
     ns = ET.Element('eml:eml')
     ns.set('xmlns:eml', "eml://ecoinformatics.org/eml-2.1.1")
     ns.set('xsi:schemaLocation', "eml://ecoinformatics.org/eml-2.1.1 eml.xsd")
@@ -74,15 +86,24 @@ def create_minimum_eml(tale, user, item_ids, eml_pid):
     ns.set('system', "knb")
     ns.set('packageId', eml_pid)
 
+    """
+    Create a `dataset` field, and assign the title to
+     the name of the Tale. The DataONE Quality Engine
+     prefers to have titles with at least 7 words.
+    """
     dataset = ET.SubElement(ns, 'dataset')
     ET.SubElement(dataset, 'title').text = str(tale.get('title', ''))
 
+    """
+    Create a `creator` section, using the information in the
+     `model.user` object to provide values.
+    """
     creator = ET.SubElement(dataset, 'creator')
     individual_name = ET.SubElement(creator, 'individualName')
     ET.SubElement(individual_name, 'givenName').text = firstName
     ET.SubElement(individual_name, 'surName').text = lastName
 
-    # Only add an abstract section if the tale has a description
+    # Create a `description` field, but only if the Tale has a description.
     description = get_tale_description(tale)
     if description is not str():
         abstract = ET.SubElement(dataset, 'abstract')
@@ -93,61 +114,177 @@ def create_minimum_eml(tale, user, item_ids, eml_pid):
     ET.SubElement(ind_name, 'givenName').text = firstName
     ET.SubElement(ind_name, 'surName').text = lastName
 
-    # Add a <otherEntity> block for each object
-    for item_id in item_ids:
-        item = Item().load(item_id, user=user)
-        description = item['description']
-
+    def create_other_entity(name, description):
+        """
+        Create an otherEntity section
+        :param name: The name of the object
+        :param description: The description of the object
+        :type name: str
+        :type description: str
+        :return:
+        """
         other_entity = ET.SubElement(dataset, 'otherEntity')
-        ET.SubElement(other_entity, 'entityName').text = item['name']
-        ET.SubElement(other_entity, 'entityDescription').text = description if\
+        ET.SubElement(other_entity, 'entityName').text = name
+        ET.SubElement(other_entity, 'entityDescription').text = description if \
             bool(len(description)) else 'None'
+        return other_entity
 
-        physical = ET.SubElement(other_entity, 'physical')
-        ET.SubElement(physical, 'objectName').text = item['name']
+    def create_physical(other_entity_section, name, size):
+        """
+        Creates a `physical` section.
+        :param other_entity_section: The super-section
+        :param name: The name of the object
+        :param size: The size in bytes of the object
+        :type other_entity_section: xml.etree.ElementTree.Element
+        :type name: str
+        :type size: str
+        :return: The physical section
+        :rtype: xml.etree.ElementTree.Element
+        """
+        physical = ET.SubElement(other_entity_section, 'physical')
+        ET.SubElement(physical, 'objectName').text = name
         size_element = ET.SubElement(physical, 'size')
-        size_element.text = str(item['size'])
+        size_element.text = str(size)
         size_element.set('unit', 'bytes')
-        format = get_file_format(item_id, user)
-        data_format = ET.SubElement(physical, 'dataFormat')
+        return physical
+
+    def create_format(format, physical_section):
+        data_format = ET.SubElement(physical_section, 'dataFormat')
         externally_defined = ET.SubElement(data_format, 'externallyDefinedFormat')
         ET.SubElement(externally_defined, 'formatName').text = format
 
-        ET.SubElement(other_entity, 'entityType').text = 'Other'
+    def add_object_record(name, description, size, format):
+        """
+        Add a section to the EML that describes an object.
+        :param name: The name of the object
+        :param description: The object's description
+        :param size: The size of the object
+        :param format: The format type
+        :return: None
+        """
+        other_entity_section = create_other_entity(name, description)
+        physical_section = create_physical(other_entity_section,
+                                           name,
+                                           size)
+        create_format(format, physical_section)
+        ET.SubElement(other_entity_section, 'entityType').text = 'Other'
 
-    # call decode to get the string representation instead of as a byte str
+    # Add a <otherEntity> block for each object
+    for item_id in item_ids:
+        item = Item().load(item_id, user=user)
+        format = get_file_format(item_id, user)
+
+        # Create the record for the object
+        add_object_record(item['name'], item['description'], item['size'], format)
+
+    # Add a section for the file describing any remote objects
+    if bool(external_data):
+        description = "Describes a set of objects that exist on remote repositories. This file " \
+                      "contains the name, path, and md5 checksum of each file."
+        name = 'globus_references.json'
+        format = 'application/json'
+        add_object_record(name, description, external_data['size'], format)
+
+    # call decode to get the string representation instead of a byte str
     xml = ET.tostring(ns, encoding='UTF-8', xml_declaration=True, method='xml').decode()
     return xml
 
 
-def get_file_md5(file_object, md5):
+def compute_md5(file):
+    """
+    Takes an file handle and computes the md5 of it. This uses duck typing
+    to allow for any file handle that supports .read. Note that it is left to the
+    caller to close the file handle and to handle any exceptions
+    :param file:
+    :return: Returns an updated md5 object. Returns None if it fails
+    :rtype: md5
+    """
+    md5 = hashlib.md5()
+    while True:
+        buf = file.read(8192)
+        if not buf:
+            break
+        md5.update(buf)
+    return md5
+
+
+def get_file_md5(file_object):
     """
     Computes the md5 of a file on the Girder filesystem.
 
     :param file_object: The file object that will be hashed
-    :param md5: The md5 object which will generate and hold the hash
     :type file_object: girder.models.file
-    :type md5: md5
     :return: Returns an updated md5 object. Returns None if it fails
     :rtype: md5
     """
 
     assetstore = File().getAssetstoreAdapter(file_object)
+
     try:
-        handle = assetstore.open(file_object)
-
-        while True:
-            buf = handle.read(8192)
-            if not buf:
-                break
-            md5.update(buf)
-
+        file = assetstore.open(file_object)
+        md5 = compute_md5(file)
     except Exception as e:
         logger.warning('Error: {}'.format(e))
-        return None
+        raise RestException('Failed to download and md5 a remote file. {}'.format(e))
     finally:
-        handle.close()
+        file.close()
     return md5
+
+
+def create_external_reference_file(external_files, user):
+    """
+    Creates a JSON file that describes a file in Globus which has the following format
+     {file_name : {'url': url, 'md5': md5}
+     We'll want to compute the md5, so we have to save the file
+     temporarily.
+
+    :param external_files:
+    :param user:
+    :type external_files:
+    :type user:
+    :return:
+    """
+
+    reference_file = dict()
+    try:
+        for item in external_files:
+            """
+            Get the underlying file object from the supplied item id.
+            We'll need the `linkUrl` field to determine where it is pointing to.
+            """
+            file = get_file_item(item, user)
+            if file is not None:
+                url = file.get('linkUrl')
+                if url is not None:
+                    """
+                    Create a temporary file object which will eventually hold the contents
+                    of the remote object.
+                    """
+                    temp_file = tempfile.NamedTemporaryFile()
+                    src = urlopen(url)
+                    try:
+                        # Copy the repsone into the temporary file
+                        copyfileobj(src, temp_file)
+                    except Exception as e:
+                        error_msg = 'Error Copying File: {}'.format(e)
+                        logger.warning(error_msg)
+                        raise RestException(error_msg)
+
+                    # Get the md5 of the file
+                    md5 = compute_md5(temp_file)
+                    digest = md5.hexdigest()
+
+                    """
+                    Create dictionary entries for the file. We key off of the file name,
+                     and store the url and md5 with it.
+                    """
+                    url_entry = {'url': url}
+                    md5_entry = {'md5': digest}
+                    reference_file[file['name']] = url_entry, md5_entry
+    except Exception as e:
+        logger.warning('Error while processing file from Globus. {}'.format(e))
+        raise RestException('Failed to process file located at {}. {}'.format(url, e))
+    return reference_file
 
 
 def generate_system_metadata(pid, format_id, file_object, name, is_file=False):
@@ -170,7 +307,7 @@ def generate_system_metadata(pid, format_id, file_object, name, is_file=False):
 
     md5 = hashlib.md5()
     if is_file:
-        md5 = get_file_md5(file_object, md5)
+        md5 = get_file_md5(file_object)
         size = file_object['size']
     else:
         # Check that the file_object is unicode, attempt to convert it if it's a str

--- a/server/dataone_register.py
+++ b/server/dataone_register.py
@@ -53,6 +53,11 @@ def query(q,
     :return: The content of the response
     """
 
+    """
+    Create the query section of the url. Note that the DataONE Python library
+     has functionality for solr queries. If time permits or if errors occur
+     in this area, it is worth looking into refactoring with it.
+    """
     fl = ",".join(fields)
     query_url = "{}/query/solr/?q={}&fl={}&rows={}&start={}&wt=json".format(
         base_url, q, fl, rows, start)

--- a/server/dataone_upload.py
+++ b/server/dataone_upload.py
@@ -326,8 +326,8 @@ def create_upload_package(item_ids, tale, user, repository):
         if len(remote_objects) > 0:
             logger.debug('Processing remote objects.')
             external_file_pid, reference_file_length = create_upload_remote_file(client,
-                                                                  remote_objects,
-                                                                  user)
+                                                                                 remote_objects,
+                                                                                 user)
 
         """
         Create an EML document describing the data, and then upload it. Save the

--- a/server/dataone_upload.py
+++ b/server/dataone_upload.py
@@ -320,7 +320,7 @@ def create_upload_package(item_ids, tale, user, repository):
          to the resource map (so we save it).
         """
         remote_objects = filtered_items['remote']
-        external_file_pid = list()
+        external_file_pid = str()
         # A dict that can be used to hold information about the external_data file
         external_data = dict()
         if len(remote_objects) > 0:
@@ -340,7 +340,8 @@ def create_upload_package(item_ids, tale, user, repository):
         Once all objects are uploaded, create and upload the resource map. This file describes
          the object relations (ie the package). This should be the last file that is uploaded.
         """
-        upload_objects = filtered_items['dataone'] + list(external_file_pid) + local_file_pids
+        upload_objects = filtered_items['dataone'] + [external_file_pid] + local_file_pids
+
         create_upload_resmap(str(uuid.uuid4()), eml_pid, upload_objects, client)
     except DataONEException as e:
         logger.warning('DataONE Error: {}'.format(e))

--- a/server/utils.py
+++ b/server/utils.py
@@ -121,8 +121,22 @@ def get_dataone_url(item_id, user):
         raise RestException(file_error)
     url = file.get('linkUrl')
     if url is not None:
-        if url.find('dataone.org'):
+        if is_dataone_url(url):
             return url
+
+
+def is_dataone_url(url):
+    """
+    Checks if a url has dataone in it
+    :param url: The url in question
+    :return: True if it does, False otherwise
+    """
+
+    res = url.find('dataone.org')
+    if res is not -1:
+        return True
+    else:
+        return False
 
 
 def check_pid(pid):
@@ -154,7 +168,13 @@ def get_remote_url(item_id, user):
     :return: The url that points to the object
     :rtype: str or None
     """
-    url = get_file_item(item_id, user).get('linkUrl')
+
+    file = get_file_item(item_id, user)
+    if file is None:
+        file_error = 'Failed to find the file with ID {}'.format(item_id)
+        logger.warning(file_error)
+        raise RestException(file_error)
+    url = file.get('linkUrl')
     if url is not None:
         return url
 


### PR DESCRIPTION
Changes in dataone_package.py:
   I added a parameter to create_minimul_eml that holds any useful information about the globus description file. I made it a dict in case we need to add more parameters to beef the EML up rather than adding n function parameters. The only element in it is the file size.
  I broke the code that was getting executed in the item loop into functions so that they can get called if there is a globus file.
  I also broke the old md5 function up so that it can be used more independently elsewhere.
  The biggest addition is `create_external_reference_file`. This is responsible for downloading the remote resource and getting it's md5. We download the file and store the bytes in a `NamedTemporaryFile`, and then compute the md5 of it.

Changes in dataone_upload.py
  You'll see that calls to create_upload_eml and create_minimum_eml have the dict mentioned above.
  I added a new function, `create_upload_remote_file` which handles creating and uploading the globus reference file.

I also threw in an experimental requirements.txt file-I may take a look at the library this weekend to see if I can update the requirements.