### PR TITLE
Fix dev data registration and fix provInfo default value

### DIFF
--- a/server/rest/harvester.py
+++ b/server/rest/harvester.py
@@ -57,14 +57,23 @@ def register_DataONE_resource(parent,
     data = extract_data_docs(docs)
     children = extract_resource_docs(docs)
 
+    """
+    The download url is different between DataONE production and DataONE dev.
+    Check which place we're registering from and set the url section.
+    """
+    if base_url == DataONELocations.prod_cn:
+        url_insert = 'resolve'
+    else:
+        url_insert = 'object'
+
     # Add in URLs to resolve each metadata/data object by
     for i in range(len(metadata)):
         metadata[i]['url'] = \
-            "{}/resolve/{}".format(base_url, metadata[i]['identifier'])
+            "{}/{}/{}".format(base_url, url_insert, metadata[i]['identifier'])
 
     for i in range(len(data)):
         data[i]['url'] = \
-            "{}/resolve/{}".format(base_url, data[i]['identifier'])
+            "{}/{}/{}".format(base_url, url_insert, data[i]['identifier'])
 
     # Determine the folder name. This is usually the title of the metadata file
     # in the package but when there are multiple metadata files in the package,

--- a/server/rest/publish.py
+++ b/server/rest/publish.py
@@ -55,7 +55,7 @@ class Publish(Resource):
                        remoteMemberNode,
                        authToken,
                        licenseSPDX,
-                       provInfo=str()):
+                       provInfo=dict()):
 
         user = self.getCurrentUser()
         token = self.getCurrentToken()


### PR DESCRIPTION


Change 1: Removed unused parameter from `dataone_register.query` (line 22)

Change 2: Made hash fragments optional when parsing dataset URLS (lines 170-178)

Change 3: Access `doc` elements with `get`. I noticed that in some cases the dict entries were missing and we would die before raising the `RestException`.

Change 4: Data from the member node was getting the wrong URI. Fixed in the harvester

Change 5: provInfo should default to `dict()` instead of `str()`