### PR TITLE
Construct instance url in gwvolman, rather than in Girder

### DIFF
--- a/server/constants.py
+++ b/server/constants.py
@@ -3,7 +3,7 @@
 
 from girder import events
 
-API_VERSION = '2.0'
+API_VERSION = '2.1'
 CATALOG_NAME = 'WholeTale Catalog'
 WORKSPACE_NAME = 'WholeTale Workspaces'
 DATADIRS_NAME = 'WholeTale Data Mountpoints'


### PR DESCRIPTION
Avoids the hassle of reconstructing instance url on Girder side. gwvolman task has all the required information to construct it during the service creation.