### PR TITLE
Close Connection After Uploads

### DIFF
--- a/server/dataone_upload.py
+++ b/server/dataone_upload.py
@@ -571,8 +571,9 @@ def publish(item_ids,
         logger.debug('Creating the DataONE client')
         client = create_client(repository, {
             "headers": {
-                "Authorization": "Bearer " + jwt},
-            "user_agent": "safari"})
+                "Authorization": "Bearer " + jwt,
+                "user_agent": "safari",
+                "Connection": "close"}})
 
     except DataONEException as e:
         logger.warning('Error creating the DataONE Client: {}'.format(e))


### PR DESCRIPTION
When uploading a large number of files, the connection dies. If we take the performance hit of closing each connection we'll get reliable uploads.