### PR TITLE
Explicitly query DataONE with every string that's passed to lookup. Fixes #176

### DIFF
--- a/plugin_tests/data/test_find_resource_pid.txt
+++ b/plugin_tests/data/test_find_resource_pid.txt
@@ -21,7 +21,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:29 GMT']
+      Date: ['Wed, 21 Nov 2018 18:56:59 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]

--- a/plugin_tests/data/test_get_package_list_flat.txt
+++ b/plugin_tests/data/test_get_package_list_flat.txt
@@ -9,7 +9,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22urn%3Auuid%3A7ec733c4-aa63-405a-a58d-1d773a9025a9%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":72,"params":{"q":"identifier:\"urn:uuid:7ec733c4-aa63-405a-a58d-1d773a9025a9\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"urn:uuid:7ec733c4-aa63-405a-a58d-1d773a9025a9","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_urn:uuid:7ec733c4-aa63-405a-a58d-1d773a9025a9"]}]}}
+    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"identifier:\"urn:uuid:7ec733c4-aa63-405a-a58d-1d773a9025a9\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"urn:uuid:7ec733c4-aa63-405a-a58d-1d773a9025a9","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_urn:uuid:7ec733c4-aa63-405a-a58d-1d773a9025a9"]}]}}
 
 '}
     headers:
@@ -21,7 +21,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:32 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:02 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -36,7 +36,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_urn%3Auuid%3A7ec733c4-aa63-405a-a58d-1d773a9025a9%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":70,"params":{"q":"resourceMap:\"resource_map_urn:uuid:7ec733c4-aa63-405a-a58d-1d773a9025a9\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":5,"start":0,"docs":[{"identifier":"urn:uuid:7ec733c4-aa63-405a-a58d-1d773a9025a9","fileName":"science_metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":8961,"title":"Doctoral
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"resourceMap:\"resource_map_urn:uuid:7ec733c4-aa63-405a-a58d-1d773a9025a9\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":5,"start":0,"docs":[{"identifier":"urn:uuid:7ec733c4-aa63-405a-a58d-1d773a9025a9","fileName":"science_metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":8961,"title":"Doctoral
         Dissertation Research: Mapping Community Exposure to Coastal Climate Hazards
         in the Arctic: A Case Study in Alaska''s North Slope","documents":["resource_map_doi:10.18739/A2PT0N","resource_map_doi:10.18739/A2VV3P","resource_map_doi:10.18739/A2TH5P","urn:uuid:7ec733c4-aa63-405a-a58d-1d773a9025a9","resource_map_doi:10.18739/A2R48D"]},{"identifier":"resource_map_doi:10.18739/A2R48D","fileName":"file16b4761a23a7b","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":2801},{"identifier":"resource_map_doi:10.18739/A2PT0N","fileName":"file466e26f0df74","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":2801},{"identifier":"resource_map_doi:10.18739/A2TH5P","fileName":"file466e3509408","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":2801},{"identifier":"resource_map_doi:10.18739/A2VV3P","fileName":"file16b4779ff25fe","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":2801}]}}
 
@@ -50,7 +50,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:32 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:02 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -65,7 +65,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.18739%2FA2R48D%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":5,"params":{"q":"identifier:\"doi:10.18739/A2R48D\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2R48D","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A2R48D"]}]}}
+    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"identifier:\"doi:10.18739/A2R48D\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2R48D","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A2R48D"]}]}}
 
 '}
     headers:
@@ -77,7 +77,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:33 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:03 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -105,7 +105,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:34 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:03 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -132,7 +132,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:34 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:04 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -160,7 +160,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:34 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:04 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -187,7 +187,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:35 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:05 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -216,7 +216,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:35 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:05 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -231,7 +231,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.18739%2FA2VV3P%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":71,"params":{"q":"identifier:\"doi:10.18739/A2VV3P\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2VV3P","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A2VV3P"]}]}}
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"doi:10.18739/A2VV3P\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2VV3P","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A2VV3P"]}]}}
 
 '}
     headers:
@@ -243,7 +243,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:36 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:06 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -258,7 +258,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_doi%3A10.18739%2FA2VV3P%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":71,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A2VV3P\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2VV3P","fileName":"science_metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":10491,"title":"Arctic
+    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A2VV3P\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2VV3P","fileName":"science_metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":10491,"title":"Arctic
         Slope Shoreline Change Susceptibility Spatial Data Model, 2015-16","documents":["doi:10.18739/A2VV3P"]}]}}
 
 '}
@@ -271,7 +271,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:37 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:06 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]

--- a/plugin_tests/data/test_get_package_list_nested.txt
+++ b/plugin_tests/data/test_get_package_list_nested.txt
@@ -9,7 +9,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22urn%3Auuid%3A6f5533ab-6508-4ac7-82a3-1df88ed4580e%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":72,"params":{"q":"identifier:\"urn:uuid:6f5533ab-6508-4ac7-82a3-1df88ed4580e\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"urn:uuid:6f5533ab-6508-4ac7-82a3-1df88ed4580e","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_urn:uuid:ec4f122b-876f-4e33-818c-2c91e7a2488f"]}]}}
+    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"identifier:\"urn:uuid:6f5533ab-6508-4ac7-82a3-1df88ed4580e\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"urn:uuid:6f5533ab-6508-4ac7-82a3-1df88ed4580e","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_urn:uuid:ec4f122b-876f-4e33-818c-2c91e7a2488f"]}]}}
 
 '}
     headers:
@@ -21,7 +21,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:37 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:07 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -36,7 +36,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_urn%3Auuid%3Aec4f122b-876f-4e33-818c-2c91e7a2488f%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"resourceMap:\"resource_map_urn:uuid:ec4f122b-876f-4e33-818c-2c91e7a2488f\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":8,"start":0,"docs":[{"identifier":"resource_map_urn:uuid:dab72bc5-7f7a-4aa3-98e4-0eeb17ccca94","fileName":"resourceMap_urn:uuid:3c22abab-e923-4a99-936b-096465016ddc.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":11087},{"identifier":"urn:uuid:6f5533ab-6508-4ac7-82a3-1df88ed4580e","fileName":"science_metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":8940,"title":"Temperature
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"resourceMap:\"resource_map_urn:uuid:ec4f122b-876f-4e33-818c-2c91e7a2488f\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":8,"start":0,"docs":[{"identifier":"resource_map_urn:uuid:dab72bc5-7f7a-4aa3-98e4-0eeb17ccca94","fileName":"resourceMap_urn:uuid:3c22abab-e923-4a99-936b-096465016ddc.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":11087},{"identifier":"urn:uuid:6f5533ab-6508-4ac7-82a3-1df88ed4580e","fileName":"science_metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":8940,"title":"Temperature
         and bio-geochemical data from Toolik Lake, Lake N2, Lake E1, Lake E5, and
         Lake E6, North Slope, Alaska","documents":["resource_map_urn:uuid:dab72bc5-7f7a-4aa3-98e4-0eeb17ccca94","urn:uuid:6f5533ab-6508-4ac7-82a3-1df88ed4580e","resource_map_urn:uuid:d720d3d0-34bc-4d36-9b27-e6589c3a961b","resource_map_urn:uuid:9d06a11b-7c9a-4f83-a87b-df93c11d3f7e","resource_map_urn:uuid:c5d13183-0e4f-4008-9492-b53b2cd40a26","resource_map_urn:uuid:fabf29dc-574c-4cd3-b6b7-9abc3788b179","resource_map_urn:uuid:8c4cb5f6-9b11-4975-9668-c875dc4bbc2a","resource_map_urn:uuid:799b7a86-cb1c-497c-a05a-d73492915cad"]},{"identifier":"resource_map_urn:uuid:d720d3d0-34bc-4d36-9b27-e6589c3a961b","fileName":"file38a6171ed9727","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":9374},{"identifier":"resource_map_urn:uuid:9d06a11b-7c9a-4f83-a87b-df93c11d3f7e","fileName":"file23bf7bcf1f67","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":9374},{"identifier":"resource_map_urn:uuid:c5d13183-0e4f-4008-9492-b53b2cd40a26","fileName":"resourceMap_urn:uuid:59bd67d1-5357-4824-931f-9b404d2e3157.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":11087},{"identifier":"resource_map_urn:uuid:fabf29dc-574c-4cd3-b6b7-9abc3788b179","fileName":"file38a616a8945fe","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":9374},{"identifier":"resource_map_urn:uuid:8c4cb5f6-9b11-4975-9668-c875dc4bbc2a","fileName":"file38a611bde64c4","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":9374},{"identifier":"resource_map_urn:uuid:799b7a86-cb1c-497c-a05a-d73492915cad","fileName":"file25514868de2a","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":9374}]}}
 
@@ -50,7 +50,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:38 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:08 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -65,7 +65,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22resource_map_urn%3Auuid%3Adab72bc5-7f7a-4aa3-98e4-0eeb17ccca94%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"identifier:\"resource_map_urn:uuid:dab72bc5-7f7a-4aa3-98e4-0eeb17ccca94\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"resource_map_urn:uuid:dab72bc5-7f7a-4aa3-98e4-0eeb17ccca94","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","resourceMap":["resource_map_urn:uuid:431105b1-52ee-4324-9182-11e59e2b6efe","resource_map_urn:uuid:ec4f122b-876f-4e33-818c-2c91e7a2488f"]}]}}
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"resource_map_urn:uuid:dab72bc5-7f7a-4aa3-98e4-0eeb17ccca94\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"resource_map_urn:uuid:dab72bc5-7f7a-4aa3-98e4-0eeb17ccca94","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","resourceMap":["resource_map_urn:uuid:431105b1-52ee-4324-9182-11e59e2b6efe","resource_map_urn:uuid:ec4f122b-876f-4e33-818c-2c91e7a2488f"]}]}}
 
 '}
     headers:
@@ -77,7 +77,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:38 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:08 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:39 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:09 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -133,7 +133,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:39 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:09 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -148,7 +148,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_urn%3Auuid%3Ad720d3d0-34bc-4d36-9b27-e6589c3a961b%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":71,"params":{"q":"resourceMap:\"resource_map_urn:uuid:d720d3d0-34bc-4d36-9b27-e6589c3a961b\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":5,"start":0,"docs":[{"identifier":"resource_map_doi:10.18739/A22W0R","fileName":"resourceMap_urn:uuid:72a4828b-fb98-4e55-b4fd-39ea6116bb2b.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":6182},{"identifier":"urn:uuid:d720d3d0-34bc-4d36-9b27-e6589c3a961b","fileName":"E5_metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":8502,"title":"Time
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"resourceMap:\"resource_map_urn:uuid:d720d3d0-34bc-4d36-9b27-e6589c3a961b\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":5,"start":0,"docs":[{"identifier":"resource_map_doi:10.18739/A22W0R","fileName":"resourceMap_urn:uuid:72a4828b-fb98-4e55-b4fd-39ea6116bb2b.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":6182},{"identifier":"urn:uuid:d720d3d0-34bc-4d36-9b27-e6589c3a961b","fileName":"E5_metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":8502,"title":"Time
         series of water temperature, specific conductance, and oxygen from Lake E5,
         North Slope, Alaska","documents":["resource_map_doi:10.18739/A22W0R","urn:uuid:d720d3d0-34bc-4d36-9b27-e6589c3a961b","resource_map_doi:10.18739/A2BC5Z","resource_map_doi:10.18739/A26K2N","resource_map_doi:10.18739/A2G287"]},{"identifier":"resource_map_doi:10.18739/A2BC5Z","fileName":"resourceMap_urn:uuid:13ce15b5-17ec-4620-bbd0-a394a6723020.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":8776},{"identifier":"resource_map_doi:10.18739/A26K2N","fileName":"resourceMap_urn:uuid:662397af-a5ce-48be-a64a-8f914513e0b9.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":8776},{"identifier":"resource_map_doi:10.18739/A2G287","fileName":"resourceMap_urn:uuid:bef26a90-5f19-459d-ad1c-ac33dcfe5a6a.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":8776}]}}
 
@@ -162,7 +162,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:40 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:10 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -189,7 +189,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:41 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:10 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -204,7 +204,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_doi%3A10.18739%2FA22W0R%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A22W0R\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":3,"start":0,"docs":[{"identifier":"urn:uuid:50a17fbf-2739-45ea-970a-f5d1a60fb20a","fileName":"2013_summer_E5_temperature.csv","formatId":"text/csv","formatType":"DATA","size":3622122},{"identifier":"urn:uuid:9f4a0258-dae2-4bf3-857d-bd65704a1b03","fileName":"2012_2013_winter_E5_temperature.csv","formatId":"text/csv","formatType":"DATA","size":6959182},{"identifier":"doi:10.18739/A22W0R","fileName":"E5_2013metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":31522,"title":"Time
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A22W0R\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":3,"start":0,"docs":[{"identifier":"urn:uuid:50a17fbf-2739-45ea-970a-f5d1a60fb20a","fileName":"2013_summer_E5_temperature.csv","formatId":"text/csv","formatType":"DATA","size":3622122},{"identifier":"urn:uuid:9f4a0258-dae2-4bf3-857d-bd65704a1b03","fileName":"2012_2013_winter_E5_temperature.csv","formatId":"text/csv","formatType":"DATA","size":6959182},{"identifier":"doi:10.18739/A22W0R","fileName":"E5_2013metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":31522,"title":"Time
         series of water temperature, specific conductance, and oxygen from Lake E5,
         North Slope, Alaska, 2012-2013","documents":["doi:10.18739/A22W0R","urn:uuid:50a17fbf-2739-45ea-970a-f5d1a60fb20a","urn:uuid:9f4a0258-dae2-4bf3-857d-bd65704a1b03"]}]}}
 
@@ -218,7 +218,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:41 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:11 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -245,7 +245,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:42 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:11 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -274,7 +274,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:42 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:12 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -289,7 +289,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.18739%2FA26K2N%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":72,"params":{"q":"identifier:\"doi:10.18739/A26K2N\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A26K2N","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A26K2N"]}]}}
+    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"identifier:\"doi:10.18739/A26K2N\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A26K2N","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A26K2N"]}]}}
 
 '}
     headers:
@@ -301,7 +301,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:43 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:12 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -316,7 +316,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_doi%3A10.18739%2FA26K2N%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":70,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A26K2N\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":5,"start":0,"docs":[{"identifier":"doi:10.18739/A26K2N","fileName":"E5_2014metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":39491,"title":"Time
+    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A26K2N\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":5,"start":0,"docs":[{"identifier":"doi:10.18739/A26K2N","fileName":"E5_2014metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":39491,"title":"Time
         series of water temperature, specific conductance, and oxygen from Lake E5,
         North Slope, Alaska, 2013-2014","documents":["urn:uuid:6ce71af2-4deb-43d8-ad9d-c045f913855b","urn:uuid:d6f2ad00-70be-4359-a656-bc3cb5a76b1b","doi:10.18739/A26K2N","urn:uuid:39bc0782-b56d-4943-929d-af90b63579ad","urn:uuid:8d8e38e6-cea0-4048-b628-c748e0c7f0d0"]},{"identifier":"urn:uuid:6ce71af2-4deb-43d8-ad9d-c045f913855b","fileName":"2013_2014_winter_E5_spconductance.csv","formatId":"text/csv","formatType":"DATA","size":467919},{"identifier":"urn:uuid:d6f2ad00-70be-4359-a656-bc3cb5a76b1b","fileName":"2014_summer_E5_temperature.csv","formatId":"text/csv","formatType":"DATA","size":3239402},{"identifier":"urn:uuid:39bc0782-b56d-4943-929d-af90b63579ad","fileName":"2013_2014_winter_E5_dissoxy.csv","formatId":"text/csv","formatType":"DATA","size":1395110},{"identifier":"urn:uuid:8d8e38e6-cea0-4048-b628-c748e0c7f0d0","fileName":"2013_2014_winter_E5_temperature.csv","formatId":"text/csv","formatType":"DATA","size":11365382}]}}
 
@@ -330,7 +330,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:43 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:13 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -345,7 +345,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.18739%2FA2G287%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":71,"params":{"q":"identifier:\"doi:10.18739/A2G287\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2G287","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A2G287"]}]}}
+    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"identifier:\"doi:10.18739/A2G287\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2G287","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A2G287"]}]}}
 
 '}
     headers:
@@ -357,7 +357,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:44 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:13 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -386,7 +386,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:44 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:14 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -413,7 +413,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:45 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:14 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -428,7 +428,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_urn%3Auuid%3A9d06a11b-7c9a-4f83-a87b-df93c11d3f7e%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":80,"params":{"q":"resourceMap:\"resource_map_urn:uuid:9d06a11b-7c9a-4f83-a87b-df93c11d3f7e\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":5,"start":0,"docs":[{"identifier":"resource_map_doi:10.18739/A28K3N","fileName":"resourceMap_urn:uuid:0ff6b5c7-d3b4-43be-924b-05209b629107.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":7479},{"identifier":"resource_map_doi:10.18739/A2D86X","fileName":"resourceMap_urn:uuid:25a78d02-fa21-40f6-843d-b7fd8638dad2.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":8776},{"identifier":"resource_map_doi:10.18739/A24S0B","fileName":"resourceMap_urn:uuid:66bbbbf5-1e63-4f3c-abd2-9c33b9542d3e.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":11370},{"identifier":"resource_map_doi:10.18739/A2F299","fileName":"file1b49627f919d2","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":10073},{"identifier":"urn:uuid:9d06a11b-7c9a-4f83-a87b-df93c11d3f7e","fileName":"toolik_metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":8506,"title":"Time
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"resourceMap:\"resource_map_urn:uuid:9d06a11b-7c9a-4f83-a87b-df93c11d3f7e\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":5,"start":0,"docs":[{"identifier":"resource_map_doi:10.18739/A28K3N","fileName":"resourceMap_urn:uuid:0ff6b5c7-d3b4-43be-924b-05209b629107.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":7479},{"identifier":"resource_map_doi:10.18739/A2D86X","fileName":"resourceMap_urn:uuid:25a78d02-fa21-40f6-843d-b7fd8638dad2.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":8776},{"identifier":"resource_map_doi:10.18739/A24S0B","fileName":"resourceMap_urn:uuid:66bbbbf5-1e63-4f3c-abd2-9c33b9542d3e.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":11370},{"identifier":"resource_map_doi:10.18739/A2F299","fileName":"file1b49627f919d2","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":10073},{"identifier":"urn:uuid:9d06a11b-7c9a-4f83-a87b-df93c11d3f7e","fileName":"toolik_metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":8506,"title":"Time
         series of water temperature, specific conductance, and oxygen from Toolik
         Lake, North Slope, Alaska","documents":["urn:uuid:9d06a11b-7c9a-4f83-a87b-df93c11d3f7e","resource_map_doi:10.18739/A28K3N","resource_map_doi:10.18739/A2D86X","resource_map_doi:10.18739/A24S0B","resource_map_doi:10.18739/A2F299"]}]}}
 
@@ -442,7 +442,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:45 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:15 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -457,7 +457,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.18739%2FA28K3N%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":71,"params":{"q":"identifier:\"doi:10.18739/A28K3N\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A28K3N","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A28K3N"]}]}}
+    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"identifier:\"doi:10.18739/A28K3N\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A28K3N","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A28K3N"]}]}}
 
 '}
     headers:
@@ -469,7 +469,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:46 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:15 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -498,7 +498,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:46 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:16 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -525,7 +525,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:47 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:16 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -554,7 +554,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:47 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:17 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -581,7 +581,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:48 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:17 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -596,7 +596,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_doi%3A10.18739%2FA24S0B%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":71,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A24S0B\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":7,"start":0,"docs":[{"identifier":"doi:10.18739/A24S0B","fileName":"toolik_2015metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":65009,"title":"Time
+    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A24S0B\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":7,"start":0,"docs":[{"identifier":"doi:10.18739/A24S0B","fileName":"toolik_2015metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":65009,"title":"Time
         series of water temperature, specific conductance, and oxygen from Toolik
         Lake, North Slope, Alaska, 2014-2015","documents":["urn:uuid:a5ac2b21-45bd-437f-a16b-adbc657b59b3","urn:uuid:dc761000-8e3f-4fc7-bd61-b05292f8ecda","urn:uuid:f4b70f62-e4d0-471e-838b-a221130f6b16","urn:uuid:b52abc55-3f19-478c-ab1f-ddd1fe5078a1","doi:10.18739/A24S0B","urn:uuid:2cfe4b84-4acd-4102-abaa-9edf3cd56cd7","urn:uuid:97c08ad2-b11f-4577-b28a-18a19d2a2da6"]},{"identifier":"urn:uuid:a5ac2b21-45bd-437f-a16b-adbc657b59b3","fileName":"2014_2015_winter_toolik_dissoxy.csv","formatId":"text/csv","formatType":"DATA","size":2938042},{"identifier":"urn:uuid:dc761000-8e3f-4fc7-bd61-b05292f8ecda","fileName":"2015_summer_toolik_spconductance.csv","formatId":"text/csv","formatType":"DATA","size":326729},{"identifier":"urn:uuid:f4b70f62-e4d0-471e-838b-a221130f6b16","fileName":"2015_summer_toolik_dissoxy.csv","formatId":"text/csv","formatType":"DATA","size":422900},{"identifier":"urn:uuid:b52abc55-3f19-478c-ab1f-ddd1fe5078a1","fileName":"2014_2015_winter_toolik_temperature.csv","formatId":"text/csv","formatType":"DATA","size":17568419},{"identifier":"urn:uuid:2cfe4b84-4acd-4102-abaa-9edf3cd56cd7","fileName":"2015_summer_toolik_temperature.csv","formatId":"text/csv","formatType":"DATA","size":7388577},{"identifier":"urn:uuid:97c08ad2-b11f-4577-b28a-18a19d2a2da6","fileName":"2014_2015_winter_toolik_spconductance.csv","formatId":"text/csv","formatType":"DATA","size":944978}]}}
 
@@ -610,7 +610,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:48 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:17 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -625,7 +625,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.18739%2FA2F299%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":71,"params":{"q":"identifier:\"doi:10.18739/A2F299\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2F299","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A2F299"]}]}}
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"doi:10.18739/A2F299\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2F299","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A2F299"]}]}}
 
 '}
     headers:
@@ -637,7 +637,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:49 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:18 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -652,7 +652,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_doi%3A10.18739%2FA2F299%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":114,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A2F299\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":6,"start":0,"docs":[{"identifier":"doi:10.18739/A2F299","fileName":"toolik_2016metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":62748,"title":"Time
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A2F299\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":6,"start":0,"docs":[{"identifier":"doi:10.18739/A2F299","fileName":"toolik_2016metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":62748,"title":"Time
         series of water temperature, specific conductance, and oxygen from Toolik
         Lake, North Slope, Alaska, 2015-2016","documents":["doi:10.18739/A2F299","urn:uuid:bd0652ad-f6fe-4bcc-9b98-84e45fba205e","urn:uuid:9f38e678-b5c5-480d-b33e-50bbd94225f5","urn:uuid:c60403bb-226c-4330-bcb8-c9024560a9e0","urn:uuid:a82f1d5c-13b4-4df0-829f-ea0c0d782b29","urn:uuid:11986ca1-5560-48ac-b8f9-0469ce561946"]},{"identifier":"urn:uuid:bd0652ad-f6fe-4bcc-9b98-84e45fba205e","fileName":"2015_2016_winter_toolik_spconductance.csv","formatId":"text/csv","formatType":"DATA","size":1508161},{"identifier":"urn:uuid:9f38e678-b5c5-480d-b33e-50bbd94225f5","fileName":"2016_summer_toolik_temperature.csv","formatId":"text/csv","formatType":"DATA","size":6424024},{"identifier":"urn:uuid:c60403bb-226c-4330-bcb8-c9024560a9e0","fileName":"2015_2016_winter_toolik_dissoxy.csv","formatId":"text/csv","formatType":"DATA","size":3195361},{"identifier":"urn:uuid:a82f1d5c-13b4-4df0-829f-ea0c0d782b29","fileName":"2016_summer_toolik_dissoxy.csv","formatId":"text/csv","formatType":"DATA","size":278700},{"identifier":"urn:uuid:11986ca1-5560-48ac-b8f9-0469ce561946","fileName":"2015_2016_winter_toolik_temperature.csv","formatId":"text/csv","formatType":"DATA","size":20143003}]}}
 
@@ -666,7 +666,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:49 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:18 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -681,7 +681,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22resource_map_urn%3Auuid%3Ac5d13183-0e4f-4008-9492-b53b2cd40a26%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"identifier:\"resource_map_urn:uuid:c5d13183-0e4f-4008-9492-b53b2cd40a26\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"resource_map_urn:uuid:c5d13183-0e4f-4008-9492-b53b2cd40a26","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","resourceMap":["resource_map_urn:uuid:431105b1-52ee-4324-9182-11e59e2b6efe","resource_map_urn:uuid:ec4f122b-876f-4e33-818c-2c91e7a2488f"]}]}}
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"resource_map_urn:uuid:c5d13183-0e4f-4008-9492-b53b2cd40a26\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"resource_map_urn:uuid:c5d13183-0e4f-4008-9492-b53b2cd40a26","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","resourceMap":["resource_map_urn:uuid:431105b1-52ee-4324-9182-11e59e2b6efe","resource_map_urn:uuid:ec4f122b-876f-4e33-818c-2c91e7a2488f"]}]}}
 
 '}
     headers:
@@ -693,7 +693,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:50 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:19 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -722,7 +722,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:51 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:19 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -737,7 +737,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22resource_map_urn%3Auuid%3Afabf29dc-574c-4cd3-b6b7-9abc3788b179%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":5,"params":{"q":"identifier:\"resource_map_urn:uuid:fabf29dc-574c-4cd3-b6b7-9abc3788b179\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"resource_map_urn:uuid:fabf29dc-574c-4cd3-b6b7-9abc3788b179","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","resourceMap":["resource_map_urn:uuid:431105b1-52ee-4324-9182-11e59e2b6efe","resource_map_urn:uuid:ec4f122b-876f-4e33-818c-2c91e7a2488f"]}]}}
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"resource_map_urn:uuid:fabf29dc-574c-4cd3-b6b7-9abc3788b179\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"resource_map_urn:uuid:fabf29dc-574c-4cd3-b6b7-9abc3788b179","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","resourceMap":["resource_map_urn:uuid:431105b1-52ee-4324-9182-11e59e2b6efe","resource_map_urn:uuid:ec4f122b-876f-4e33-818c-2c91e7a2488f"]}]}}
 
 '}
     headers:
@@ -749,7 +749,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:51 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:20 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -764,7 +764,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_urn%3Auuid%3Afabf29dc-574c-4cd3-b6b7-9abc3788b179%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"resourceMap:\"resource_map_urn:uuid:fabf29dc-574c-4cd3-b6b7-9abc3788b179\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":5,"start":0,"docs":[{"identifier":"resource_map_doi:10.18739/A2C86M","fileName":"resourceMap_urn:uuid:b76fec30-7740-4400-a588-bf09814fc4b3.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":7479},{"identifier":"urn:uuid:fabf29dc-574c-4cd3-b6b7-9abc3788b179","fileName":"N2_metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":8502,"title":"Time
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"resourceMap:\"resource_map_urn:uuid:fabf29dc-574c-4cd3-b6b7-9abc3788b179\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":5,"start":0,"docs":[{"identifier":"resource_map_doi:10.18739/A2C86M","fileName":"resourceMap_urn:uuid:b76fec30-7740-4400-a588-bf09814fc4b3.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":7479},{"identifier":"urn:uuid:fabf29dc-574c-4cd3-b6b7-9abc3788b179","fileName":"N2_metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":8502,"title":"Time
         series of water temperature, specific conductance, and oxygen from Lake N2,
         North Slope, Alaska","documents":["resource_map_doi:10.18739/A2C86M","urn:uuid:fabf29dc-574c-4cd3-b6b7-9abc3788b179","resource_map_doi:10.18739/A2H28J","resource_map_doi:10.18739/A27K3B","resource_map_doi:10.18739/A23W02"]},{"identifier":"resource_map_doi:10.18739/A2H28J","fileName":"resourceMap_urn:uuid:2b608d76-1e38-461c-a3e3-76223089b658.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":10073},{"identifier":"resource_map_doi:10.18739/A27K3B","fileName":"resourceMap_urn:uuid:1237624b-15c8-4265-ba09-d6ba32cfbf5e.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":8776},{"identifier":"resource_map_doi:10.18739/A23W02","fileName":"resourceMap_urn:uuid:d1d2500e-a84d-4fe2-9cae-17fa0e0c0412.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":10073}]}}
 
@@ -778,7 +778,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:52 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:21 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -805,7 +805,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:52 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:21 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -820,7 +820,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_doi%3A10.18739%2FA2C86M%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A2C86M\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":4,"start":0,"docs":[{"identifier":"urn:uuid:49b91560-6677-4a63-a090-0d0a72074423","fileName":"2015_2016_winter_N2_temperature.csv","formatId":"text/csv","formatType":"DATA","size":9175080},{"identifier":"urn:uuid:b34d202d-84b8-47c7-ab26-17440034e972","fileName":"2015_2016_winter_N2_spconductance.csv","formatId":"text/csv","formatType":"DATA","size":669063},{"identifier":"doi:10.18739/A2C86M","fileName":"N2_2016metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":27618,"title":"Time
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A2C86M\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":4,"start":0,"docs":[{"identifier":"urn:uuid:49b91560-6677-4a63-a090-0d0a72074423","fileName":"2015_2016_winter_N2_temperature.csv","formatId":"text/csv","formatType":"DATA","size":9175080},{"identifier":"urn:uuid:b34d202d-84b8-47c7-ab26-17440034e972","fileName":"2015_2016_winter_N2_spconductance.csv","formatId":"text/csv","formatType":"DATA","size":669063},{"identifier":"doi:10.18739/A2C86M","fileName":"N2_2016metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":27618,"title":"Time
         series of water temperature, specific conductance, and oxygen from Lake N2,
         North Slope, Alaska, 2015-2016","documents":["urn:uuid:49b91560-6677-4a63-a090-0d0a72074423","urn:uuid:b34d202d-84b8-47c7-ab26-17440034e972","doi:10.18739/A2C86M","urn:uuid:b081764e-0e12-4687-a0bd-5b055c915a52"]},{"identifier":"urn:uuid:b081764e-0e12-4687-a0bd-5b055c915a52","fileName":"2015_2016_winter_N2_dissoxy.csv","formatId":"text/csv","formatType":"DATA","size":2274196}]}}
 
@@ -834,7 +834,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:53 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:22 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -849,7 +849,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.18739%2FA2H28J%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"identifier:\"doi:10.18739/A2H28J\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2H28J","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A2H28J"]}]}}
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"doi:10.18739/A2H28J\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2H28J","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A2H28J"]}]}}
 
 '}
     headers:
@@ -861,7 +861,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:53 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:22 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -890,7 +890,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:54 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:22 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -905,7 +905,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.18739%2FA27K3B%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"identifier:\"doi:10.18739/A27K3B\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A27K3B","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A27K3B"]}]}}
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"doi:10.18739/A27K3B\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A27K3B","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A27K3B"]}]}}
 
 '}
     headers:
@@ -917,7 +917,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:54 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:23 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -932,7 +932,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_doi%3A10.18739%2FA27K3B%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":71,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A27K3B\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":5,"start":0,"docs":[{"identifier":"urn:uuid:c9fde2ea-cca0-431d-b0ff-84b93edfd78c","fileName":"2014_2015_winter_N2_spconductance.csv","formatId":"text/csv","formatType":"DATA","size":764082},{"identifier":"doi:10.18739/A27K3B","fileName":"N2_2015metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":38880,"title":"Time
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A27K3B\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":5,"start":0,"docs":[{"identifier":"urn:uuid:c9fde2ea-cca0-431d-b0ff-84b93edfd78c","fileName":"2014_2015_winter_N2_spconductance.csv","formatId":"text/csv","formatType":"DATA","size":764082},{"identifier":"doi:10.18739/A27K3B","fileName":"N2_2015metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":38880,"title":"Time
         series of water temperature, specific conductance, and oxygen from Lake N2,
         North Slope, Alaska, 2014-2015","documents":["urn:uuid:c9fde2ea-cca0-431d-b0ff-84b93edfd78c","doi:10.18739/A27K3B","urn:uuid:25a90f3d-f0d9-4a24-8f1a-3288e398f0f0","urn:uuid:f745841f-1c85-4d28-b2a6-14a083db8224","urn:uuid:df23ddc4-1c81-4386-9d77-705b93788d97"]},{"identifier":"urn:uuid:25a90f3d-f0d9-4a24-8f1a-3288e398f0f0","fileName":"2014_2015_winter_N2_temperature.csv","formatId":"text/csv","formatType":"DATA","size":8186731},{"identifier":"urn:uuid:f745841f-1c85-4d28-b2a6-14a083db8224","fileName":"2014_2015_winter_N2_dissoxy.csv","formatId":"text/csv","formatType":"DATA","size":2041484},{"identifier":"urn:uuid:df23ddc4-1c81-4386-9d77-705b93788d97","fileName":"2015_summer_N2_temperature.csv","formatId":"text/csv","formatType":"DATA","size":3959476}]}}
 
@@ -946,7 +946,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:55 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:23 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -961,7 +961,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.18739%2FA23W02%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":71,"params":{"q":"identifier:\"doi:10.18739/A23W02\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A23W02","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A23W02"]}]}}
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"doi:10.18739/A23W02\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A23W02","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A23W02"]}]}}
 
 '}
     headers:
@@ -973,7 +973,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:55 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:24 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -988,7 +988,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_doi%3A10.18739%2FA23W02%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A23W02\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":6,"start":0,"docs":[{"identifier":"urn:uuid:6c2d697e-bd0f-4449-9bf4-c76f191bc417","fileName":"2013_2014_winter_N2_spconductance.csv","formatId":"text/csv","formatType":"DATA","size":805573},{"identifier":"urn:uuid:bdd04c25-73f9-4d17-bc91-3c38bf05d561","fileName":"2014_summer_N2_temperature.csv","formatId":"text/csv","formatType":"DATA","size":3985764},{"identifier":"doi:10.18739/A23W02","fileName":"N2_2014metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":42453,"title":"Time
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A23W02\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":6,"start":0,"docs":[{"identifier":"urn:uuid:6c2d697e-bd0f-4449-9bf4-c76f191bc417","fileName":"2013_2014_winter_N2_spconductance.csv","formatId":"text/csv","formatType":"DATA","size":805573},{"identifier":"urn:uuid:bdd04c25-73f9-4d17-bc91-3c38bf05d561","fileName":"2014_summer_N2_temperature.csv","formatId":"text/csv","formatType":"DATA","size":3985764},{"identifier":"doi:10.18739/A23W02","fileName":"N2_2014metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":42453,"title":"Time
         series of water temperature, specific conductance, and oxygen from Lake N2,
         North Slope, Alaska, 2013-2014","documents":["urn:uuid:6c2d697e-bd0f-4449-9bf4-c76f191bc417","urn:uuid:bdd04c25-73f9-4d17-bc91-3c38bf05d561","doi:10.18739/A23W02","urn:uuid:62451306-55f6-4392-a548-5e57edff2ccc","urn:uuid:0e648447-b685-4a8d-b2d1-9143c799509f","urn:uuid:76770fec-8b7e-43b9-8b50-821bd042af95"]},{"identifier":"urn:uuid:62451306-55f6-4392-a548-5e57edff2ccc","fileName":"2013_2014_winter_N2_temperature.csv","formatId":"text/csv","formatType":"DATA","size":8799847},{"identifier":"urn:uuid:0e648447-b685-4a8d-b2d1-9143c799509f","fileName":"2013_2014_winter_N2_dissoxy.csv","formatId":"text/csv","formatType":"DATA","size":2199099},{"identifier":"urn:uuid:76770fec-8b7e-43b9-8b50-821bd042af95","fileName":"2014_summer_N2_spconductance.csv","formatId":"text/csv","formatType":"DATA","size":109399}]}}
 
@@ -1002,7 +1002,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:56 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:24 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1029,7 +1029,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:56 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:25 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1044,7 +1044,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_urn%3Auuid%3A8c4cb5f6-9b11-4975-9668-c875dc4bbc2a%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":70,"params":{"q":"resourceMap:\"resource_map_urn:uuid:8c4cb5f6-9b11-4975-9668-c875dc4bbc2a\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":5,"start":0,"docs":[{"identifier":"resource_map_doi:10.18739/A2TC59","fileName":"resourceMap_urn:uuid:e5f59fbf-cd0d-4c22-af79-a90155a34965.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":6182},{"identifier":"resource_map_doi:10.18739/A2Z577","fileName":"resourceMap_urn:uuid:8cb2898b-a659-4095-afd0-4ca6d2533cf9.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":8776},{"identifier":"resource_map_doi:10.18739/A2JW1G","fileName":"resourceMap_urn:uuid:a80c563a-e478-46fd-b32f-12e4f8a05b13.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":8776},{"identifier":"resource_map_doi:10.18739/A2PK3C","fileName":"resourceMap_urn:uuid:f6b3a38f-6edd-4b69-bd1d-97ef7193b3ee.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":8776},{"identifier":"urn:uuid:8c4cb5f6-9b11-4975-9668-c875dc4bbc2a","fileName":"E6_metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":8502,"title":"Time
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"resourceMap:\"resource_map_urn:uuid:8c4cb5f6-9b11-4975-9668-c875dc4bbc2a\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":5,"start":0,"docs":[{"identifier":"resource_map_doi:10.18739/A2TC59","fileName":"resourceMap_urn:uuid:e5f59fbf-cd0d-4c22-af79-a90155a34965.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":6182},{"identifier":"resource_map_doi:10.18739/A2Z577","fileName":"resourceMap_urn:uuid:8cb2898b-a659-4095-afd0-4ca6d2533cf9.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":8776},{"identifier":"resource_map_doi:10.18739/A2JW1G","fileName":"resourceMap_urn:uuid:a80c563a-e478-46fd-b32f-12e4f8a05b13.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":8776},{"identifier":"resource_map_doi:10.18739/A2PK3C","fileName":"resourceMap_urn:uuid:f6b3a38f-6edd-4b69-bd1d-97ef7193b3ee.xml","formatId":"http://www.openarchives.org/ore/terms","formatType":"RESOURCE","size":8776},{"identifier":"urn:uuid:8c4cb5f6-9b11-4975-9668-c875dc4bbc2a","fileName":"E6_metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":8502,"title":"Time
         series of water temperature, specific conductance, and oxygen from Lake E6,
         North Slope, Alaska","documents":["resource_map_doi:10.18739/A2TC59","resource_map_doi:10.18739/A2Z577","resource_map_doi:10.18739/A2JW1G","resource_map_doi:10.18739/A2PK3C","urn:uuid:8c4cb5f6-9b11-4975-9668-c875dc4bbc2a"]}]}}
 
@@ -1058,7 +1058,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:57 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:25 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1085,7 +1085,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:57 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:26 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1100,7 +1100,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_doi%3A10.18739%2FA2TC59%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":73,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A2TC59\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":3,"start":0,"docs":[{"identifier":"doi:10.18739/A2TC59","fileName":"E6_2013metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":26487,"title":"Time
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A2TC59\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":3,"start":0,"docs":[{"identifier":"doi:10.18739/A2TC59","fileName":"E6_2013metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":26487,"title":"Time
         series of water temperature, specific conductance, and oxygen from Lake E6,
         North Slope, Alaska, 2012-2013","documents":["doi:10.18739/A2TC59","urn:uuid:b440e41f-0647-41eb-a071-de92bcba818b","urn:uuid:0bf1c4b3-53ba-4a30-82a5-f713155eb5aa"]},{"identifier":"urn:uuid:b440e41f-0647-41eb-a071-de92bcba818b","fileName":"2013_summer_E6_temperature.csv","formatId":"text/csv","formatType":"DATA","size":1809400},{"identifier":"urn:uuid:0bf1c4b3-53ba-4a30-82a5-f713155eb5aa","fileName":"2012_2013_winter_E6_temperature.csv","formatId":"text/csv","formatType":"DATA","size":10530736}]}}
 
@@ -1114,7 +1114,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:58 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:26 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1141,7 +1141,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:58 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:27 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1170,7 +1170,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:59 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:27 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1197,7 +1197,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:22:59 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:28 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1226,7 +1226,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:23:00 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:28 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1253,7 +1253,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:23:00 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:29 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1268,7 +1268,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_doi%3A10.18739%2FA2PK3C%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":71,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A2PK3C\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":5,"start":0,"docs":[{"identifier":"urn:uuid:c160536c-80d7-4db1-9973-f2b222fa9634","fileName":"2016_summer_E6_temperature.csv","formatId":"text/csv","formatType":"DATA","size":1925158},{"identifier":"urn:uuid:35b7bd04-50a1-44d9-b7b3-e704cf2bfc0b","fileName":"2015_2016_winter_E6_dissoxy.csv","formatId":"text/csv","formatType":"DATA","size":1197456},{"identifier":"doi:10.18739/A2PK3C","fileName":"E6_2016metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":32344,"title":"Time
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A2PK3C\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":5,"start":0,"docs":[{"identifier":"urn:uuid:c160536c-80d7-4db1-9973-f2b222fa9634","fileName":"2016_summer_E6_temperature.csv","formatId":"text/csv","formatType":"DATA","size":1925158},{"identifier":"urn:uuid:35b7bd04-50a1-44d9-b7b3-e704cf2bfc0b","fileName":"2015_2016_winter_E6_dissoxy.csv","formatId":"text/csv","formatType":"DATA","size":1197456},{"identifier":"doi:10.18739/A2PK3C","fileName":"E6_2016metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":32344,"title":"Time
         series of water temperature, specific conductance, and oxygen from Lake E6,
         North Slope, Alaska, 2015-2016","documents":["urn:uuid:c160536c-80d7-4db1-9973-f2b222fa9634","urn:uuid:35b7bd04-50a1-44d9-b7b3-e704cf2bfc0b","doi:10.18739/A2PK3C","urn:uuid:84ce5e6b-7206-444d-a8e6-98d9c5279644","urn:uuid:6b59982f-9f9a-4769-a12a-eb56b8966e5c"]},{"identifier":"urn:uuid:84ce5e6b-7206-444d-a8e6-98d9c5279644","fileName":"2015_2016_winter_E6_temperature.csv","formatId":"text/csv","formatType":"DATA","size":6833526},{"identifier":"urn:uuid:6b59982f-9f9a-4769-a12a-eb56b8966e5c","fileName":"2015_2016_winter_E6_spconductance.csv","formatId":"text/csv","formatType":"DATA","size":503972}]}}
 
@@ -1282,7 +1282,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:23:01 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:29 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1309,7 +1309,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:23:01 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:30 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1338,7 +1338,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:23:02 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:30 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1353,7 +1353,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.18739%2FA2028W%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"identifier:\"doi:10.18739/A2028W\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2028W","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A2028W"]}]}}
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"doi:10.18739/A2028W\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2028W","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A2028W"]}]}}
 
 '}
     headers:
@@ -1365,7 +1365,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:23:02 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:31 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1380,7 +1380,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_doi%3A10.18739%2FA2028W%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A2028W\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":4,"start":0,"docs":[{"identifier":"doi:10.18739/A2028W","fileName":"E1_2016metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":26819,"title":"Time
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A2028W\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":4,"start":0,"docs":[{"identifier":"doi:10.18739/A2028W","fileName":"E1_2016metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":26819,"title":"Time
         series of water temperature, specific conductance and oxygen from Lake E1,
         North Slope, Alaska, 2015-2016","documents":["urn:uuid:65753f42-5204-40f7-92b8-b0fab9cf0b35","urn:uuid:ccc96cc5-3abc-479a-ae78-a0e12995c983","urn:uuid:8cbdadcc-b227-47a4-8fba-e3f01810bdff","doi:10.18739/A2028W"]},{"identifier":"urn:uuid:65753f42-5204-40f7-92b8-b0fab9cf0b35","fileName":"2015_2016_winter_E1_spconductance.csv","formatId":"text/csv","formatType":"DATA","size":500013},{"identifier":"urn:uuid:ccc96cc5-3abc-479a-ae78-a0e12995c983","fileName":"2015_2016_winter_E1_dissoxy.csv","formatId":"text/csv","formatType":"DATA","size":1396269},{"identifier":"urn:uuid:8cbdadcc-b227-47a4-8fba-e3f01810bdff","fileName":"2015_2016_winter_E1_temperature.csv","formatId":"text/csv","formatType":"DATA","size":11166136}]}}
 
@@ -1394,7 +1394,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:23:03 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:31 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1409,7 +1409,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.18739%2FA2QK29%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"identifier:\"doi:10.18739/A2QK29\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2QK29","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A2QK29"]}]}}
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"doi:10.18739/A2QK29\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2QK29","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A2QK29"]}]}}
 
 '}
     headers:
@@ -1421,7 +1421,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:23:03 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:32 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1450,7 +1450,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:23:04 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:32 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1477,7 +1477,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:23:04 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:33 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1492,7 +1492,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_doi%3A10.18739%2FA2KS1R%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":71,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A2KS1R\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":3,"start":0,"docs":[{"identifier":"doi:10.18739/A2KS1R","fileName":"E1_2013metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":32211,"title":"Time
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A2KS1R\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":3,"start":0,"docs":[{"identifier":"doi:10.18739/A2KS1R","fileName":"E1_2013metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":32211,"title":"Time
         series of water temperature, specific conductance and oxygen from Lake E1,
         North Slope, Alaska, 2012-2013","documents":["urn:uuid:fa913a0f-7d09-48af-8325-bfb0426dcc73","doi:10.18739/A2KS1R","urn:uuid:3f658463-2af4-4ee2-8304-4f2edf83650b"]},{"identifier":"urn:uuid:fa913a0f-7d09-48af-8325-bfb0426dcc73","fileName":"2013_summer_E1_temperature.csv","formatId":"text/csv","formatType":"DATA","size":3782958},{"identifier":"urn:uuid:3f658463-2af4-4ee2-8304-4f2edf83650b","fileName":"2012_2013_winter_E1_temperature.csv","formatId":"text/csv","formatType":"DATA","size":11118770}]}}
 
@@ -1506,7 +1506,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:23:05 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:33 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1521,7 +1521,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.18739%2FA2VC5M%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"identifier:\"doi:10.18739/A2VC5M\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2VC5M","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A2VC5M"]}]}}
+    body: {string: '{"responseHeader":{"status":0,"QTime":5,"params":{"q":"identifier:\"doi:10.18739/A2VC5M\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2VC5M","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A2VC5M"]}]}}
 
 '}
     headers:
@@ -1533,7 +1533,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:23:06 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:34 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1548,7 +1548,7 @@ interactions:
     method: GET
     uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_doi%3A10.18739%2FA2VC5M%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":72,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A2VC5M\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":6,"start":0,"docs":[{"identifier":"doi:10.18739/A2VC5M","fileName":"E1_2015metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":45972,"title":"Time
+    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A2VC5M\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":6,"start":0,"docs":[{"identifier":"doi:10.18739/A2VC5M","fileName":"E1_2015metadata.xml","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":45972,"title":"Time
         series of water temperature, specific conductance and oxygen from Lake E1,
         North Slope, Alaska, 2014-2015","documents":["urn:uuid:decdc717-897c-4540-a7bb-edbc3988280f","doi:10.18739/A2VC5M","urn:uuid:80d6518d-be44-4136-84eb-20d8db71f445","urn:uuid:b84ef5f5-8f74-4ce8-a4a5-c307cb231c35","urn:uuid:95709f18-1f7e-41bb-a7ff-caef22891ca2","urn:uuid:0f4b4d12-01ea-4821-9ce1-607985a7f039"]},{"identifier":"urn:uuid:decdc717-897c-4540-a7bb-edbc3988280f","fileName":"2014_2015_winter_E1_temperature.csv","formatId":"text/csv","formatType":"DATA","size":9679469},{"identifier":"urn:uuid:80d6518d-be44-4136-84eb-20d8db71f445","fileName":"2015_summer_E1_spconductance.csv","formatId":"text/csv","formatType":"DATA","size":183913},{"identifier":"urn:uuid:b84ef5f5-8f74-4ce8-a4a5-c307cb231c35","fileName":"2014_2015_winter_E1_dissoxy.csv","formatId":"text/csv","formatType":"DATA","size":1603002},{"identifier":"urn:uuid:95709f18-1f7e-41bb-a7ff-caef22891ca2","fileName":"2014_2015_winter_E1_spconductance.csv","formatId":"text/csv","formatType":"DATA","size":586667},{"identifier":"urn:uuid:0f4b4d12-01ea-4821-9ce1-607985a7f039","fileName":"2015_summer_E1_temperature.csv","formatId":"text/csv","formatType":"DATA","size":5687791}]}}
 
@@ -1562,7 +1562,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Tue, 13 Nov 2018 17:23:06 GMT']
+      Date: ['Wed, 21 Nov 2018 18:57:35 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]

--- a/plugin_tests/data/test_list_files.txt
+++ b/plugin_tests/data/test_list_files.txt
@@ -12,19 +12,46 @@ interactions:
 
         <body><a href="https://arcticdata.io/catalog/#view/doi:10.5065/D6862DM8">https://arcticdata.io/catalog/#view/doi:10.5065/D6862DM8</a></body></html>'}
     headers:
-      CF-RAY: [479b6be5b9035504-ORD]
+      CF-RAY: [47d5600178f854e6-ORD]
       Connection: [close]
       Content-Length: ['197']
       Content-Type: [text/html;charset=utf-8]
-      Date: ['Wed, 14 Nov 2018 18:08:06 GMT']
+      Date: ['Wed, 21 Nov 2018 18:56:13 GMT']
       Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-      Expires: ['Wed, 14 Nov 2018 18:56:27 GMT']
+      Expires: ['Wed, 21 Nov 2018 19:23:53 GMT']
       Location: ['https://arcticdata.io/catalog/#view/doi:10.5065/D6862DM8']
       Server: [cloudflare]
-      Set-Cookie: ['__cfduid=dc315844ea220c61897dac731b1cbe7841542218886; expires=Thu,
-          14-Nov-19 18:08:06 GMT; path=/; domain=.doi.org; HttpOnly']
+      Set-Cookie: ['__cfduid=d81e22e42d94738ad7002a59365a3cb191542826573; expires=Thu,
+          21-Nov-19 18:56:13 GMT; path=/; domain=.doi.org; HttpOnly']
       Vary: [Accept]
     status: {code: 302, message: ''}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.19.1]
+    method: GET
+    uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.5065%2FD6862DM8%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
+  response:
+    body: {string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"identifier:\"doi:10.5065/D6862DM8\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.5065/D6862DM8","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.5065/D6862DM8"]}]}}
+
+'}
+    headers:
+      Access-Control-Allow-Credentials: ['true']
+      Access-Control-Allow-Headers: ['Authorization, Content-Type, Location, Content-Length,
+          x-annotator-auth-token']
+      Access-Control-Allow-Methods: ['POST, GET, OPTIONS, PUT, DELETE']
+      Access-Control-Allow-Origin: ['']
+      Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
+      Connection: [Keep-Alive]
+      Content-Type: [application/json; charset=UTF-8]
+      Date: ['Wed, 21 Nov 2018 18:56:13 GMT']
+      Keep-Alive: ['timeout=5, max=100']
+      Server: [Apache/2.4.7 (Ubuntu)]
+      Transfer-Encoding: [chunked]
+    status: {code: 200, message: OK}
 - request:
     body: null
     headers:
@@ -47,7 +74,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Wed, 14 Nov 2018 18:08:06 GMT']
+      Date: ['Wed, 21 Nov 2018 18:56:13 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -75,7 +102,7 @@ interactions:
       Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
       Connection: [Keep-Alive]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Wed, 14 Nov 2018 18:08:06 GMT']
+      Date: ['Wed, 21 Nov 2018 18:56:14 GMT']
       Keep-Alive: ['timeout=5, max=100']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]

--- a/plugin_tests/dataone_register_test.py
+++ b/plugin_tests/dataone_register_test.py
@@ -205,38 +205,6 @@ class TestDataONERegister(base.TestCase):
 
         self.assertDictEqual(package, expected_result)
 
-    @vcr.use_cassette(os.path.join(DATA_PATH, 'test_cn_switch.txt'))
-    def test_cn_switch(self):
-        from girder.plugins.wholetale.constants import PluginSettings, SettingDefault
-        resp = self.request('/system/setting', user=self.admin, method='PUT',
-                            params={'key': PluginSettings.DATAONE_URL,
-                                    'value': 'https://dev.nceas.ucsb.edu/knb/d1/mn/v2'})
-        self.assertStatus(resp, 200)
-
-        resp = self.request(
-            path='/repository/lookup', method='GET',
-            params={'dataId':
-                json.dumps(['https://dev.nceas.ucsb.edu/view/urn:uuid:e921cacb-8583-465a-bb65-60ffe6b994f6']),
-                'base_url': 'https://dev.nceas.ucsb.edu/knb/d1/mn/v2'})
-        self.assertStatus(resp, 200)
-        dataMap = resp.json
-        self.assertEqual(resp.json,
-            [
-                {
-                    "dataId": "urn:uuid:3f19ef84-e495-43b2-aaa0-102e917b2f5f",
-                    "doi": "urn:uuid:e921cacb-8583-465a-bb65-60ffe6b994f6",
-                    "name": "Testing rightsholder",
-                    "repository": "DataONE",
-                    "size": 2491
-                }
-            ]
-        )
-
-        resp = self.request('/system/setting', user=self.admin, method='PUT',
-                            params={'key': PluginSettings.DATAONE_URL,
-                                    'value': SettingDefault.defaults[PluginSettings.DATAONE_URL]})
-        self.assertStatus(resp, 200)
-
     def tearDown(self):
         self.model('user').remove(self.user)
         self.model('user').remove(self.admin)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -5,7 +5,6 @@ from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 import six
-from urllib.parse import urlparse
 
 from girder import events, logprint, logger
 from girder.api import access
@@ -98,27 +97,9 @@ def validateInstanceCap(doc):
             'Instance Cap needs to be an integer.', 'value')
 
 
-@setting_utilities.validator(PluginSettings.DATAONE_URL)
-def validateDataONEURL(doc):
-    if not doc['value']:
-        raise ValidationException(
-            'DataONE CN URL must be set.', 'value')
-    try:
-        result = urlparse(doc['value'])
-        return all([result.scheme, result.netloc, result.path])
-    except Exception:
-        raise ValidationException(
-            'Invalid DataONE CN URL', 'value')
-
-
 @setting_utilities.default(PluginSettings.INSTANCE_CAP)
 def defaultInstanceCap():
     return SettingDefault.defaults[PluginSettings.INSTANCE_CAP]
-
-
-@setting_utilities.default(PluginSettings.DATAONE_URL)
-def defaultDataONEURL():
-    return SettingDefault.defaults[PluginSettings.DATAONE_URL]
 
 
 @access.public(scope=TokenScope.DATA_READ)

--- a/server/constants.py
+++ b/server/constants.py
@@ -23,13 +23,11 @@ class PluginSettings:
     HUB_PRIV_KEY = 'wholetale.priv_key'
     HUB_PUB_KEY = 'wholetale.pub_key'
     INSTANCE_CAP = 'wholetale.instance_cap'
-    DATAONE_URL = 'wholetale.dataone_url'
 
 
 class SettingDefault:
     defaults = {
         PluginSettings.INSTANCE_CAP: 2,
-        PluginSettings.DATAONE_URL: 'https://cn.dataone.org/cn/v2/node'
     }
 
 

--- a/web_client/templates/configView.pug
+++ b/web_client/templates/configView.pug
@@ -16,11 +16,6 @@ form#g-wholetale-config-form(role="form")
       type="text", value=settings['wholetale.instance_cap'] || '',
       placeholder=`Default: ${defaults['wholetale.instance_cap'] || 'none'}`,
       title="Number of instances that user can run concurrently.")
-    label.control-label(for="wholetale_dataone_url") DataONE CN URL
-    input.input-sm.form-control#wholetale_dataone_url(
-      type="text", value=settings['wholetale.dataone_url'] || '',
-      placeholder=`Default: ${defaults['wholetale.dataone_url'] || 'none'}`,
-      title="Location of a DataONE Coordinating Node.")
   p#g-wholetale-error-message.g-validation-failed-message
   button.g-generate-key.btn.btn-small.btn-primary(title="Generate Key")
     | Generate Key

--- a/web_client/views/ConfigView.js
+++ b/web_client/views/ConfigView.js
@@ -24,9 +24,6 @@ var ConfigView = View.extend({
                 key: 'wholetale.pub_key',
                 value: this.$('#wholetale_pub_key').val()
             }, {
-                key: 'wholetale.dataone_url',
-                value: this.$('#wholetale_dataone_url').val()
-            }, {
                 key: 'wholetale.instance_cap',
                 value: this.$('#wholetale_instance_cap').val()
             }]);
@@ -55,7 +52,6 @@ var ConfigView = View.extend({
             'wholetale.tmpnb_url',
             'wholetale.priv_key',
             'wholetale.pub_key',
-            'wholetale.dataone_url',
             'wholetale.instance_cap'
         ];
 


### PR DESCRIPTION
This PR reverts behavior for lookup to always querying DataONE with whatever we pass to `GET /repository/lookup` instead of trying to determine origin using heuristics. 