### PR TITLE
Fix toggling 'public' parameter on a Tale. Fixes #121, #16

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -24,6 +24,7 @@ jobs:
             git clone https://github.com/whole-tale/girder /tmp/girder
             set -o pipefail; cd /tmp/girder ; python3 -m pip install -r requirements-dev.txt | cat
             cp /tmp/girder/CMakeLists.txt /girder/
+            cp /tmp/girder/.coveragerc /girder/
             cp -r /tmp/girder/tests /girder/
       - run:
           name: Running Tests
@@ -42,7 +43,7 @@ jobs:
           command: pip install codecov
       - run:
           name: Collect coverage reports
-          command: cp /girder/.coverage .
+          command: coverage combine /girder/build/test/coverage/python_temp/
       - run:
           name: Uploading Coverage Results
           command: codecov

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -366,7 +366,7 @@ class TaleTestCase(base.TestCase):
         resp = self.request(
             path='/tale/%s/access' % tale_admin_image['_id'], method='PUT',
             user=self.user, params={'access': json.dumps(input_tale_access)})
-        self.assertStatus(resp, 403)
+        self.assertStatus(resp, 200)  # TODO: fix me
 
         # Check that the access control list was correctly set for the tale
         resp = self.request(

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -11,10 +11,10 @@ from girder.api.rest import Resource, filtermodel, RestException,\
 
 from girder.constants import AccessType, SortDir, TokenScope
 from girder.utility import ziputil
-from ..schema.tale import taleModel
+from ..schema.tale import taleModel as taleSchema
 
 
-addModel('tale', taleModel, resources='tale')
+addModel('tale', taleSchema, resources='tale')
 
 
 class Tale(Resource):
@@ -84,7 +84,7 @@ class Tale(Resource):
         Description('Update an existing tale.')
         .modelParam('id', model='tale', plugin='wholetale',
                     level=AccessType.WRITE, destName='taleObj')
-        .jsonParam('tale', 'Updated tale', paramType='body', schema=taleModel,
+        .jsonParam('tale', 'Updated tale', paramType='body', schema=taleSchema,
                    dataType='tale')
         .responseClass('tale')
         .errorResponse('ID was invalid.')
@@ -115,7 +115,7 @@ class Tale(Resource):
     @access.user
     @autoDescribeRoute(
         Description('Create a new tale.')
-        .jsonParam('tale', 'A new tale', paramType='body', schema=taleModel,
+        .jsonParam('tale', 'A new tale', paramType='body', schema=taleSchema,
                    dataType='tale')
         .responseClass('tale')
         .errorResponse('You are not authorized to create tales.', 403)


### PR DESCRIPTION
We currently allow to change Tale's `public` attribute via `PUT /tale/{id}`. We shouldn't be doing that... Nevertheless:
* I've modified the update method to detect whether `public` was flipped and now we apply ACLs properly. 
* Changing ACLs on Tale no longer fails if user has insufficient privilege to modify the underlying Image. I think it's more sane behavior since:
  * we have only public Images right now,
  * potentially not accessible Tale with non public Image is less crazy, than user making Image private without taking into account all the other public Tales that might be using it...