### PR TITLE
Add support for ORCID IDs in the EML metadata document. I also moved …

### DIFF
--- a/plugin_tests/dataone_package_test.py
+++ b/plugin_tests/dataone_package_test.py
@@ -81,7 +81,7 @@ class TestDataONEUpload(base.TestCase):
         user = {'lastName': 'testLastName', 'firstName': 'testFirstName'}
         eml_pid ='123456789'
 
-        eml = create_minimum_eml(tale, user, [], eml_pid, {}, 1)
+        eml = create_minimum_eml(tale, user, [], eml_pid, {}, 1, "http://myorcid")
 
         root = ET.fromstring(eml)
 
@@ -100,7 +100,7 @@ class TestDataONEUpload(base.TestCase):
         user = {'lastName': 'testLastName', 'firstName': 'testFirstName'}
         eml_pid ='123456789'
 
-        eml = create_minimum_eml(tale, user, [], eml_pid, {}, 1)
+        eml = create_minimum_eml(tale, user, [], eml_pid, {}, 1, "http://myorcid")
 
         root = ET.fromstring(eml)
         abstract = root.findall('abstract')

--- a/plugin_tests/dataone_upload_test.py
+++ b/plugin_tests/dataone_upload_test.py
@@ -35,7 +35,6 @@ class TestDataONEUpload(base.TestCase):
         # Test for create_upload_eml that will generate metadata and attempt to upload it.
         # Note that the upload should not go thorugh, and we should catch an exception
 
-        from server.dataone_upload import upload_file
         from server.dataone_upload import create_client
         from server.dataone_upload import create_upload_eml
 
@@ -54,6 +53,7 @@ class TestDataONEUpload(base.TestCase):
                           user,
                           [],
                           1,
+                          "https://orcid.org/0-0-0-0-0",
                           dict())
 
     def test_create_upload_resmap(self):

--- a/plugin_tests/utils_test.py
+++ b/plugin_tests/utils_test.py
@@ -181,7 +181,7 @@ class TestDataONEUtils(base.TestCase):
               "L1PCc6TzAG0_FnWqOcpzsl1bNrRNOFkgyg"
 
         res = extract_user_id(jwt)
-        self.assertEqual(res, "http://orcid.org/0000-0002-1756-2128")
+        self.assertEqual(res, "https://orcid.org/0000-0002-1756-2128")
 
     def test_strip_html_tags(self):
         from server.utils import strip_html_tags
@@ -197,3 +197,10 @@ class TestDataONEUtils(base.TestCase):
         input = 'http:\/\/orcid.org\/000-000-000-00'
         res = is_orcid_id(input)
         self.assertTrue(res)
+
+    def test_make_url_https(self):
+        from server.utils import make_url_https
+
+        url = 'http://afakeurlthatisntreal'
+        res = make_url_https(url)
+        self.assertEqual(res, 'https://afakeurlthatisntreal')

--- a/plugin_tests/utils_test.py
+++ b/plugin_tests/utils_test.py
@@ -161,3 +161,24 @@ class TestDataONEUtils(base.TestCase):
         # Test that we get the right url when using prod
         url = get_dataone_package_url(DataONELocations.prod_cn, pid)
         self.assertEqual(url, 'https://search.dataone.org/#view/'+pid)
+
+    def test_extract_orcid_id(self):
+        from server.utils import parse_jwt
+        from server.utils import extract_orcid_id
+
+        jwt = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJodHRwOlwvXC9vcmNpZC5vcm" \
+              "dcLzAwMDAtMDAwMi0xNzU2LTIxMjgiLCJmdWxsTmFtZSI6IlRob21hc" \
+              "yBUaGVsZW4iLCJpc3N1ZWRBdCI6IjIwMTgtMDgtMDJUMjI6MDY6MDYu" \
+              "NDAzKzAwOjAwIiwiY29uc3VtZXJLZXkiOiJ0aGVjb25zdW1lcmtleSI" \
+              "sImV4cCI6MTUzMzMxMjM2NiwidXNlcklkIjoiaHR0cDpcL1wvb3JjaW" \
+              "Qub3JnXC8wMDAwLTAwMDItMTc1Ni0yMTI4IiwidHRsIjo2NDgwMCwia" \
+              "WF0IjoxNTMzMjQ3NTY2fQ.cGnBNtWmLghJj_I0nVpn4S0900eHD0siI" \
+              "cYZDW3AHx6B2KDFxnzd9A7l7HDHF3VmtA6te2xkiERQzBUFRqYuKtEE" \
+              "WCtX5r4AdkGgEEgozm9a3d8pl1I7YxYG2snhoay0CEZuMlm1KrA9Hoy" \
+              "0KVeFRsJw6Eyx8BP3Ftozt7GAEDkPJzNnYdRHc1oyybNgefY8tHNX20" \
+              "hEIlsteNkBcQcNuuZRSgUcSCvWajWkrIrDpm1JySPZA5TIjcrSpksTe" \
+              "kbCEA7b2KfMRdjfk7ZRaRa0FGVw5K25mDmXbkJ1ScCLUnDMZIW20ENU" \
+              "L1PCc6TzAG0_FnWqOcpzsl1bNrRNOFkgyg"
+
+        res = extract_orcid_id(jwt)
+        self.assertEqual(res, "http://orcid.org/0000-0002-1756-2128")

--- a/plugin_tests/utils_test.py
+++ b/plugin_tests/utils_test.py
@@ -163,9 +163,9 @@ class TestDataONEUtils(base.TestCase):
         self.assertEqual(url, 'https://search.dataone.org/#view/'+pid)
 
     def test_extract_orcid_id(self):
-        from server.utils import parse_jwt
-        from server.utils import extract_orcid_id
+        from server.utils import extract_user_id
 
+        # Test with a JWT that has an orcid account
         jwt = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJodHRwOlwvXC9vcmNpZC5vcm" \
               "dcLzAwMDAtMDAwMi0xNzU2LTIxMjgiLCJmdWxsTmFtZSI6IlRob21hc" \
               "yBUaGVsZW4iLCJpc3N1ZWRBdCI6IjIwMTgtMDgtMDJUMjI6MDY6MDYu" \
@@ -180,13 +180,20 @@ class TestDataONEUtils(base.TestCase):
               "kbCEA7b2KfMRdjfk7ZRaRa0FGVw5K25mDmXbkJ1ScCLUnDMZIW20ENU" \
               "L1PCc6TzAG0_FnWqOcpzsl1bNrRNOFkgyg"
 
-        res = extract_orcid_id(jwt)
+        res = extract_user_id(jwt)
         self.assertEqual(res, "http://orcid.org/0000-0002-1756-2128")
 
-    def test_strip_html(self):
-        from server.utils import strip_html
+    def test_strip_html_tags(self):
+        from server.utils import strip_html_tags
 
         str_no_html = 'test description'
-        messy_str = '<p>'+str_no_html+'</p>'
-        self.assertEqual(strip_html(messy_str), str_no_html)
+        str_with_tags = '<p>'+str_no_html+'</p>'
+        self.assertEqual(strip_html_tags(str_with_tags), str_no_html)
 
+    def test_is_orcid_id(self):
+        from server.utils import is_orcid_id
+
+        # This is what the decoded jwt userid can look like
+        input = 'http:\/\/orcid.org\/000-000-000-00'
+        res = is_orcid_id(input)
+        self.assertTrue(res)

--- a/plugin_tests/utils_test.py
+++ b/plugin_tests/utils_test.py
@@ -201,6 +201,14 @@ class TestDataONEUtils(base.TestCase):
     def test_make_url_https(self):
         from server.utils import make_url_https
 
-        url = 'http://afakeurlthatisntreal'
+        url = 'http://afakeurlthatisntreal.net'
         res = make_url_https(url)
-        self.assertEqual(res, 'https://afakeurlthatisntreal')
+        self.assertEqual(res, 'https://afakeurlthatisntreal.net')
+
+        url = 'http://afakeurlthatisntreal.com/http-example'
+        res = make_url_https(url)
+        self.assertEqual(res, 'https://afakeurlthatisntreal.com/http-example')
+
+        url = 'htts://example.com'
+        res = make_url_https(url)
+        self.assertEqual(res, 'https://example.com')

--- a/server/dataone_package.py
+++ b/server/dataone_package.py
@@ -52,7 +52,8 @@ def create_minimum_eml(tale,
                        item_ids,
                        eml_pid,
                        file_sizes,
-                       license_id):
+                       license_id,
+                       orcid_id):
     """
     Creates a bare minimum EML record for a package. Note that the
     ordering of the xml elements matters.
@@ -64,12 +65,14 @@ def create_minimum_eml(tale,
     :param file_sizes: When we upload files that are not in the girder system (ie not
      files or items) we need to manually pass their size in. Use this dict to do that.
     :param license_id: The ID of the license
+    :param orcid_id: The user's orcid ID
     :type tale: wholetale.models.tale
     :type user: girder.models.user
     :type item_ids: list
     :type eml_pid: str
     :type file_sizes: dict
     :type licenseId: int
+    :type orcid_id: str
     :return: The EML as as string of bytes
     :rtype: bytes
     """
@@ -192,6 +195,9 @@ def create_minimum_eml(tale,
     individual_name = ET.SubElement(creator, 'individualName')
     ET.SubElement(individual_name, 'givenName').text = firstName
     ET.SubElement(individual_name, 'surName').text = lastName
+    userId = ET.SubElement(creator, 'userId')
+    userId.text = orcid_id
+    userId.set('directory', "https://orcid.org")
 
     # Create a `description` field, but only if the Tale has a description.
     description = get_tale_description(tale)

--- a/server/dataone_package.py
+++ b/server/dataone_package.py
@@ -18,7 +18,8 @@ from .utils import \
     get_file_format, \
     get_tale_description, \
     get_file_item, \
-    strip_html
+    strip_html_tags, \
+    get_directory
 
 from .constants import \
     ExtraFileNames, \
@@ -54,7 +55,7 @@ def create_minimum_eml(tale,
                        eml_pid,
                        file_sizes,
                        license_id,
-                       orcid_id):
+                       user_id):
     """
     Creates a bare minimum EML record for a package. Note that the
     ordering of the xml elements matters.
@@ -66,14 +67,14 @@ def create_minimum_eml(tale,
     :param file_sizes: When we upload files that are not in the girder system (ie not
      files or items) we need to manually pass their size in. Use this dict to do that.
     :param license_id: The ID of the license
-    :param orcid_id: The user's orcid ID
+    :param user_id: The user's user id from the JWT
     :type tale: wholetale.models.tale
     :type user: girder.models.user
     :type item_ids: list
     :type eml_pid: str
     :type file_sizes: dict
     :type licenseId: int
-    :type orcid_id: str
+    :type user_id: str
     :return: The EML as as string of bytes
     :rtype: bytes
     """
@@ -150,7 +151,7 @@ def create_minimum_eml(tale,
         :param object_format: The format type
         :return: None
         """
-        entity_section = create_entity(name, strip_html(description))
+        entity_section = create_entity(name, strip_html_tags(description))
         physical_section = create_physical(entity_section,
                                            name,
                                            size)
@@ -160,7 +161,7 @@ def create_minimum_eml(tale,
     """
     Check that we're able to assign a first, last, and email to the record.
     If we aren't throw an exception and let the user know. We'll also check that
-    the user has an ORCID ID set.
+    the user has a userID from their JWT.
     """
     lastName = user.get('lastName', None)
     firstName = user.get('firstName', None)
@@ -197,14 +198,14 @@ def create_minimum_eml(tale,
     ET.SubElement(individual_name, 'givenName').text = firstName
     ET.SubElement(individual_name, 'surName').text = lastName
     userId = ET.SubElement(creator, 'userId')
-    userId.text = orcid_id
-    userId.set('directory', "https://orcid.org")
+    userId.text = user_id
+    userId.set('directory', get_directory(user_id))
 
     # Create a `description` field, but only if the Tale has a description.
     description = get_tale_description(tale)
     if description is not str():
         abstract = ET.SubElement(dataset, 'abstract')
-        ET.SubElement(abstract, 'para').text = strip_html(description)
+        ET.SubElement(abstract, 'para').text = strip_html_tags(description)
 
     # Add a section for the license file
     create_intellectual_rights(dataset, license_id)

--- a/server/dataone_register.py
+++ b/server/dataone_register.py
@@ -3,37 +3,15 @@ Code for querying DataONE and verifying query results. Specifically used for
  finding datasets based on the url and for listing package contents. Some of
   these methods are used elsewhere in the WholeTale plugin, specifically in  the harvester.
 """
-
 import re
 import json
-import six.moves.urllib as urllib
 import requests
 
 from girder import logger
 from girder.api.rest import RestException
 from .constants import DataONELocations
-
-
-def esc(value):
-    """
-    Escape a string so it can be used in a Solr query string
-    :param value: The string that will be escaped
-    :type value: str
-    :return: The escaped string
-    :rtype: str
-    """
-    return urllib.parse.quote_plus(value)
-
-
-def unesc(value):
-    """
-    Un-escapes a string so it can used in URLS.
-    :param value: The string that will be un-escaped
-    :type value: str
-    :return: The un-escaped string
-    :rtype: str
-    """
-    return urllib.parse.unquote_plus(value)
+from .utils import \
+    esc
 
 
 def query(q,

--- a/server/dataone_upload.py
+++ b/server/dataone_upload.py
@@ -21,7 +21,8 @@ from .utils import \
     get_file_item, \
     get_remote_url, \
     is_dataone_url, \
-    get_dataone_package_url
+    get_dataone_package_url, \
+    extract_orcid_id
 from .constants import \
     API_VERSION, \
     ExtraFileNames
@@ -68,7 +69,13 @@ def upload_file(client, pid, file_object, system_metadata):
         raise ValidationException('Error uploading file to DataONE. {0}'.format(str(e)))
 
 
-def create_upload_eml(tale, client, user, item_ids, license_id, file_sizes=dict()):
+def create_upload_eml(tale,
+                      client,
+                      user,
+                      item_ids,
+                      license_id,
+                      orcid_id,
+                      file_sizes=dict()):
     """
     Creates the EML metadata document along with an additional metadata document
     and uploads them both to DataONE. A pid is created for the EML document, and is
@@ -99,7 +106,8 @@ def create_upload_eml(tale, client, user, item_ids, license_id, file_sizes=dict(
                                  item_ids,
                                  eml_pid,
                                  file_sizes,
-                                 license_id)
+                                 license_id,
+                                 orcid_id,)
 
     # Create the metadata describing the EML document
     meta = generate_system_metadata(pid=eml_pid,
@@ -403,6 +411,8 @@ def create_upload_package(item_ids,
                                                                   item_ids,
                                                                   user,
                                                                   client)
+
+        orcid_id = extract_orcid_id(jwt)
         """
         Create an EML document describing the data, and then upload it. Save the
          pid for the resource map.
@@ -413,6 +423,7 @@ def create_upload_package(item_ids,
                                     user,
                                     item_ids,
                                     license_id,
+                                    orcid_id,
                                     file_sizes)
 
         """

--- a/server/dataone_upload.py
+++ b/server/dataone_upload.py
@@ -22,7 +22,7 @@ from .utils import \
     get_remote_url, \
     is_dataone_url, \
     get_dataone_package_url, \
-    extract_orcid_id
+    extract_user_id
 from .constants import \
     API_VERSION, \
     ExtraFileNames
@@ -74,7 +74,7 @@ def create_upload_eml(tale,
                       user,
                       item_ids,
                       license_id,
-                      orcid_id,
+                      user_id,
                       file_sizes=dict()):
     """
     Creates the EML metadata document along with an additional metadata document
@@ -107,7 +107,7 @@ def create_upload_eml(tale,
                                  eml_pid,
                                  file_sizes,
                                  license_id,
-                                 orcid_id,)
+                                 user_id,)
 
     # Create the metadata describing the EML document
     meta = generate_system_metadata(pid=eml_pid,
@@ -412,7 +412,7 @@ def create_upload_package(item_ids,
                                                                   user,
                                                                   client)
 
-        orcid_id = extract_orcid_id(jwt)
+        user_id = extract_user_id(jwt)
         """
         Create an EML document describing the data, and then upload it. Save the
          pid for the resource map.
@@ -423,7 +423,7 @@ def create_upload_package(item_ids,
                                     user,
                                     item_ids,
                                     license_id,
-                                    orcid_id,
+                                    user_id,
                                     file_sizes)
 
         """

--- a/server/dataone_upload.py
+++ b/server/dataone_upload.py
@@ -107,7 +107,7 @@ def create_upload_eml(tale,
                                  eml_pid,
                                  file_sizes,
                                  license_id,
-                                 user_id,)
+                                 user_id)
 
     # Create the metadata describing the EML document
     meta = generate_system_metadata(pid=eml_pid,

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,5 +1,5 @@
 import re
-import base64
+import jwt
 import six.moves.urllib as urllib
 
 from girder.utility.model_importer import ModelImporter
@@ -268,33 +268,27 @@ def get_dataone_package_url(repository, pid):
         return str('https://dev.nceas.ucsb.edu/#view/'+pid)
 
 
-def parse_jwt(jwt_token):
-    """
-    Takes a jwt token and returns the decoded section of it
-
-    :param jwt_token: The jwt token
-    :type jwt_token: str
-    :return: A dictionary of the jwt information
-    :rtype: dict
-    """
-    base_section = re.search('\.([^\.]+)\.', jwt_token).group(1)
-    if base_section is not None:
-        pad = len(base_section) % 4
-        base_section += "=" * pad
-        return str(base64.b64decode(base_section))
-    return base_section
-
-
-def extract_orcid_id(jwt):
+def extract_user_id(jwt_token):
     """
     Takes a JWT and extracts the orcid id out.
-    :param jwt:
-    :return:
+    :param jwt: The decoded JWT
+    :type jwt: str
+    :return: The ORCID ID
     :rtype: str
     """
-    parsed_jwt = parse_jwt(jwt)
-    orcid_res = re.search('"userId"\s*:\s*"([^"]*)"', parsed_jwt).group(1)
-    return orcid_res.replace("\\", "")
+    jwt_token = jwt.decode(jwt_token, verify=False)
+    return jwt_token['userId']
+
+
+def is_orcid_id(id):
+    """
+    Checks whether a string is a link to an ORCID account
+    :param id: The string that may contain the ORCID account
+    :type id: str
+    :return: True/False if it is or isn't
+    :rtype: bool
+    """
+    return bool(id.find('orcid.org'))
 
 
 def esc(value):
@@ -308,12 +302,27 @@ def esc(value):
     return urllib.parse.quote_plus(value)
 
 
-def strip_html(string):
+def strip_html_tags(string):
     """
-    Removes HTML from a string
+    Removes HTML tags from a string
     :param string: The string with HTML
     :type string: str
     :return: The string without HTML
     :rtype: str
     """
     return re.sub('<[^<]+?>', '', string)
+
+
+def get_directory(user_id):
+    """
+    Returns the directory that should be used in the EML
+
+    :param user_id: The user ID
+    :type user_id: str
+    :return: The directory name
+    :rtype: str
+    """
+    logger.info(type(user_id))
+    if is_orcid_id(user_id):
+        return "https://orcid.org"
+    return "https://cilogon.org"

--- a/server/utils.py
+++ b/server/utils.py
@@ -268,7 +268,6 @@ def get_dataone_package_url(repository, pid):
         return str('https://dev.nceas.ucsb.edu/#view/'+pid)
 
 
-
 def parse_jwt(jwt_token):
     """
     Takes a jwt token and returns the decoded section of it
@@ -308,6 +307,7 @@ def esc(value):
     """
     return urllib.parse.quote_plus(value)
 
+
 def strip_html(string):
     """
     Removes HTML from a string
@@ -317,4 +317,3 @@ def strip_html(string):
     :rtype: str
     """
     return re.sub('<[^<]+?>', '', string)
-

--- a/server/utils.py
+++ b/server/utils.py
@@ -340,5 +340,5 @@ def make_url_https(url):
     :return: The url as https
     :rtype: str
     """
-    res = url.replace("http", "https")
-    return res
+    parsed = urllib.parse.urlparse(url)
+    return parsed._replace(scheme="https").geturl()

--- a/server/utils.py
+++ b/server/utils.py
@@ -277,6 +277,9 @@ def extract_user_id(jwt_token):
     :rtype: str
     """
     jwt_token = jwt.decode(jwt_token, verify=False)
+    user_id = jwt_token['userId']
+    if is_orcid_id(user_id):
+        return make_url_https(user_id)
     return jwt_token['userId']
 
 
@@ -326,3 +329,16 @@ def get_directory(user_id):
     if is_orcid_id(user_id):
         return "https://orcid.org"
     return "https://cilogon.org"
+
+
+def make_url_https(url):
+    """
+    Given an http url, return it as https
+
+    :param url: The http url
+    :type url: str
+    :return: The url as https
+    :rtype: str
+    """
+    res = url.replace("http", "https")
+    return res


### PR DESCRIPTION
Since we have the user's DataONE JWT, we can take the section of it between `.`s and base 64 decode it. Once decoded, we can extract the orcid ID out. Note that the jwt used in the unit test has been invalidated.

This fixes issue #120