### PR TITLE
Wrap errors in lookups with RestException. Fixes #189

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -28,5 +28,8 @@ add_python_test(dataverse
   plugins/wholetale/dataverse_listFiles.json
 )
 add_python_test(integration PLUGIN wholetale)
+add_python_test(repository
+  PLUGIN wholetale
+)
 add_python_style_test(python_static_analysis_wholetale
                       "${PROJECT_SOURCE_DIR}/plugins/wholetale/server")

--- a/plugin_tests/repository_test.py
+++ b/plugin_tests/repository_test.py
@@ -1,0 +1,43 @@
+import json
+from tests import base
+
+# TODO: for some reason vcr is stuck in a infinite loop
+
+
+def setUpModule():
+    base.enabledPlugins.append('wholetale')
+    base.startServer()
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class RepositoryTestCase(base.TestCase):
+
+    def _lookup(self, url, path):
+        return self.request(
+            path='/repository/' + path, method='GET',
+            params={'dataId': json.dumps([url])}
+        )
+
+    def testErrorHandling(self):
+        for path in ('lookup', 'listFiles'):
+            resp = self._lookup('https://doi.org/10.7910/DVN/blah', path)
+            self.assertStatus(resp, 400)
+            self.assertEqual(resp.json, {
+                'message': 'Id "https://doi.org/10.7910/DVN/blah" was '
+                           'categorized as DOI, but its resolution failed.',
+                'type': 'rest'
+            })
+
+            resp = self._lookup('https://wrong.url', path)
+            self.assertStatus(resp, 400)
+            if path == 'lookup':
+                self.assertTrue(resp.json['message'].startswith(
+                    'Lookup for "https://wrong.url" failed with:'
+                ))
+            else:
+                self.assertTrue(resp.json['message'].startswith(
+                    'Listing files at "https://wrong.url" failed with:'
+                ))


### PR DESCRIPTION
Girder throws nice errors now. They're not parsed and showed to the user in the dashboard, but 500s weren't either.