### PR TITLE
[WIP] Allow to create Tales with multiple data sources. Fixes #96

### DIFF
--- a/server/constants.py
+++ b/server/constants.py
@@ -7,7 +7,7 @@ from girder import events
 API_VERSION = '2.0'
 CATALOG_NAME = 'WholeTale Catalog'
 WORKSPACE_NAME = 'WholeTale Workspaces'
-
+DATADIRS_NAME = 'WholeTale Data Mountpoints'
 
 class HarvesterType:
     """

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -109,7 +109,7 @@ class Tale(AccessControlledModel):
             creatorId = creator.get('_id', None)
 
         if title is None:
-            title = '{} with {}'.format(image['fullName'], folder['name'])
+            title = '{} with {}'.format(image['fullName'], DATADIRS_NAME)
         # if illustration is None:
             # Get image from SILS
 

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -4,27 +4,27 @@ import datetime
 
 from bson.objectid import ObjectId
 
-from ..constants import WORKSPACE_NAME
+from ..constants import WORKSPACE_NAME, DATADIRS_NAME
 from ..utils import getOrCreateRootFolder
-from girder.models.model_base import \
-    AccessControlledModel
+from girder.models.model_base import AccessControlledModel
+from girder.models.folder import Folder
+from girder.models.user import User
 from girder.constants import AccessType
+from girder.exceptions import \
+    GirderException, ValidationException
 
 
 # Whenever the Tale object schema is modified (e.g. fields are added or
 # removed) increase `_currentTaleFormat` to retroactively apply those
 # changes to existing Tales.
-_currentTaleFormat = 1
+_currentTaleFormat = 2
 
 
 class Tale(AccessControlledModel):
 
     def initialize(self):
         self.name = 'tale'
-        self.ensureIndices(
-            ('folderId', 'title', 'imageId',
-             ([('folderId', 1), ('title', 1), ('imageId', 1)], {}))
-        )
+        self.ensureIndices(('imageId', ([('imageId', 1)], {})))
         self.ensureTextIndex({
             'title': 10,
             'description': 1
@@ -36,14 +36,29 @@ class Tale(AccessControlledModel):
         self.exposeFields(
             level=AccessType.READ,
             fields=({'_id', 'folderId', 'imageId', 'creatorId', 'created',
-                     'format'} | self.modifiableFields))
+                     'format', 'data'} | self.modifiableFields))
         self.exposeFields(level=AccessType.ADMIN, fields={'published'})
 
     def validate(self, tale):
         if 'iframe' not in tale:
             tale['iframe'] = False
-        if 'format' not in tale:
-            tale['format'] = _currentTaleFormat
+        if tale.get('format', 0) < 2:
+            dataFolder = getOrCreateRootFolder(DATADIRS_NAME)
+            try:
+                origFolder = Folder().load(tale['folderId'], force=True, exc=True)
+            except ValidationException:
+                raise GirderException(
+                    'Tale ({_id}) references folder ({folderId}) that does not exist'.format(**tale))
+            if origFolder.get('creatorId'):
+                creator = User().load(origFolder['creatorId'], force=True)
+            else:
+                creator = None
+            tale['data'] = {'type': 'folder', 'id': tale.pop('folderId')}
+            newFolder = Folder().copyFolder(
+                origFolder, parent=dataFolder, name=str(tale['_id']),
+                creator=creator, progress=False)
+            tale['folderId'] = newFolder['_id']
+        tale['format'] = _currentTaleFormat
         return tale
 
     def setPublished(self, tale, publish, save=False):
@@ -129,7 +144,13 @@ class Tale(AccessControlledModel):
             self.createWorkspace(tale, creator=creator)
         return tale
 
+    def createDataMountpoint(self, tale, creator=None):
+        return self._createAuxFolder(self, tale, DATADIRS_NAME, creator=creator)
+
     def createWorkspace(self, tale, creator=None):
+        return self._createAuxFolder(self, tale, WORKSPACE_NAME, creator=creator)
+
+    def _createAuxFolder(self, tale, rootFolderName, creator=None):
         if creator is None:
             creator = self.model('user').load(tale['creatorId'], force=True)
 
@@ -138,16 +159,16 @@ class Tale(AccessControlledModel):
         else:
             public = False
 
-        workspaceFolder = getOrCreateRootFolder(WORKSPACE_NAME)
-        taleWorkspace = self.model('folder').createFolder(
-            workspaceFolder, str(tale['_id']), parentType='folder',
+        rootFolder = getOrCreateRootFolder(rootFolderName)
+        auxFolder = self.model('folder').createFolder(
+            rootFolder, str(tale['_id']), parentType='folder',
             public=public, reuseExisting=True)
         self.setUserAccess(
-            taleWorkspace, user=creator, level=AccessType.ADMIN,
+            auxFolder, user=creator, level=AccessType.ADMIN,
             save=True)
-        taleWorkspace = self.model('folder').setMetadata(
-            taleWorkspace, {'taleId': str(tale['_id'])})
-        return taleWorkspace
+        auxFolder = self.model('folder').setMetadata(
+            auxFolder, {'taleId': str(tale['_id'])})
+        return auxFolder
 
     def updateTale(self, tale):
         """

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -139,11 +139,9 @@ class Tale(Resource):
         else:
             image = self.model('image', 'wholetale').load(
                 tale['imageId'], user=user, level=AccessType.READ, exc=True)
-            folder = self.model('folder').load(
-                tale['folderId'], user=user, level=AccessType.READ, exc=True)
             default_author = ' '.join((user['firstName'], user['lastName']))
             return self.model('tale', 'wholetale').createTale(
-                image, folder, creator=user, save=True,
+                image, tale['data'], creator=user, save=True,
                 title=tale.get('title'), description=tale.get('description'),
                 public=tale.get('public'), config=tale.get('config'),
                 icon=image.get('icon', ('https://raw.githubusercontent.com/'

--- a/server/schema/misc.py
+++ b/server/schema/misc.py
@@ -3,6 +3,26 @@
 from girder.api.docs import addModel
 
 
+dataResourceSchema = {
+    'title': 'dataResource',
+    '$schema': 'http://json-schema.org/draft-04/schema#',
+    'description': 'A schema representing data elements used in WholeTale',
+    'type': 'object',
+    'properties': {
+        'type': {
+            'type': 'string',
+            'enum': ['item', 'folder'],
+            'description': 'Either a Girder item or a Girder folder'
+        },
+        'id': {
+            'type': 'string',
+            'description': 'Girder object id'
+        }
+    },
+    'required': ['type', 'id']
+}
+
+
 dataMapSchema = {
     'title': 'dataMap',
     '$schema': 'http://json-schema.org/draft-04/schema#',

--- a/server/schema/tale.py
+++ b/server/schema/tale.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from .misc import containerConfigSchema
+from .misc import containerConfigSchema, dataResourceSchema
 
 taleModel = {
     "definitions": {
@@ -9,7 +9,7 @@ taleModel = {
     },
     "description": "Object representing a Tale.",
     "required": [
-        "folderId",
+        "data",
         "imageId"
     ],
     "properties": {
@@ -31,7 +31,12 @@ taleModel = {
         },
         "folderId": {
             "type": "string",
-            "description": "ID of a data folder used by the Tale"
+            "description": "ID of a folder containing copy of tale['data']"
+        },
+        "data": {
+            "type": "array",
+            "items": dataResourceSchema,
+            "description": "Resources used to create Tale's data folder"
         },
         "format": {
             "type": "integer",

--- a/server/utils.py
+++ b/server/utils.py
@@ -3,7 +3,7 @@ from girder.utility.model_importer import ModelImporter
 
 def getOrCreateRootFolder(name):
     collection = ModelImporter.model('collection').createCollection(
-        name, public=True, reuseExisting=True)
+        name, public=False, reuseExisting=True)
     folder = ModelImporter.model('folder').createFolder(
         collection, name, parentType='collection', public=True, reuseExisting=True)
     return folder


### PR DESCRIPTION
This PR allows to create Tales with an array of objects ("folders" and "items") as a data source. 
For simplicity I created a hidden collection that will keep a copy of selected data and will be used as single mountpoint for FUSE filesystem. In the future that will also allow us to create copies of data selected from volatile storage (Home, Workspace), for now this should be disallowed though.

TODO:
- [ ] fix tests
- [ ] add tests for migration step