### PR TITLE
Set the rightsHolder in the EML

### DIFF
--- a/plugin_tests/dataone_upload_test.py
+++ b/plugin_tests/dataone_upload_test.py
@@ -46,6 +46,7 @@ class TestDataONEUpload(base.TestCase):
         object = 'test data'
         tale = {'title': 'test_title', 'description': 'Test tale description'}
         user = {'lastName': 'testLastName', 'firstName': 'testFirstName'}
+        rights_holder = 'https://orcid.org/0000-0000-0000-0000'
 
         self.assertRaises(ValidationException, create_upload_eml,
                           tale,
@@ -53,7 +54,7 @@ class TestDataONEUpload(base.TestCase):
                           user,
                           [],
                           1,
-                          "https://orcid.org/0-0-0-0-0",
+                          rights_holder,
                           dict())
 
     def test_create_upload_resmap(self):
@@ -65,6 +66,7 @@ class TestDataONEUpload(base.TestCase):
         from server.dataone_upload import create_upload_eml
 
         member_node = 'https://dev.nceas.ucsb.edu/knb/d1/mn/'
+        rights_holder = 'https://orcid.org/0000-0000-0000-0000'
         header = {"headers": {
             "Authorization": "Bearer TOKEN"}}
         client = create_client(member_node, header)
@@ -77,4 +79,5 @@ class TestDataONEUpload(base.TestCase):
                           res_pid,
                           eml_pid,
                           obj_pids,
-                          client)
+                          client,
+                          rights_holder)

--- a/server/utils.py
+++ b/server/utils.py
@@ -270,7 +270,8 @@ def get_dataone_package_url(repository, pid):
 
 def extract_user_id(jwt_token):
     """
-    Takes a JWT and extracts the orcid id out.
+    Takes a JWT and extracts the 'userId` field. This is used
+    as the package's owner and contact.
     :param jwt: The decoded JWT
     :type jwt: str
     :return: The ORCID ID
@@ -280,7 +281,7 @@ def extract_user_id(jwt_token):
     user_id = jwt_token['userId']
     if is_orcid_id(user_id):
         return make_url_https(user_id)
-    return jwt_token['userId']
+    return user_id
 
 
 def is_orcid_id(id):


### PR DESCRIPTION
This commit adds functionality for setting the rightsHolder field in the EML.

# Change 1: Setting rightsHolder

This is just the `userId` field from the jwt. Most of the changes are trickling this ID to all of the `generate_system_metadata` calls.

# Change 2: Add Email to EML

I noticed the email wasn't getting set in the EML, so I went ahead and added it (since we have it)

# Change 3: Add the user ID to the Contacts Field

We were adding it to the Creator field, but it should also go in `Contacts`.


Here's a package that was created using code from this PR. 
https://dev.nceas.ucsb.edu/#view/664d9781-cd8a-43b4-9850-fb1e91a1e5a2