### PR TITLE
Remove obsolete config options, fixes #185

### DIFF
--- a/plugin_tests/basic_test.py
+++ b/plugin_tests/basic_test.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import json
-import six
 from tests import base
 
 
@@ -34,46 +33,6 @@ class WholeTaleTestCase(base.TestCase):
         })
         self.admin, self.user = [self.model('user').createUser(**user)
                                  for user in users]
-
-    def testConfigValidators(self):
-        from girder.plugins.wholetale.constants import PluginSettings
-        resp = self.request('/system/setting', user=self.admin, method='PUT',
-                            params={'key': PluginSettings.TMPNB_URL,
-                                    'value': ''})
-        self.assertStatus(resp, 400)
-        self.assertEqual(resp.json, {
-            'field': 'value',
-            'type': 'validation',
-            'message': 'TmpNB URL must not be empty.'
-        })
-
-        keys = {'PUB_KEY': PluginSettings.HUB_PUB_KEY,
-                'PRIV_KEY': PluginSettings.HUB_PRIV_KEY}
-        for k, v in six.iteritems(keys):
-            params = {
-                'key': v,
-                'value': ''
-            }
-            resp = self.request('/system/setting', user=self.admin, method='PUT',
-                                params=params)
-            self.assertStatus(resp, 400)
-            self.assertEqual(resp.json, {
-                'field': 'value',
-                'type': 'validation',
-                'message': '%s must not be empty.' % k
-            })
-
-            params = {
-                'key': v,
-                'value': 'blah'
-            }
-            resp = self.request('/system/setting', user=self.admin, method='PUT',
-                                params=params)
-            self.assertStatus(resp, 400)
-            self.assertEqual(resp.json, {
-                'type': 'validation',
-                'message': "%s's data structure could not be decoded." % k
-            })
 
     def testListing(self):
         user = self.user
@@ -113,22 +72,10 @@ class WholeTaleTestCase(base.TestCase):
                          set((str(fl1['_id']), str(fl2['_id']))))
 
     def testHubRoutes(self):
-        from girder.plugins.wholetale.constants import PluginSettings
-        self.model('setting').set(
-            PluginSettings.TMPNB_URL, 'https://tmpnb.null')
-
-        resp = self.request(path='/wholetale/genkey', user=self.admin,
-                            method='POST')
-        self.assertStatusOk(resp)
-        self.assertIn(PluginSettings.HUB_PUB_KEY, resp.json)
-        self.assertIn(PluginSettings.HUB_PRIV_KEY, resp.json)
-
-        pubkey = resp.json[PluginSettings.HUB_PUB_KEY]
-
+        from girder.plugins.wholetale.constants import API_VERSION
         resp = self.request(path='/wholetale', method='GET')
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json['url'], 'https://tmpnb.null')
-        self.assertEqual(resp.json['pubkey'], pubkey)
+        self.assertEqual(resp.json['api_version'], API_VERSION)
 
     def testUserSettings(self):
         resp = self.request(path='/user/settings', method='GET')

--- a/plugin_tests/constants_test.py
+++ b/plugin_tests/constants_test.py
@@ -19,13 +19,6 @@ class TestDataONEUtils(base.TestCase):
 
         self.assertEqual(HarvesterType.DATAONE, 0)
 
-    def test_plugin_settings(self):
-        from server.constants import PluginSettings
-
-        self.assertEqual(PluginSettings.TMPNB_URL, 'wholetale.tmpnb_url')
-        self.assertEqual(PluginSettings.HUB_PRIV_KEY, 'wholetale.priv_key')
-        self.assertEqual(PluginSettings.HUB_PUB_KEY, 'wholetale.pub_key')
-
     def test_dataone_endpoints(self):
         # Testing this to make sure the endpoints aren't accidentally changed
         from server.lib.dataone import DataONELocations

--- a/plugin_tests/dataverse_test.py
+++ b/plugin_tests/dataverse_test.py
@@ -134,6 +134,19 @@ class DataverseHarversterTestCase(base.TestCase):
                     'value': SettingDefault.defaults[PluginSettings.DATAVERSE_URL]})
         self.assertStatusOk(resp)
 
+        resp = self.request(
+            '/system/setting', user=self.admin, method='PUT',
+            params={'key': PluginSettings.DATAVERSE_URL,
+                    'value': ''})
+        self.assertStatusOk(resp)
+        resp = self.request(
+            '/system/setting', user=self.admin, method='GET',
+            params={'key': PluginSettings.DATAVERSE_URL})
+        self.assertStatusOk(resp)
+        self.assertEqual(
+            resp.body[0].decode(),
+            '"{}"'.format(SettingDefault.defaults[PluginSettings.DATAVERSE_URL]))
+
     @vcr.use_cassette(os.path.join(DATA_PATH, 'dataverse_single.txt'))
     def testSingleDataverseInstance(self):
         from girder.plugins.wholetale.constants import PluginSettings, SettingDefault
@@ -204,6 +217,20 @@ class DataverseHarversterTestCase(base.TestCase):
             'type': 'validation',
             'message': 'Invalid URL in Dataverse extra hosts'
         })
+
+        # defaults
+        resp = self.request(
+            '/system/setting', user=self.admin, method='PUT',
+            params={'key': PluginSettings.DATAVERSE_EXTRA_HOSTS,
+                    'value': ''})
+        self.assertStatusOk(resp)
+        resp = self.request(
+            '/system/setting', user=self.admin, method='GET',
+            params={'key': PluginSettings.DATAVERSE_EXTRA_HOSTS})
+        self.assertStatusOk(resp)
+        self.assertEqual(
+            resp.body[0].decode(),
+            str(SettingDefault.defaults[PluginSettings.DATAVERSE_EXTRA_HOSTS]))
 
         resp = self.request(
             '/system/setting', user=self.admin, method='PUT',

--- a/plugin_tests/dataverse_test.py
+++ b/plugin_tests/dataverse_test.py
@@ -120,16 +120,6 @@ class DataverseHarversterTestCase(base.TestCase):
         from girder.plugins.wholetale.constants import PluginSettings, SettingDefault
         resp = self.request('/system/setting', user=self.admin, method='PUT',
                             params={'key': PluginSettings.DATAVERSE_URL,
-                                    'value': ''})
-        self.assertStatus(resp, 400)
-        self.assertEqual(resp.json, {
-            'field': 'value',
-            'type': 'validation',
-            'message': 'Dataverse Instances list URL must not be empty.'
-        })
-
-        resp = self.request('/system/setting', user=self.admin, method='PUT',
-                            params={'key': PluginSettings.DATAVERSE_URL,
                                     'value': 'random_string'})
         self.assertStatus(resp, 400)
         self.assertEqual(resp.json, {

--- a/plugin_tests/instance_test.py
+++ b/plugin_tests/instance_test.py
@@ -131,11 +131,25 @@ class TaleTestCase(base.TestCase):
             self.assertStatusOk(resp)
 
     def testInstanceCap(self):
+        from girder.plugins.wholetale.constants import PluginSettings, SettingDefault
         with six.assertRaisesRegex(self, ValidationException,
                                    '^Instance Cap needs to be an integer.$'):
             self.model('setting').set(PluginSettings.INSTANCE_CAP, 'a')
 
         setting = self.model('setting')
+
+        resp = self.request(
+            '/system/setting', user=self.admin, method='PUT',
+            params={'key': PluginSettings.INSTANCE_CAP,
+                    'value': ''})
+        self.assertStatusOk(resp)
+        resp = self.request(
+            '/system/setting', user=self.admin, method='GET',
+            params={'key': PluginSettings.INSTANCE_CAP})
+        self.assertStatusOk(resp)
+        self.assertEqual(
+            resp.body[0].decode(),
+            str(SettingDefault.defaults[PluginSettings.INSTANCE_CAP]))
 
         with mock.patch('celery.Celery') as celeryMock:
             with mock.patch('tornado.httpclient.HTTPClient') as tornadoMock:

--- a/plugin_tests/instance_test.py
+++ b/plugin_tests/instance_test.py
@@ -132,9 +132,6 @@ class TaleTestCase(base.TestCase):
 
     def testInstanceCap(self):
         with six.assertRaisesRegex(self, ValidationException,
-                                   '^Instance Cap needs to be set.$'):
-            self.model('setting').set(PluginSettings.INSTANCE_CAP, '')
-        with six.assertRaisesRegex(self, ValidationException,
                                    '^Instance Cap needs to be an integer.$'):
             self.model('setting').set(PluginSettings.INSTANCE_CAP, 'a')
 

--- a/plugin_tests/instance_test.py
+++ b/plugin_tests/instance_test.py
@@ -51,8 +51,6 @@ class TaleTestCase(base.TestCase):
         from girder.plugins.wholetale.constants import PluginSettings
         from girder.plugins.wholetale.rest.instance import instanceCapErrMsg
         self.model('setting').set(
-            PluginSettings.TMPNB_URL, 'https://tmpnb.null')
-        self.model('setting').set(
             PluginSettings.INSTANCE_CAP, '2')
         users = ({
             'email': 'root@dev.null',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 rdflib
-cryptography
 tornado
 celery[redis]
 requests

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -34,10 +34,11 @@ from .models.instance import finalizeInstance
 
 @setting_utilities.validator(PluginSettings.DATAVERSE_EXTRA_HOSTS)
 def validateDataverseExtraHosts(doc):
-    val = doc['value']
-    if not isinstance(val, list):
+    if not doc['value']:
+        doc['value'] = defaultDataverseExtraHosts()
+    if not isinstance(doc['value'], list):
         raise ValidationException('Dataverse extra hosts setting must be a list.', 'value')
-    for url in val:
+    for url in doc['value']:
         if not validators.url(url):
             raise ValidationException('Invalid URL in Dataverse extra hosts', 'value')
 
@@ -45,8 +46,7 @@ def validateDataverseExtraHosts(doc):
 @setting_utilities.validator(PluginSettings.INSTANCE_CAP)
 def validateInstanceCap(doc):
     if not doc['value']:
-        raise ValidationException(
-            'Instance Cap needs to be set.', 'value')
+        doc['value'] = defaultInstanceCap()
     try:
         int(doc['value'])
     except ValueError:
@@ -57,8 +57,7 @@ def validateInstanceCap(doc):
 @setting_utilities.validator(PluginSettings.DATAVERSE_URL)
 def validateDataverseURL(doc):
     if not doc['value']:
-        raise ValidationException(
-            'Dataverse Instances list URL must not be empty.', 'value')
+        doc['value'] = defaultDataverseURL()
     if not validators.url(doc['value']):
         raise ValidationException('Invalid Dataverse URL', 'value')
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from cryptography.exceptions import UnsupportedAlgorithm
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import serialization
 import six
 import validators
 
@@ -35,51 +32,6 @@ from .rest.wholetale import wholeTale
 from .models.instance import finalizeInstance
 
 
-@setting_utilities.validator(PluginSettings.HUB_PRIV_KEY)
-def validateHubPrivKey(doc):
-    if not doc['value']:
-        raise ValidationException(
-            'PRIV_KEY must not be empty.', 'value')
-    try:
-        key = doc['value'].encode('utf8')
-    except AttributeError:
-        key = doc['value']
-    try:
-        serialization.load_pem_private_key(
-            key, password=None, backend=default_backend()
-        )
-    except ValueError:
-        raise ValidationException(
-            "PRIV_KEY's data structure could not be decoded.")
-    except TypeError:
-        raise ValidationException(
-            "PRIV_KEY is password encrypted, yet no password provided.")
-    except UnsupportedAlgorithm:
-        raise ValidationException(
-            "PRIV_KEY's type is not supported.")
-
-
-@setting_utilities.validator(PluginSettings.HUB_PUB_KEY)
-def validateHubPubKey(doc):
-    if not doc['value']:
-        raise ValidationException(
-            'PUB_KEY must not be empty.', 'value')
-    try:
-        key = doc['value'].encode('utf8')
-    except AttributeError:
-        key = doc['value']
-    try:
-        serialization.load_pem_public_key(
-            key, backend=default_backend()
-        )
-    except ValueError:
-        raise ValidationException(
-            "PUB_KEY's data structure could not be decoded.")
-    except UnsupportedAlgorithm:
-        raise ValidationException(
-            "PUB_KEY's type is not supported.")
-
-
 @setting_utilities.validator(PluginSettings.DATAVERSE_EXTRA_HOSTS)
 def validateDataverseExtraHosts(doc):
     val = doc['value']
@@ -88,13 +40,6 @@ def validateDataverseExtraHosts(doc):
     for url in val:
         if not validators.url(url):
             raise ValidationException('Invalid URL in Dataverse extra hosts', 'value')
-
-
-@setting_utilities.validator(PluginSettings.TMPNB_URL)
-def validateTmpNbUrl(doc):
-    if not doc['value']:
-        raise ValidationException(
-            'TmpNB URL must not be empty.', 'value')
 
 
 @setting_utilities.validator(PluginSettings.INSTANCE_CAP)

--- a/server/constants.py
+++ b/server/constants.py
@@ -19,9 +19,6 @@ class HarvesterType:
 
 
 class PluginSettings:
-    TMPNB_URL = 'wholetale.tmpnb_url'
-    HUB_PRIV_KEY = 'wholetale.priv_key'
-    HUB_PUB_KEY = 'wholetale.pub_key'
     INSTANCE_CAP = 'wholetale.instance_cap'
     DATAVERSE_URL = 'wholetale.dataverse_url'
     DATAVERSE_EXTRA_HOSTS = 'wholetale.dataverse_extra_hosts'

--- a/server/rest/wholetale.py
+++ b/server/rest/wholetale.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
 from girder.api import access
 from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource
 
-from ..constants import PluginSettings
+from ..constants import API_VERSION
 
 
 class wholeTale(Resource):
@@ -16,39 +13,11 @@ class wholeTale(Resource):
         super(wholeTale, self).__init__()
         self.resourceName = 'wholetale'
 
-        self.route('GET', (), self.get_wholetale_url)
-        self.route('POST', ('genkey',), self.generateRSAKey)
-
-    @access.admin
-    @describeRoute(
-        Description('Generate wholetale\'s RSA key')
-    )
-    def generateRSAKey(self, params):
-        rsa_key = rsa.generate_private_key(
-            public_exponent=65537,
-            key_size=2048,
-            backend=default_backend()
-        )
-
-        pubkey_pem = rsa_key.public_key().public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo
-        ).decode('utf8')
-        privkey_pem = rsa_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.TraditionalOpenSSL,
-            encryption_algorithm=serialization.NoEncryption()
-        ).decode('utf8')
-        self.model('setting').set(PluginSettings.HUB_PUB_KEY, pubkey_pem)
-        self.model('setting').set(PluginSettings.HUB_PRIV_KEY, privkey_pem)
-        return {PluginSettings.HUB_PUB_KEY: pubkey_pem,
-                PluginSettings.HUB_PRIV_KEY: privkey_pem}
+        self.route('GET', (), self.get_wholetale_info)
 
     @access.public
     @describeRoute(
-        Description('Return url for tmpnb hub.')
+        Description('Return basic info about Whole Tale plugin')
     )
-    def get_wholetale_url(self, params):
-        setting = self.model('setting')
-        return {'url': setting.get(PluginSettings.TMPNB_URL),
-                'pubkey': setting.get(PluginSettings.HUB_PUB_KEY)}
+    def get_wholetale_info(self, params):
+        return {'api_version': API_VERSION}

--- a/web_client/collections/index.js
+++ b/web_client/collections/index.js
@@ -2,6 +2,6 @@ import InstanceCollection from './InstanceCollection';
 import ImageCollection from './ImageCollection';
 
 export {
-  InstanceCollection,
-  ImageCollection
+    InstanceCollection,
+    ImageCollection
 };

--- a/web_client/models/index.js
+++ b/web_client/models/index.js
@@ -2,6 +2,6 @@ import InstanceModel from './InstanceModel';
 import ImageModel from './ImageModel';
 
 export {
-  InstanceModel,
-  ImageModel
+    InstanceModel,
+    ImageModel
 };

--- a/web_client/templates/configView.pug
+++ b/web_client/templates/configView.pug
@@ -5,12 +5,12 @@ form#g-wholetale-config-form(role="form")
   .form-group
     label.control-label(for="wholetale_instance_cap") Instance Cap
     input.input-sm.form-control#wholetale_instance_cap(
-      type="text", value=settings['wholetale.instance_cap'] || '',
+      type="text", value=settings['wholetale.instance_cap'] || null,
       placeholder=`Default: ${defaults['wholetale.instance_cap'] || 'none'}`,
       title="Number of instances that user can run concurrently.")
     label.control-label(for="wholetale_dataverse_url") Dataverse Installations Map
     input.input-sm.form-control#wholetale_dataverse_url(
-      type="text", value=settings['wholetale.dataverse_url'] || '',
+      type="text", value=settings['wholetale.dataverse_url'] || null,
       placeholder=`Default: ${defaults['wholetale.dataverse_url'] || 'none'}`,
       title="Location of a map of dataverse installations.")
     label.control-label(for="wholetale_extra_hosts") Extra Dataverse Installations

--- a/web_client/templates/configView.pug
+++ b/web_client/templates/configView.pug
@@ -3,16 +3,6 @@ p.g-wholetale-description
   | Configure Whole Tale plugin
 form#g-wholetale-config-form(role="form")
   .form-group
-    label.control-label(for="wholetale_tmpnb") tmpnb URL
-    input.input-sm.form-control#wholetale_tmpnb(
-      type="text", placeholder="Temporary instance server's URL",
-      value=settings['wholetale.tmpnb_url'] || '')
-    label.control-label(for="wholetale_priv_key") yt Hub's private RSA key
-    textarea#wholetale_priv_key.form-control(
-      placeholder='Private RSA key')= settings['wholetale.priv_key'] || ''
-    label.control-label(for="wholetale_pub_key") yt Hub's public RSA key
-    textarea#wholetale_pub_key.form-control(
-      placeholder='Public RSA key')= settings['wholetale.pub_key'] || ''
     label.control-label(for="wholetale_instance_cap") Instance Cap
     input.input-sm.form-control#wholetale_instance_cap(
       type="text", value=settings['wholetale.instance_cap'] || '',
@@ -26,8 +16,7 @@ form#g-wholetale-config-form(role="form")
     label.control-label(for="wholetale_extra_hosts") Extra Dataverse Installations
     textarea#wholetale_extra_hosts.form-control(
       placeholder=`Default: ${defaults['wholetale.dataverse_extra_hosts'] || '[]'}`,
-      title="Additional supported Dataverse installations.")= extraHosts
+      title="Additional supported Dataverse installations. (JSON array [\"data1\", \"data2\", ...])")
+        = JSON.stringify(settings['wholetale.dataverse_extra_hosts'] || defaults['wholetale.dataverse_extra_hosts'], 4)
   p#g-wholetale-error-message.g-validation-failed-message
-  button.g-generate-key.btn.btn-small.btn-primary(title="Generate Key")
-    | Generate Key
   input.btn.btn-sm.btn-primary(type="submit", value="Save")

--- a/web_client/views/ConfigView.js
+++ b/web_client/views/ConfigView.js
@@ -15,37 +15,15 @@ var ConfigView = View.extend({
             this.$('#g-wholetale-error-message').empty();
 
             this._saveSettings([{
-                key: 'wholetale.tmpnb_url',
-                value: this.$('#wholetale_tmpnb').val().trim()
-            }, {
-                key: 'wholetale.priv_key',
-                value: this.$('#wholetale_priv_key').val()
-            }, {
-                key: 'wholetale.pub_key',
-                value: this.$('#wholetale_pub_key').val()
+                key: 'wholetale.instance_cap',
+                value: this.$('#wholetale_instance_cap').val()
             }, {
                 key: 'wholetale.dataverse_url',
                 value: this.$('#wholetale_dataverse_url').val()
             }, {
-                key: 'wholetale.instance_cap',
-                value: this.$('#wholetale_instance_cap').val()
-            }, {
                 key: 'wholetale.dataverse_extra_hosts',
                 value: this.$('#wholetale_extra_hosts').val().trim()
             }]);
-        },
-        'click .g-generate-key': function (event) {
-            event.preventDefault();
-            restRequest({
-                type: 'POST',
-                url: 'wholetale/genkey',
-                data: {}
-            }).done(_.bind(function (resp) {
-                this.settings['wholetale.priv_key'] = resp['wholetale.priv_key'];
-                this.settings['wholetale.pub_key'] = resp['wholetale.pub_key'];
-                this.$('#wholetale_priv_key').val(resp['wholetale.priv_key']);
-                this.$('#wholetale_pub_key').val(resp['wholetale.pub_key']);
-            }, this));
         }
     },
     initialize: function () {
@@ -55,11 +33,8 @@ var ConfigView = View.extend({
         });
 
         var keys = [
-            'wholetale.tmpnb_url',
-            'wholetale.priv_key',
-            'wholetale.pub_key',
-            'wholetale.dataverse_url',
             'wholetale.instance_cap',
+            'wholetale.dataverse_url',
             'wholetale.dataverse_extra_hosts'
         ];
 
@@ -90,7 +65,7 @@ var ConfigView = View.extend({
         this.$el.html(ConfigViewTemplate({
             settings: this.settings,
             defaults: this.defaults,
-            extraHosts: JSON.stringify(this.settings['wholetale.dataverse_extra_hosts'], null, 4)
+            JSON: window.JSON
         }));
         this.breadcrumb.setElement(this.$('.g-config-breadcrumb-container')).render();
         return this;

--- a/web_client/views/InstanceListWidget.js
+++ b/web_client/views/InstanceListWidget.js
@@ -100,7 +100,7 @@ var InstanceListWidget = View.extend({
 
         if (this.columns & this.columnEnum.COLUMN_STATUS_ICON) {
             tr.find('td.g-status-icon-container').attr('status', instance.status)
-              .find('i').removeClass().addClass(InstanceStatus.icon(instance.status));
+                .find('i').removeClass().addClass(InstanceStatus.icon(instance.status));
         }
         if (this.columns & this.columnEnum.COLUMN_STATUS) {
             tr.find('td.g-instance-status-cell').text(InstanceStatus.text(instance.status));

--- a/web_client/views/body/LaunchTaleView.js
+++ b/web_client/views/body/LaunchTaleView.js
@@ -77,7 +77,7 @@ var LaunchTaleView = View.extend({
                         }
                     }, this));
                     this.$('.g-job-progress>.progress-bar').css('width', '100%')
-                      .removeClass('progress-bar-info').addClass('progress-bar-success');
+                        .removeClass('progress-bar-info').addClass('progress-bar-success');
                 } else if (this.job.get('status') === JobStatus.ERROR) {
                     restRequest({
                         url: 'job/' + this.job.id + '/result',
@@ -87,7 +87,7 @@ var LaunchTaleView = View.extend({
                         this.$('.g-validation-failed-message').text(resp);
                     }, this));
                     this.$('.g-job-progress>.progress-bar').css('width', '100%')
-                      .removeClass('progress-bar-info').addClass('progress-bar-danger');
+                        .removeClass('progress-bar-info').addClass('progress-bar-danger');
                 }
             }
         });


### PR DESCRIPTION
Additionally allows to save empty config form and defaults are now respected if empty values are provided.

To test:
1. Setup clean environment
1. Navigate to https://girder.local.wholetale.org/#plugins/wholetale/config
1. Verify that *tmpnb*, *priv/pub key* fields are gone.
1. Hit 'Save'
1. Verify that defaults are respected, by:
    - reloading plugin config and see if the form updates with new values
    - (optional) trying to launch more than 2 instances
    - (optional) trying to register something from dataverse.harvard.edu


