### PR TITLE
Add License Information to EML

### DIFF
--- a/plugin_tests/constants_test.py
+++ b/plugin_tests/constants_test.py
@@ -34,3 +34,10 @@ class TestDataONEUtils(base.TestCase):
         self.assertEqual(DataONELocations.prod_cn, 'https://cn.dataone.org/cn/v2')
         self.assertEqual(DataONELocations.dev_mn, 'https://dev.nceas.ucsb.edu/knb/d1/mn/v2')
         self.assertEqual(DataONELocations.dev_cn, 'https://cn-stage-2.test.dataone.org/cn/v2')
+
+    def test_text_from_id(self):
+        from server.constants import Licence
+
+        self.assertEqual(Licence.text_from_id(str(0)), Licence.LicenseText.CC0)
+        self.assertEqual(Licence.text_from_id(str(1)), Licence.LicenseText.CCBY3)
+        self.assertEqual(Licence.text_from_id(str(2)), Licence.LicenseText.CCBY4)

--- a/plugin_tests/constants_test.py
+++ b/plugin_tests/constants_test.py
@@ -34,10 +34,3 @@ class TestDataONEUtils(base.TestCase):
         self.assertEqual(DataONELocations.prod_cn, 'https://cn.dataone.org/cn/v2')
         self.assertEqual(DataONELocations.dev_mn, 'https://dev.nceas.ucsb.edu/knb/d1/mn/v2')
         self.assertEqual(DataONELocations.dev_cn, 'https://cn-stage-2.test.dataone.org/cn/v2')
-
-    def test_text_from_id(self):
-        from server.constants import Licence
-
-        self.assertEqual(Licence.text_from_id(str(0)), Licence.LicenseText.CC0)
-        self.assertEqual(Licence.text_from_id(str(1)), Licence.LicenseText.CCBY3)
-        self.assertEqual(Licence.text_from_id(str(2)), Licence.LicenseText.CCBY4)

--- a/plugin_tests/dataone_package_test.py
+++ b/plugin_tests/dataone_package_test.py
@@ -81,7 +81,7 @@ class TestDataONEUpload(base.TestCase):
         user = {'lastName': 'testLastName', 'firstName': 'testFirstName'}
         eml_pid ='123456789'
 
-        eml = create_minimum_eml(tale, user, [], eml_pid, {})
+        eml = create_minimum_eml(tale, user, [], eml_pid, {}, 1)
 
         root = ET.fromstring(eml)
 
@@ -100,7 +100,7 @@ class TestDataONEUpload(base.TestCase):
         user = {'lastName': 'testLastName', 'firstName': 'testFirstName'}
         eml_pid ='123456789'
 
-        eml = create_minimum_eml(tale, user, [], eml_pid, {})
+        eml = create_minimum_eml(tale, user, [], eml_pid, {}, 1)
 
         root = ET.fromstring(eml)
         abstract = root.findall('abstract')

--- a/plugin_tests/dataone_upload_test.py
+++ b/plugin_tests/dataone_upload_test.py
@@ -48,7 +48,13 @@ class TestDataONEUpload(base.TestCase):
         tale = {'title': 'test_title', 'description': 'Test tale description'}
         user = {'lastName': 'testLastName', 'firstName': 'testFirstName'}
 
-        self.assertRaises(ValidationException, create_upload_eml, tale, client, user, [], dict())
+        self.assertRaises(ValidationException, create_upload_eml,
+                          tale,
+                          client,
+                          user,
+                          [],
+                          1,
+                          dict())
 
     def test_create_upload_resmap(self):
         # Test for create_upload_eml that will generate metadata and attempt to upload it.

--- a/server/constants.py
+++ b/server/constants.py
@@ -3,7 +3,6 @@
 
 from girder import events
 
-
 API_VERSION = '2.0'
 CATALOG_NAME = 'WholeTale Catalog'
 WORKSPACE_NAME = 'WholeTale Workspaces'
@@ -79,3 +78,74 @@ class ExtraFileNames:
     """
     # Name for the tale config file
     tale_config = 'tale.yml'
+
+
+class Licence:
+    """
+    Class that interfaces the available licences.
+    """
+
+    class LicenseIds:
+        """
+        Key the licenses off the integers, starting at 0
+        """
+        CC0 = 0
+        CCBY3 = 1
+        CCBY4 = 2
+
+    class LicenseText:
+        """
+        Text for each license type.
+        """
+        CC0 = 'This work is dedicated to the public domain under the Creative ' \
+              'Commons Universal 1.0 Public Domain Dedication. To view a copy' \
+              ' of this dedication, visit ' \
+              'https://creativecommons.org/publicdomain/zero/1.0/.'
+
+        CCBY3 = 'This work is dedicated to the public domain under the Creative Commons ' \
+                'license CC-BY 3.0. To view a copy of this dedication, ' \
+                'visit https://creativecommons.org/licenses/by/3.0/us/legalcode.'
+
+        CCBY4 = 'This information is released to the public domain under the' \
+                ' Creative Commons license CC-BY 4.0 ' \
+                '(see: https://creativecommons.org/licenses/by/4.0/). It may be ' \
+                'distributed, remixed, and built upon. You must give appropriate' \
+                ' credit, provide a reasonable manner, but not in any way that' \
+                ' suggests the licensor endorses you or your use. The consumer ' \
+                'of these data ("Data User" herein) should realize that ' \
+                'these data may be actively used by others for ongoing ' \
+                'research and that coordination may be necessary to prevent ' \
+                'duplicate publication. The Data User is urged to ' \
+                'contact the authors of these data if any questions ' \
+                'about methodology or results occur. Where ' \
+                'appropriate, the Data User is encouraged to consider ' \
+                'collaboration or co-authorship with the authors. The Data ' \
+                'User should realize that misinterpretation of data may occur if ' \
+                'used out of context of the original study. While substantial ' \
+                'efforts are made to ensure the accuracy of data and ' \
+                'associated documentation, complete accuracy of data sets ' \
+                'cannot be guaranteed. All data are made available "as is."' \
+                ' The Data User should be aware, however, that data ' \
+                'are updated periodically and it is the responsibility ' \
+                'of the Data User to check for new versions of the data. ' \
+                'The data authors and the repository where these data ' \
+                'were obtained shall not be liable for damages ' \
+                'resulting from any use or misinterpretation ' \
+                'of the data. Thank you.'
+
+    @staticmethod
+    def text_from_id(id):
+        """
+        Given an ID, return the license text
+        :param id: The ID of the license
+        :type id: str
+        :return: The text of the corresponding license
+        :rtype: str
+        """
+        id = int(id)
+        if id == 0:
+            return Licence.LicenseText.CC0
+        if id == 1:
+            return Licence.LicenseText.CCBY3
+        elif id == 2:
+            return Licence.LicenseText.CCBY4

--- a/server/constants.py
+++ b/server/constants.py
@@ -80,72 +80,44 @@ class ExtraFileNames:
     tale_config = 'tale.yml'
 
 
-class Licence:
-    """
-    Class that interfaces the available licences.
-    """
-
-    class LicenseIds:
-        """
-        Key the licenses off the integers, starting at 0
-        """
-        CC0 = 0
-        CCBY3 = 1
-        CCBY4 = 2
-
-    class LicenseText:
-        """
-        Text for each license type.
-        """
-        CC0 = 'This work is dedicated to the public domain under the Creative ' \
-              'Commons Universal 1.0 Public Domain Dedication. To view a copy' \
-              ' of this dedication, visit ' \
-              'https://creativecommons.org/publicdomain/zero/1.0/.'
-
-        CCBY3 = 'This work is dedicated to the public domain under the Creative Commons ' \
-                'license CC-BY 3.0. To view a copy of this dedication, ' \
-                'visit https://creativecommons.org/licenses/by/3.0/us/legalcode.'
-
-        CCBY4 = 'This information is released to the public domain under the' \
-                ' Creative Commons license CC-BY 4.0 ' \
-                '(see: https://creativecommons.org/licenses/by/4.0/). It may be ' \
-                'distributed, remixed, and built upon. You must give appropriate' \
-                ' credit, provide a reasonable manner, but not in any way that' \
-                ' suggests the licensor endorses you or your use. The consumer ' \
-                'of these data ("Data User" herein) should realize that ' \
-                'these data may be actively used by others for ongoing ' \
-                'research and that coordination may be necessary to prevent ' \
-                'duplicate publication. The Data User is urged to ' \
-                'contact the authors of these data if any questions ' \
-                'about methodology or results occur. Where ' \
-                'appropriate, the Data User is encouraged to consider ' \
-                'collaboration or co-authorship with the authors. The Data ' \
-                'User should realize that misinterpretation of data may occur if ' \
-                'used out of context of the original study. While substantial ' \
-                'efforts are made to ensure the accuracy of data and ' \
-                'associated documentation, complete accuracy of data sets ' \
-                'cannot be guaranteed. All data are made available "as is."' \
-                ' The Data User should be aware, however, that data ' \
-                'are updated periodically and it is the responsibility ' \
-                'of the Data User to check for new versions of the data. ' \
-                'The data authors and the repository where these data ' \
-                'were obtained shall not be liable for damages ' \
-                'resulting from any use or misinterpretation ' \
-                'of the data. Thank you.'
-
-    @staticmethod
-    def text_from_id(id):
-        """
-        Given an ID, return the license text
-        :param id: The ID of the license
-        :type id: str
-        :return: The text of the corresponding license
-        :rtype: str
-        """
-        id = int(id)
-        if id == 0:
-            return Licence.LicenseText.CC0
-        if id == 1:
-            return Licence.LicenseText.CCBY3
-        elif id == 2:
-            return Licence.LicenseText.CCBY4
+"""
+The DataONE packages need to have descriptions in the EML metadata. The
+license_text dictionary holds the descriptions for each license type. If
+you add a license to support, be sure to add the description below.
+0: CC0
+1: CCBY 3
+2: CCBY 4
+"""
+license_text = {0: 'This work is dedicated to the public domain under the Creative '
+                   'Commons Universal 1.0 Public Domain Dedication. To view a copy '
+                   'of this dedication, visit '
+                   'https://creativecommons.org/publicdomain/zero/1.0/.',
+                1: 'This work is dedicated to the public domain under the Creative Commons '
+                   'license CC-BY 3.0. To view a copy of this dedication, '
+                   'visit https://creativecommons.org/licenses/by/3.0/us/legalcode.',
+                2: 'This information is released to the public domain under the '
+                   'Creative Commons license CC-BY 4.0 '
+                   '(see: https://creativecommons.org/licenses/by/4.0/). It may be '
+                   'distributed, remixed, and built upon. You must give appropriate '
+                   'credit, provide a reasonable manner, but not in any way that '
+                   'suggests the licensor endorses you or your use. The consumer '
+                   'of these data ("Data User" herein) should realize that '
+                   'these data may be actively used by others for ongoing '
+                   'research and that coordination may be necessary to prevent '
+                   'duplicate publication. The Data User is urged to '
+                   'contact the authors of these data if any questions '
+                   'about methodology or results occur. Where '
+                   'appropriate, the Data User is encouraged to consider '
+                   'collaboration or co-authorship with the authors. The Data '
+                   'User should realize that misinterpretation of data may occur if '
+                   'used out of context of the original study. While substantial '
+                   'efforts are made to ensure the accuracy of data and '
+                   'associated documentation, complete accuracy of data sets '
+                   'cannot be guaranteed. All data are made available "as is." '
+                   'The Data User should be aware, however, that data '
+                   'are updated periodically and it is the responsibility '
+                   'of the Data User to check for new versions of the data. '
+                   'The data authors and the repository where these data '
+                   'were obtained shall not be liable for damages '
+                   'resulting from any use or misinterpretation '
+                   'of the data. Thank you.'}

--- a/server/dataone_package.py
+++ b/server/dataone_package.py
@@ -21,7 +21,7 @@ from .utils import \
 
 from .constants import \
     ExtraFileNames, \
-    Licence
+    license_text
 
 from d1_common.types import dataoneTypes
 from d1_common import const as d1_const
@@ -134,8 +134,8 @@ def create_minimum_eml(tale,
         intellectual_rights = ET.SubElement(dataset_element, 'intellectualRights')
         section = ET.SubElement(intellectual_rights, 'section')
         para = ET.SubElement(section, 'para')
-        ET.SubElement(para, 'literalLayout').text =\
-            Licence.text_from_id(license_id)
+        ET.SubElement(para, 'literalLayout').text = \
+            license_text.get(license_id, '')
 
     def add_object_record(name, description, size, object_format):
         """
@@ -216,12 +216,11 @@ def create_minimum_eml(tale,
         add_object_record(item['name'], item['description'], item['size'], object_format)
 
     # Add a section for the tale.yml file
-    if file_sizes.get('tale_yaml') != int() or None:
+    if not isinstance(file_sizes.get('tale_yaml'), int):
         description = "Configuration file that has information that will be useful " \
                       "for re-creating the computational environment."
         name = ExtraFileNames.tale_config
         object_format = 'application/x-yaml'
-        logger.info(file_sizes)
         add_object_record(name, description, file_sizes.get('tale_yaml'), object_format)
 
     """

--- a/server/dataone_package.py
+++ b/server/dataone_package.py
@@ -18,7 +18,10 @@ from .utils import \
     get_file_format, \
     get_tale_description, \
     get_file_item
-from .constants import ExtraFileNames
+
+from .constants import \
+    ExtraFileNames, \
+    Licence
 
 from d1_common.types import dataoneTypes
 from d1_common import const as d1_const
@@ -48,9 +51,11 @@ def create_minimum_eml(tale,
                        user,
                        item_ids,
                        eml_pid,
-                       file_sizes):
+                       file_sizes,
+                       license_id):
     """
-    Creates a bare minimum EML record for a package.
+    Creates a bare minimum EML record for a package. Note that the
+    ordering of the xml elements matters.
 
     :param tale: The tale that is being packaged.
     :param user: The user that hit the endpoint
@@ -58,65 +63,16 @@ def create_minimum_eml(tale,
     :param eml_pid: The PID for the eml document. Assume that this is the package doi
     :param file_sizes: When we upload files that are not in the girder system (ie not
      files or items) we need to manually pass their size in. Use this dict to do that.
+    :param license_id: The ID of the license
     :type tale: wholetale.models.tale
     :type user: girder.models.user
     :type item_ids: list
     :type eml_pid: str
     :type file_sizes: dict
+    :type licenseId: int
     :return: The EML as as string of bytes
     :rtype: bytes
     """
-
-    """
-    Check that we're able to assign a first, last, and email to the record.
-    If we aren't throw an exception and let the user know. We'll also check that
-    the user has an ORCID ID set.
-    """
-    lastName = user.get('lastName', None)
-    firstName = user.get('firstName', None)
-    email = user.get('email', None)
-
-    if any((None for x in [lastName, firstName, email])):
-        raise RestException('Unable to find your name or email address. Please ensure '
-                            'you have authenticated with DataONE.')
-
-    # Create the namespace
-    ns = ET.Element('eml:eml')
-    ns.set('xmlns:eml', "eml://ecoinformatics.org/eml-2.1.1")
-    ns.set('xsi:schemaLocation', "eml://ecoinformatics.org/eml-2.1.1 eml.xsd")
-    ns.set('xmlns:stmml', "http://www.xml-cml.org/schema/stmml-1.1")
-    ns.set('xmlns:xsi', "http://www.w3.org/2001/XMLSchema-instance")
-    ns.set('scope', "system")
-    ns.set('system', "knb")
-    ns.set('packageId', eml_pid)
-
-    """
-    Create a `dataset` field, and assign the title to
-     the name of the Tale. The DataONE Quality Engine
-     prefers to have titles with at least 7 words.
-    """
-    dataset = ET.SubElement(ns, 'dataset')
-    ET.SubElement(dataset, 'title').text = str(tale.get('title', ''))
-
-    """
-    Create a `creator` section, using the information in the
-     `model.user` object to provide values.
-    """
-    creator = ET.SubElement(dataset, 'creator')
-    individual_name = ET.SubElement(creator, 'individualName')
-    ET.SubElement(individual_name, 'givenName').text = firstName
-    ET.SubElement(individual_name, 'surName').text = lastName
-
-    # Create a `description` field, but only if the Tale has a description.
-    description = get_tale_description(tale)
-    if description is not str():
-        abstract = ET.SubElement(dataset, 'abstract')
-        ET.SubElement(abstract, 'para').text = description
-
-    contact = ET.SubElement(dataset, 'contact')
-    ind_name = ET.SubElement(contact, 'individualName')
-    ET.SubElement(ind_name, 'givenName').text = firstName
-    ET.SubElement(ind_name, 'surName').text = lastName
 
     def create_entity(name, description):
         """
@@ -167,6 +123,20 @@ def create_minimum_eml(tale,
         externally_defined = ET.SubElement(data_format, 'externallyDefinedFormat')
         ET.SubElement(externally_defined, 'formatName').text = object_format
 
+    def create_intellectual_rights(dataset_element, license_id):
+        """
+        :param dataset_element: The xml element that defines the `dataset`
+        :param license_id: The ID of the license
+        :type dataset_element: xml.etree.ElementTree.Element
+        :type license_id: int
+        :return: None
+        """
+        intellectual_rights = ET.SubElement(dataset_element, 'intellectualRights')
+        section = ET.SubElement(intellectual_rights, 'section')
+        para = ET.SubElement(section, 'para')
+        ET.SubElement(para, 'literalLayout').text =\
+            Licence.text_from_id(license_id)
+
     def add_object_record(name, description, size, object_format):
         """
         Add a section to the EML that describes an object.
@@ -183,6 +153,60 @@ def create_minimum_eml(tale,
         create_format(object_format, physical_section)
         ET.SubElement(entity_section, 'entityType').text = 'dataTable'
 
+    """
+    Check that we're able to assign a first, last, and email to the record.
+    If we aren't throw an exception and let the user know. We'll also check that
+    the user has an ORCID ID set.
+    """
+    lastName = user.get('lastName', None)
+    firstName = user.get('firstName', None)
+    email = user.get('email', None)
+
+    if any((None for x in [lastName, firstName, email])):
+        raise RestException('Unable to find your name or email address. Please ensure '
+                            'you have authenticated with DataONE.')
+
+    # Create the namespace
+    ns = ET.Element('eml:eml')
+    ns.set('xmlns:eml', "eml://ecoinformatics.org/eml-2.1.1")
+    ns.set('xsi:schemaLocation', "eml://ecoinformatics.org/eml-2.1.1 eml.xsd")
+    ns.set('xmlns:stmml', "http://www.xml-cml.org/schema/stmml-1.1")
+    ns.set('xmlns:xsi', "http://www.w3.org/2001/XMLSchema-instance")
+    ns.set('scope', "system")
+    ns.set('system', "knb")
+    ns.set('packageId', eml_pid)
+
+    """
+    Create a `dataset` field, and assign the title to
+     the name of the Tale. The DataONE Quality Engine
+     prefers to have titles with at least 7 words.
+    """
+    dataset = ET.SubElement(ns, 'dataset')
+    ET.SubElement(dataset, 'title').text = str(tale.get('title', ''))
+
+    """
+    Create a `creator` section, using the information in the
+     `model.user` object to provide values.
+    """
+    creator = ET.SubElement(dataset, 'creator')
+    individual_name = ET.SubElement(creator, 'individualName')
+    ET.SubElement(individual_name, 'givenName').text = firstName
+    ET.SubElement(individual_name, 'surName').text = lastName
+
+    # Create a `description` field, but only if the Tale has a description.
+    description = get_tale_description(tale)
+    if description is not str():
+        abstract = ET.SubElement(dataset, 'abstract')
+        ET.SubElement(abstract, 'para').text = description
+
+    # Add a section for the license file
+    create_intellectual_rights(dataset, license_id)
+
+    contact = ET.SubElement(dataset, 'contact')
+    ind_name = ET.SubElement(contact, 'individualName')
+    ET.SubElement(ind_name, 'givenName').text = firstName
+    ET.SubElement(ind_name, 'surName').text = lastName
+
     # Add a <otherEntity> block for each object
     for item_id in item_ids:
         item = Item().load(item_id, user=user, level=AccessType.READ)
@@ -192,12 +216,13 @@ def create_minimum_eml(tale,
         add_object_record(item['name'], item['description'], item['size'], object_format)
 
     # Add a section for the tale.yml file
-    if file_sizes.get('tale_yaml') is not int() or None:
+    if file_sizes.get('tale_yaml') != int() or None:
         description = "Configuration file that has information that will be useful " \
                       "for re-creating the computational environment."
         name = ExtraFileNames.tale_config
         object_format = 'application/x-yaml'
-        add_object_record(name, description, file_sizes.get('external_files'), object_format)
+        logger.info(file_sizes)
+        add_object_record(name, description, file_sizes.get('tale_yaml'), object_format)
 
     """
     Emulate the behavior of ElementTree.tostring in Python 3.6.0

--- a/server/dataone_upload.py
+++ b/server/dataone_upload.py
@@ -403,7 +403,6 @@ def create_upload_package(item_ids,
                                                                   item_ids,
                                                                   user,
                                                                   client)
-        logger.info(license_id)
         """
         Create an EML document describing the data, and then upload it. Save the
          pid for the resource map.

--- a/server/rest/repository.py
+++ b/server/rest/repository.py
@@ -225,8 +225,15 @@ class Repository(Resource):
         .param('jwt',
                description='The user\'s DataONE jwt.',
                required=True)
+        .param('licenseId',
+               description='The ID of the license that the package is under.'
+                           '0: CC0'
+                           '1: CCBY3'
+                           '2: CCBY4',
+               required=True)
+
     )
-    def createPackage(self, itemIds, taleId, repository, jwt):
+    def createPackage(self, itemIds, taleId, repository, jwt, licenseId):
         user = ModelImporter.model('user').getAdmins()[0]
         tale = self.model('tale',
                           'wholetale').load(taleId,
@@ -237,5 +244,6 @@ class Repository(Resource):
                                             tale=tale,
                                             user=user,
                                             repository=repository,
-                                            jwt=jwt)
+                                            jwt=jwt,
+                                            license_id=int(licenseId))
         return package_url


### PR DESCRIPTION
We need to let the user pick a license for their package. This adds a parameter to the package endpoint. The licenses are keyed in constants.py

Most of the change can be read by first looking at the changes in constants.py, then going to repository.py and following the call stack. You'll see that the license id persists up to EML generation.

Note that in dataone_package.py I re-arranged some of the EML generation function. Mostly putting the code below the function declarations.
This corresponds to issue #128 