### PR TITLE
Strip HTML in EML

### DIFF
--- a/plugin_tests/dataone_package_test.py
+++ b/plugin_tests/dataone_package_test.py
@@ -7,7 +7,7 @@ from d1_client.mnclient_2_0 import MemberNodeClient_2_0
 from d1_common.types import dataoneTypes
 import uuid
 import datetime
-
+import re
 
 def setUpModule():
     base.enabledPlugins.append('wholetale')

--- a/plugin_tests/utils_test.py
+++ b/plugin_tests/utils_test.py
@@ -161,3 +161,10 @@ class TestDataONEUtils(base.TestCase):
         # Test that we get the right url when using prod
         url = get_dataone_package_url(DataONELocations.prod_cn, pid)
         self.assertEqual(url, 'https://search.dataone.org/#view/'+pid)
+
+    def test_strip_html(self):
+        from server.utils import strip_html
+
+        str_no_html = 'test description'
+        messy_str = '<p>'+str_no_html+'</p>'
+        self.assertEqual(strip_html(messy_str), str_no_html)

--- a/server/dataone_package.py
+++ b/server/dataone_package.py
@@ -17,7 +17,8 @@ from .utils import \
     check_pid, \
     get_file_format, \
     get_tale_description, \
-    get_file_item
+    get_file_item, \
+    strip_html
 
 from .constants import \
     ExtraFileNames, \
@@ -146,7 +147,7 @@ def create_minimum_eml(tale,
         :param object_format: The format type
         :return: None
         """
-        entity_section = create_entity(name, description)
+        entity_section = create_entity(name, strip_html(description))
         physical_section = create_physical(entity_section,
                                            name,
                                            size)
@@ -197,7 +198,7 @@ def create_minimum_eml(tale,
     description = get_tale_description(tale)
     if description is not str():
         abstract = ET.SubElement(dataset, 'abstract')
-        ET.SubElement(abstract, 'para').text = description
+        ET.SubElement(abstract, 'para').text = strip_html(description)
 
     # Add a section for the license file
     create_intellectual_rights(dataset, license_id)

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,3 +1,5 @@
+import re
+
 from girder.utility.model_importer import ModelImporter
 from girder import logger
 from girder.models.item import Item
@@ -262,3 +264,14 @@ def get_dataone_package_url(repository, pid):
         return str('https://search.dataone.org/#view/'+pid)
     elif repository in DataONELocations.dev_mn:
         return str('https://dev.nceas.ucsb.edu/#view/'+pid)
+
+
+def strip_html(string):
+    """
+    Removes HTML from a string
+    :param string: The string with HTML
+    :type string: str
+    :return: The string without HTML
+    :rtype: str
+    """
+    return re.sub('<[^<]+?>', '', string)


### PR DESCRIPTION
Commit a56e6e4 has changes that stip html out of the girder item fields (or a string in general). Fixes issue #117 

I branched off of `dataone_publishing` which had a pending PR (e17de4e13cc19378b03310040127d0913f6fd99d) which is why you see it here. I didn't want to branch off of `master` because it would require merging after `e17de4e13cc19378b03310040127d0913f6fd99d` is accepted.
