### PR TITLE
Pass TaleID to Worker Instead of Tale Dict

### DIFF
--- a/server/rest/publish.py
+++ b/server/rest/publish.py
@@ -3,7 +3,7 @@
 
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
-from girder.constants import TokenScope, AccessType
+from girder.constants import TokenScope
 from girder.api.rest import Resource
 from girder.plugins.jobs.models.job import Job
 

--- a/server/rest/publish.py
+++ b/server/rest/publish.py
@@ -59,16 +59,12 @@ class Publish(Resource):
 
         user = self.getCurrentUser()
         token = self.getCurrentToken()
-        tale = self.model('tale',
-                          'wholetale').load(taleId,
-                                            user=user,
-                                            level=AccessType.READ)
 
-        jobTitle = 'Publishing %s to DataONE' % tale['category']
+        jobTitle = 'Publishing Tale to DataONE'
         jobModel = Job()
 
         args = (itemIds,
-                tale,
+                taleId,
                 remoteMemberNode,
                 authToken,
                 str(token['_id']),


### PR DESCRIPTION
Instead of parsing the mongo entries out of the Tale dictionary and passing it to the worker, pass the TaleID and load the Tale from inside the worker.