### PR TITLE
Environmental variables can be passed to a running Tale

### DIFF
--- a/server/schema/misc.py
+++ b/server/schema/misc.py
@@ -84,6 +84,14 @@ containerConfigSchema = {
         'cpuShares': {
             'type': 'string',
         },
+        'environment': {
+            'type': 'array',
+            'description': 'List of environment variables passed to a container',
+            'items': {
+                'type': 'string',
+                'description': 'Environment variable, in the form KEY=val'
+            }
+        },
         'memLimit': {
             'type': 'string',
         },


### PR DESCRIPTION
This PR adds new `environment` field to `containerConfig` schema, which allows to pass env vars to containers.

Corresponding changes to gwvolman: https://github.com/whole-tale/gwvolman/commit/b4c068a0d81e19ff43602cf7ed5696e39d98297e