### PR TITLE
Dataverse External Tools integration

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -27,5 +27,6 @@ add_python_test(dataverse
   plugins/wholetale/dataverse_lookup.txt
   plugins/wholetale/dataverse_listFiles.json
 )
+add_python_test(integration PLUGIN wholetale)
 add_python_style_test(python_static_analysis_wholetale
                       "${PROJECT_SOURCE_DIR}/plugins/wholetale/server")

--- a/plugin_tests/integration_test.py
+++ b/plugin_tests/integration_test.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from tests import base
+
+
+def setUpModule():
+    base.enabledPlugins.append('wholetale')
+    base.startServer()
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class IntegrationTestCase(base.TestCase):
+
+    def testDataverseIntegration(self):
+        resp = self.request(
+            '/integration/dataverse', method='GET',
+            params={'fileId': 'blah', 'siteUrl': 'https://dataverse.someplace'})
+        self.assertStatus(resp, 400)
+        self.assertEqual(resp.json, {
+            'message': 'Invalid fileId (should be integer)',
+            'type': 'rest'
+        })
+
+        resp = self.request(
+            '/integration/dataverse', method='GET',
+            params={'fileId': '1234', 'siteUrl': 'definitely not a URL'})
+        self.assertStatus(resp, 400)
+        self.assertEqual(resp.json, {
+            'message': 'Not a valid URL: siteUrl',
+            'type': 'rest'
+        })
+
+        resp = self.request(
+            '/integration/dataverse', method='GET',
+            params={'fileId': '1234', 'siteUrl': 'https://dataverse.someplace'})
+        self.assertStatus(resp, 303)
+        self.assertEqual(
+            resp.headers['Location'],
+            'https://dashboard.wholetale.org/compose?uri='
+            'https%3A%2F%2Fdataverse.someplace%2Fapi%2Faccess%2Fdatafile%2F1234'
+        )

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -25,6 +25,7 @@ from .constants import PluginSettings, SettingDefault
 from .rest.dataset import Dataset
 from .rest.recipe import Recipe
 from .rest.image import Image
+from .rest.integration import Integration
 from .rest.repository import Repository
 from .rest.publish import Publish
 from .rest.harvester import listImportedData
@@ -374,6 +375,7 @@ def load(info):
     events.bind('model.user.save.created', 'wholetale', addDefaultFolders)
     info['apiRoot'].repository = Repository()
     info['apiRoot'].publish = Publish()
+    info['apiRoot'].integration = Integration()
     info['apiRoot'].folder.route('GET', ('registered',), listImportedData)
     info['apiRoot'].folder.route('GET', (':id', 'listing'), listFolder)
     info['apiRoot'].folder.route('GET', (':id', 'dataset'), getDataSet)

--- a/server/lib/dataverse/integration.py
+++ b/server/lib/dataverse/integration.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+import cherrypy
+import validators
+from urllib.parse import urlparse, urlunparse, urlencode
+from urllib.error import HTTPError, URLError
+from girder.api import access
+from girder.api.describe import Description, autoDescribeRoute
+from girder.api.rest import RestException, setResponseHeader, boundHandler
+
+from .provider import DataverseImportProvider
+
+
+@access.public
+@autoDescribeRoute(
+    Description('Convert external tools request and bounce it to the dashboard.')
+    .param('fileId', 'The Dataverse database ID of a file the external tool has '
+           'been launched on.', required=True)
+    .param('siteUrl', 'The URL of the Dataverse installation that hosts the file '
+           'with the fileId above', required=True)
+    .param('apiToken', 'The Dataverse API token of the user launching the external'
+           ' tool, if available.', required=False)
+    .notes('apiToken is currently ignored.')
+)
+@boundHandler()
+def dataverseExternalTools(self, fileId, siteUrl, apiToken):
+    if not validators.url(siteUrl):
+        raise RestException('Not a valid URL: siteUrl')
+    try:
+        fileId = int(fileId)
+    except (TypeError, ValueError):
+        raise RestException('Invalid fileId (should be integer)')
+
+    site = urlparse(siteUrl)
+    url = '{scheme}://{netloc}/api/access/datafile/{fileId}'.format(
+        scheme=site.scheme, netloc=site.netloc, fileId=fileId
+    )
+    query = {'uri': url}
+    try:
+        title, _, _ = DataverseImportProvider._parse_access_url(urlparse(url))
+        query['name'] = title
+    except (HTTPError, URLError):
+        # This doesn't bode well, but let's fail later when tale import happens
+        pass
+
+    # TODO: Make base url a plugin setting, defaulting to dashboard.<domain>
+    dashboard_url = os.environ.get('DASHBOARD_URL', 'https://dashboard.wholetale.org')
+    location = urlunparse(
+        urlparse(dashboard_url)._replace(
+            path='/compose',
+            query=urlencode(query))
+    )
+    setResponseHeader('Location', location)
+    cherrypy.response.status = 303

--- a/server/rest/integration.py
+++ b/server/rest/integration.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+import cherrypy
+import validators
+from urllib.parse import urlparse, urlunparse, urlencode
+from girder.api import access
+from girder.api.describe import Description, autoDescribeRoute
+from girder.api.rest import Resource, RestException, setResponseHeader
+
+
+class Integration(Resource):
+
+    def __init__(self):
+        super(Integration, self).__init__()
+        self.resourceName = 'integration'
+
+        self.route('GET', ('dataverse',), self.dataverseExternalTools)
+
+    @access.public
+    @autoDescribeRoute(
+        Description('Convert external tools request and bounce it to the dashboard.')
+        .param('fileId', 'The Dataverse database ID of a file the external tool has '
+               'been launched on.', required=True)
+        .param('siteUrl', 'The URL of the Dataverse installation that hosts the file '
+               'with the fileId above', required=True)
+        .param('apiToken', 'The Dataverse API token of the user launching the external'
+               ' tool, if available.', required=False)
+        .notes('apiToken is currently ignored.')
+    )
+    def dataverseExternalTools(self, fileId, siteUrl, apiToken):
+        if not validators.url(siteUrl):
+            raise RestException('Not a valid URL: siteUrl')
+        try:
+            fileId = int(fileId)
+        except (TypeError, ValueError):
+            raise RestException('Invalid fileId (should be integer)')
+
+        site = urlparse(siteUrl)
+        url = '{scheme}://{netloc}/api/access/datafile/{fileId}'.format(
+            scheme=site.scheme, netloc=site.netloc, fileId=fileId
+        )
+
+        # TODO: Make base url a plugin setting, defaulting to dashboard.<domain>
+        dashboard_url = os.environ.get('DASHBOARD_URL', 'https://dashboard.wholetale.org')
+        location = urlunparse(
+            urlparse(dashboard_url)._replace(
+                path='/compose',
+                query=urlencode({'uri': url}))
+        )
+        setResponseHeader('Location', location)
+        cherrypy.response.status = 303

--- a/server/rest/integration.py
+++ b/server/rest/integration.py
@@ -1,15 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import os
-import cherrypy
-import validators
-from urllib.parse import urlparse, urlunparse, urlencode
-from urllib.error import HTTPError, URLError
-from girder.api import access
-from girder.api.describe import Description, autoDescribeRoute
-from girder.api.rest import Resource, RestException, setResponseHeader
-
-from ..lib.dataverse.provider import DataverseImportProvider
+from girder.api.rest import Resource
+from ..lib.dataverse.integration import dataverseExternalTools
 
 
 class Integration(Resource):
@@ -18,45 +10,4 @@ class Integration(Resource):
         super(Integration, self).__init__()
         self.resourceName = 'integration'
 
-        self.route('GET', ('dataverse',), self.dataverseExternalTools)
-
-    @access.public
-    @autoDescribeRoute(
-        Description('Convert external tools request and bounce it to the dashboard.')
-        .param('fileId', 'The Dataverse database ID of a file the external tool has '
-               'been launched on.', required=True)
-        .param('siteUrl', 'The URL of the Dataverse installation that hosts the file '
-               'with the fileId above', required=True)
-        .param('apiToken', 'The Dataverse API token of the user launching the external'
-               ' tool, if available.', required=False)
-        .notes('apiToken is currently ignored.')
-    )
-    def dataverseExternalTools(self, fileId, siteUrl, apiToken):
-        if not validators.url(siteUrl):
-            raise RestException('Not a valid URL: siteUrl')
-        try:
-            fileId = int(fileId)
-        except (TypeError, ValueError):
-            raise RestException('Invalid fileId (should be integer)')
-
-        site = urlparse(siteUrl)
-        url = '{scheme}://{netloc}/api/access/datafile/{fileId}'.format(
-            scheme=site.scheme, netloc=site.netloc, fileId=fileId
-        )
-        query = {'uri': url}
-        try:
-            title, _, _ = DataverseImportProvider._parse_access_url(urlparse(url))
-            query['name'] = title
-        except (HTTPError, URLError):
-            # This doesn't bode well, but let's fail later when tale import happens
-            pass
-
-        # TODO: Make base url a plugin setting, defaulting to dashboard.<domain>
-        dashboard_url = os.environ.get('DASHBOARD_URL', 'https://dashboard.wholetale.org')
-        location = urlunparse(
-            urlparse(dashboard_url)._replace(
-                path='/compose',
-                query=urlencode(query))
-        )
-        setResponseHeader('Location', location)
-        cherrypy.response.status = 303
+        self.route('GET', ('dataverse',), dataverseExternalTools)


### PR DESCRIPTION
This PR creates a simple endpoint that accepts requests coming from Dataverse external tools and return 303 to a proper dashboard route with an encoded datafile information.

Suggested test:
1. Run girder with env `DASHBOARD_URL` set to your dashboard instance (needs https://github.com/whole-tale/dashboard/pull/287 and https://github.com/whole-tale/girder_wholetale/pull/175)
1. Run a dataverse with a ext tool integration pointing to `<your_girder>/api/v1/integration/dataverse` (remember to set `DATAVERSE_URL` in `wholetale` plugin's config)
1. See the magic happen!