### PR TITLE
Fix License Paths

### DIFF
--- a/server/dataone_upload.py
+++ b/server/dataone_upload.py
@@ -424,8 +424,6 @@ def upload_license_file(client, license_id, rights_holder):
 
     # Path to the license file
     license_path = os.path.join(ROOT_DIR,
-                                'girder',
-                                'plugins',
                                 'wholetale',
                                 'licenses',
                                 license_files[license_id])


### PR DESCRIPTION
I ssh'd into the depolyed directory and found that I can leave out 'girder' and 'plugins'.

I found that
```
license_path = os.path.join(ROOT_DIR,
    ...:                                 'wholetale',
    ...:                                 'licenses')
```

gives the correct path as
`/girder/plugins/wholetale/wholetale/licenses`

Fixes issue #150