### PR TITLE
Create tale.yml File

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ tornado
 celery[redis]
 requests
 redis
+pyyaml
 dataone.common
 dataone.libclient
 dataone.cli

--- a/server/constants.py
+++ b/server/constants.py
@@ -54,7 +54,7 @@ class ImageStatus(object):
                           ImageStatus.BUILDING, ImageStatus.AVAILABLE)
 
 
-class DataONELocations():
+class DataONELocations:
     """
     An enumeration that describes the different DataONE
     endpoints.
@@ -65,3 +65,14 @@ class DataONELocations():
     dev_mn = 'https://dev.nceas.ucsb.edu/knb/d1/mn/v2'
     # Development coordinating node
     dev_cn = 'https://cn-stage-2.test.dataone.org/cn/v2'
+
+
+class ExtraFileNames:
+    """
+    When creating data packages we'll have to create additional files, such as
+     the zipped recipe, the tale.yml file, the metadata document, and possibly
+      more. Keep their names store here so that they can easily be referenced and
+      changed in a single place.
+    """
+    # Name for the tale config file
+    tale_config = 'tale.yml'


### PR DESCRIPTION
requirements.txt:
   I'm using pyyml now

constants.py
  I found myslef duplicating the file name in a few places; if we start creating more we should just use a struct to hold them.

dataone_package.py
  I removed the eml record for the old paths and globus reference file and added one for tale.yml. I also renamed a few functions.

dataone_upload.py
  I removed `create_upload_remote_file` and refactored `create_upload_file_paths` to handle the yaml file. The yaml file is created by joining a series of dicts and dumping them (via the yaml library).

I didn't see an appropriate format type in DataONE so I set it to text.

An example package can be found below.
https://dev.nceas.ucsb.edu/#view/24375bfe-d2d4-4fa6-9998-b28aa0ee9b1f

Note that a known bug is the text after the remote file's name.`Polygon Image: !!python/tuple`. I'll try to get this fixed in the next commit.

This is attached to issue #106 