### PR TITLE
Allow to manually add supported Dataverse instances

### DIFF
--- a/plugin_tests/dataone_register_test.py
+++ b/plugin_tests/dataone_register_test.py
@@ -4,7 +4,6 @@ import json
 import os
 from tests import base
 from girder.api.rest import RestException
-from girder.constants import ROOT_DIR
 
 '''Tests for the methods in dataone_register.py. Some of these tests use live requests,
 while others use mocked JSON responses/data structures.'''
@@ -16,6 +15,7 @@ DATA_PATH = os.path.join(
     os.path.dirname(os.environ['GIRDER_TEST_DATA_PREFIX']),
     'data_src', 'plugins', 'wholetale'
 )
+
 
 def setUpModule():
     base.enabledPlugins.append('wholetale')

--- a/plugin_tests/harvester_test.py
+++ b/plugin_tests/harvester_test.py
@@ -7,7 +7,6 @@ import os
 import six
 import vcr
 from tests import base
-from girder.constants import ROOT_DIR
 from girder.api.rest import RestException
 
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -80,6 +80,16 @@ def validateHubPubKey(doc):
             "PUB_KEY's type is not supported.")
 
 
+@setting_utilities.validator(PluginSettings.DATAVERSE_EXTRA_HOSTS)
+def validateDataverseExtraHosts(doc):
+    val = doc['value']
+    if not isinstance(val, list):
+        raise ValidationException('Dataverse extra hosts setting must be a list.', 'value')
+    for url in val:
+        if not validators.url(url):
+            raise ValidationException('Invalid URL in Dataverse extra hosts', 'value')
+
+
 @setting_utilities.validator(PluginSettings.TMPNB_URL)
 def validateTmpNbUrl(doc):
     if not doc['value']:
@@ -116,6 +126,11 @@ def defaultInstanceCap():
 @setting_utilities.default(PluginSettings.DATAVERSE_URL)
 def defaultDataverseURL():
     return SettingDefault.defaults[PluginSettings.DATAVERSE_URL]
+
+
+@setting_utilities.default(PluginSettings.DATAVERSE_EXTRA_HOSTS)
+def defaultDataverseExtraHosts():
+    return SettingDefault.defaults[PluginSettings.DATAVERSE_EXTRA_HOSTS]
 
 
 @access.public(scope=TokenScope.DATA_READ)

--- a/server/constants.py
+++ b/server/constants.py
@@ -24,13 +24,15 @@ class PluginSettings:
     HUB_PUB_KEY = 'wholetale.pub_key'
     INSTANCE_CAP = 'wholetale.instance_cap'
     DATAVERSE_URL = 'wholetale.dataverse_url'
+    DATAVERSE_EXTRA_HOSTS = 'wholetale.dataverse_extra_hosts'
 
 
 class SettingDefault:
     defaults = {
         PluginSettings.INSTANCE_CAP: 2,
         PluginSettings.DATAVERSE_URL:
-            'https://services.dataverse.harvard.edu/miniverse/map/installations-json'
+            'https://services.dataverse.harvard.edu/miniverse/map/installations-json',
+        PluginSettings.DATAVERSE_EXTRA_HOSTS: []
     }
 
 

--- a/server/lib/dataverse/provider.py
+++ b/server/lib/dataverse/provider.py
@@ -85,6 +85,10 @@ class DataverseImportProvider(ImportProvider):
     def get_base_url_setting():
         return Setting().get(constants.PluginSettings.DATAVERSE_URL)
 
+    @staticmethod
+    def get_extra_hosts_setting():
+        return Setting().get(constants.PluginSettings.DATAVERSE_EXTRA_HOSTS)
+
     def create_dataverse_regex(self):
         url = self.get_base_url_setting()
         if not url.endswith('installations-json'):
@@ -103,11 +107,14 @@ class DataverseImportProvider(ImportProvider):
             urls = [_['url'] for _ in data['installations']]
         else:
             urls = [self.get_base_url_setting()]
+        urls += self.get_extra_hosts_setting()
         return re.compile("^" + "|".join(urls) + ".*$")
 
     def setting_changed(self, event):
-        if not hasattr(event, "info") or \
-                event.info.get('key', '') != constants.PluginSettings.DATAVERSE_URL:
+        triggers = {
+            constants.PluginSettings.DATAVERSE_URL, constants.PluginSettings.DATAVERSE_EXTRA_HOSTS
+        }
+        if not hasattr(event, "info") or event.info.get('key', '') not in triggers:
             return
         self._dataverse_regex = None
 

--- a/web_client/templates/configView.pug
+++ b/web_client/templates/configView.pug
@@ -1,4 +1,6 @@
 .g-config-breadcrumb-container
+p.g-wholetale-description
+  | Configure Whole Tale plugin
 form#g-wholetale-config-form(role="form")
   .form-group
     label.control-label(for="wholetale_tmpnb") tmpnb URL
@@ -21,6 +23,10 @@ form#g-wholetale-config-form(role="form")
       type="text", value=settings['wholetale.dataverse_url'] || '',
       placeholder=`Default: ${defaults['wholetale.dataverse_url'] || 'none'}`,
       title="Location of a map of dataverse installations.")
+    label.control-label(for="wholetale_extra_hosts") Extra Dataverse Installations
+    textarea#wholetale_extra_hosts.form-control(
+      placeholder=`Default: ${defaults['wholetale.dataverse_extra_hosts'] || '[]'}`,
+      title="Additional supported Dataverse installations.")= extraHosts
   p#g-wholetale-error-message.g-validation-failed-message
   button.g-generate-key.btn.btn-small.btn-primary(title="Generate Key")
     | Generate Key

--- a/web_client/views/ConfigView.js
+++ b/web_client/views/ConfigView.js
@@ -29,6 +29,9 @@ var ConfigView = View.extend({
             }, {
                 key: 'wholetale.instance_cap',
                 value: this.$('#wholetale_instance_cap').val()
+            }, {
+                key: 'wholetale.dataverse_extra_hosts',
+                value: this.$('#wholetale_extra_hosts').val().trim()
             }]);
         },
         'click .g-generate-key': function (event) {
@@ -56,7 +59,8 @@ var ConfigView = View.extend({
             'wholetale.priv_key',
             'wholetale.pub_key',
             'wholetale.dataverse_url',
-            'wholetale.instance_cap'
+            'wholetale.instance_cap',
+            'wholetale.dataverse_extra_hosts'
         ];
 
         restRequest({
@@ -85,7 +89,8 @@ var ConfigView = View.extend({
     render: function () {
         this.$el.html(ConfigViewTemplate({
             settings: this.settings,
-            defaults: this.defaults
+            defaults: this.defaults,
+            extraHosts: JSON.stringify(this.settings['wholetale.dataverse_extra_hosts'], null, 4)
         }));
         this.breadcrumb.setElement(this.$('.g-config-breadcrumb-container')).render();
         return this;


### PR DESCRIPTION
Apart from deriving a list of Dataverses from https://services.dataverse.harvard.edu, this PR allows to manually add specific Dataverse Instances.

Suggested test:
1. set DATAVERSE_URL to `https://services.dataverse.harvard.edu/miniverse/map/installations-json`
1. set DATAVERSE_EXTRA_HOSTS to `["https://dev1.dataverse.org"]`
1. Verify that `GET /repository/lookup` for `dataId=["https://dx.doi.org/doi:10.7910/DVN/TJCLKP", "https://dev1.dataverse.org/dataset.xhtml?persistentId=doi:10.5072/FK2/EPNUKP"]` results in Data Map containing two entries with `repository == Dataverse`