### PR TITLE
Add narrative to Tales

### DIFF
--- a/plugin_tests/image_test.py
+++ b/plugin_tests/image_test.py
@@ -91,7 +91,8 @@ class ImageTestCase(base.TestCase):
             self.assertEqual(celeryMock.mock_calls[0][1], ('girder_worker',))
 
             sendTaskCalls = celeryMock.return_value.send_task.mock_calls
-            mock_repo_url = 'https://github.com/{}/archive/{}.tar.gz'.format(GOOD_REPO, GOOD_COMMIT)
+            # mock_repo_url = \
+            #    'https://github.com/{}/archive/{}.tar.gz'.format(GOOD_REPO, GOOD_COMMIT)
             self.assertEqual(len(sendTaskCalls), 1)
             self.assertEqual(sendTaskCalls[0][1], (
                 'gwvolman.tasks.build_image',

--- a/server/constants.py
+++ b/server/constants.py
@@ -8,6 +8,7 @@ API_VERSION = '2.0'
 CATALOG_NAME = 'WholeTale Catalog'
 WORKSPACE_NAME = 'WholeTale Workspaces'
 DATADIRS_NAME = 'WholeTale Data Mountpoints'
+SCRIPTDIRS_NAME = 'WholeTale Narrative'
 
 
 class HarvesterType:

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -45,6 +45,10 @@ class Tale(AccessControlledModel):
     def validate(self, tale):
         if 'iframe' not in tale:
             tale['iframe'] = False
+
+        if '_id' not in tale:
+            return tale
+
         if tale.get('format', 0) < 2:
             data_folder = getOrCreateRootFolder(DATADIRS_NAME)
             try:

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -5,7 +5,7 @@ import datetime
 from bson.objectid import ObjectId
 
 from .image import Image
-from ..constants import WORKSPACE_NAME, DATADIRS_NAME
+from ..constants import WORKSPACE_NAME, DATADIRS_NAME, SCRIPTDIRS_NAME
 from ..utils import getOrCreateRootFolder
 from girder.models.model_base import AccessControlledModel
 from girder.models.item import Item
@@ -19,7 +19,7 @@ from girder.exceptions import \
 # Whenever the Tale object schema is modified (e.g. fields are added or
 # removed) increase `_currentTaleFormat` to retroactively apply those
 # changes to existing Tales.
-_currentTaleFormat = 2
+_currentTaleFormat = 3
 
 
 class Tale(AccessControlledModel):
@@ -38,14 +38,15 @@ class Tale(AccessControlledModel):
         self.exposeFields(
             level=AccessType.READ,
             fields=({'_id', 'folderId', 'imageId', 'creatorId', 'created',
-                     'format', 'involatileData'} | self.modifiableFields))
+                     'format', 'involatileData', 'narrative',
+                     'narrativeId'} | self.modifiableFields))
         self.exposeFields(level=AccessType.ADMIN, fields={'published'})
 
     def validate(self, tale):
         if 'iframe' not in tale:
             tale['iframe'] = False
         if tale.get('format', 0) < 2:
-            dataFolder = getOrCreateRootFolder(DATADIRS_NAME)
+            data_folder = getOrCreateRootFolder(DATADIRS_NAME)
             try:
                 origFolder = Folder().load(tale['folderId'], force=True, exc=True)
             except ValidationException:
@@ -60,9 +61,15 @@ class Tale(AccessControlledModel):
                 {'type': 'folder', 'id': tale.pop('folderId')}
             ]
             newFolder = Folder().copyFolder(
-                origFolder, parent=dataFolder, parentType='folder',
+                origFolder, parent=data_folder, parentType='folder',
                 name=str(tale['_id']), creator=creator, progress=False)
             tale['folderId'] = newFolder['_id']
+        if tale.get('format', 0) < 3:
+            if 'narrativeId' not in tale:
+                default = self.createNarrativeFolder(tale, default=True)
+                tale['narrativeId'] = default['_id']
+            if 'narrative' not in tale:
+                tale['narrative'] = []
         tale['format'] = _currentTaleFormat
         return tale
 
@@ -105,7 +112,8 @@ class Tale(AccessControlledModel):
 
     def createTale(self, image, data, creator=None, save=True, title=None,
                    description=None, public=None, config=None, published=False,
-                   authors=None, icon=None, category=None, illustration=None):
+                   authors=None, icon=None, category=None, illustration=None,
+                   narrative=None):
         if creator is None:
             creatorId = None
         else:
@@ -122,7 +130,7 @@ class Tale(AccessControlledModel):
             'category': category,
             'config': config,
             'creatorId': creatorId,
-            'involatileData': data,
+            'involatileData': data or [],
             'description': description,
             'format': _currentTaleFormat,
             'created': now,
@@ -130,6 +138,7 @@ class Tale(AccessControlledModel):
             'iframe': image.get('iframe', False),
             'imageId': ObjectId(image['_id']),
             'illustration': illustration,
+            'narrative': narrative or [],
             'title': title,
             'public': public,
             'published': published,
@@ -146,19 +155,37 @@ class Tale(AccessControlledModel):
         if save:
             tale = self.save(tale)
             self.createWorkspace(tale, creator=creator)
-            parent = self.createDataMountpoint(tale, creator=creator)
-            tale['folderId'] = parent['_id']
-            for obj in data:
+            data_folder = self.createDataMountpoint(tale, creator=creator)
+            tale['folderId'] = data_folder['_id']
+            for obj in tale['involatileData']:
                 if obj['type'] == 'folder':
                     folder = Folder().load(obj['id'], user=creator)
                     Folder().copyFolder(
-                        folder, parent=parent, parentType='folder',
+                        folder, parent=data_folder, parentType='folder',
                         creator=creator, progress=False)
                 elif obj['type'] == 'item':
                     item = Item().load(obj['id'], user=creator)
-                    Item().copyItem(item, creator, folder=parent)
+                    Item().copyItem(item, creator, folder=data_folder)
+
+            narrative_folder = self.createNarrativeFolder(
+                tale, creator=creator, default=not bool(tale['narrative']))
+            for obj_id in tale['narrative']:
+                item = Item().load(obj_id, user=creator)
+                Item().copyItem(item, creator, folder=narrative_folder)
+            tale['narrativeId'] = narrative_folder['_id']
             tale = self.save(tale)
         return tale
+
+    def createNarrativeFolder(self, tale, creator=None, default=False):
+        if default:
+            rootFolder = getOrCreateRootFolder(SCRIPTDIRS_NAME)
+            auxFolder = self.model('folder').createFolder(
+                rootFolder, 'default', parentType='folder',
+                public=True, reuseExisting=True)
+        else:
+            auxFolder = self._createAuxFolder(
+                tale, SCRIPTDIRS_NAME, creator=creator)
+        return auxFolder
 
     def createDataMountpoint(self, tale, creator=None):
         return self._createAuxFolder(tale, DATADIRS_NAME, creator=creator)

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -157,7 +157,7 @@ class Tale(Resource):
                                      'images/demo-graph2.jpg')),
                 authors=tale.get('authors', default_author),
                 category=tale.get('category', 'science'),
-                published=False
+                published=False, narrative=tale.get('narrative', [])
             )
 
     @access.user(scope=TokenScope.DATA_OWN)

--- a/server/schema/tale.py
+++ b/server/schema/tale.py
@@ -31,12 +31,24 @@ taleModel = {
         },
         "folderId": {
             "type": "string",
-            "description": "ID of a folder containing copy of tale['data']"
+            "description": "ID of a folder containing copy of tale['involatileData']"
+        },
+        "narrativeId": {
+            "type": "string",
+            "description": "ID of a folder containing copy of tale['narrative']"
         },
         "involatileData": {
             "type": "array",
             "items": dataResourceSchema,
             "description": "Resources used to create Tale's data folder"
+        },
+        "narrative": {
+            "type": "array",
+            "items": {
+                'type': 'string',
+                'description': "Girder Item id"
+            },
+            "description": "List of Girder Items containing Tale's narrative"
         },
         "format": {
             "type": "integer",


### PR DESCRIPTION
This PR introduces Tale's `narrative`, i.e. a set of scripts/files/notebooks that is going to be injected into the working directory upon Tale instantiation. In case of '.ipynb' and '.Rmd' files we could default to opening them after start in Jupyter and Rstudio respectively.
This feature will be divided into three stages:

1. Adding `narrative` support in Tale model (this PR)
1. Injecting `narrative` content into Tale Instance (PR to gwvolman)
1. UI modification, that would allow users to use `narrative` (PR to dashboard)

Stage 3 is outside of scope of v0.5 milestone. However, 1 and 2 will be used to address whole-tale/gwvolman#14