### PR TITLE
When requesting files via http do not accept compression. Fixes #191

### DIFF
--- a/server/lib/__init__.py
+++ b/server/lib/__init__.py
@@ -7,7 +7,7 @@ from .http_provider import HTTPImportProvider
 from .null_provider import NullImportProvider
 from .dataone.dataone_provider import DataOneImportProvider
 from .dataverse.provider import DataverseImportProvider
-from .globus.globus_provider import GlobusImportProvider
+# from .globus.globus_provider import GlobusImportProvider
 
 
 RESOLVERS = Resolvers()

--- a/server/lib/http_provider.py
+++ b/server/lib/http_provider.py
@@ -27,7 +27,8 @@ class HTTPImportProvider(ImportProvider):
             # returns True, which, various errors aside, signifies a commitment
             # to the entity being legitimate from the perspective of this provider
             raise Exception('Unknown scheme %s' % url.scheme)
-        headers = requests.head(pid).headers
+        headers = requests.head(
+            pid, headers={'Accept-Encoding': 'identity'}).headers
 
         valid_target = headers.get('Content-Type') is not None
         valid_target = valid_target and \
@@ -61,7 +62,8 @@ class HTTPImportProvider(ImportProvider):
                  base_url: str = None):
         url = dataMap.getDataId()
         progress.update(increment=1, message='Processing file {}.'.format(url))
-        headers = requests.head(url).headers
+        headers = requests.head(
+            url, headers={'Accept-Encoding': 'identity'}).headers
         size = headers.get('Content-Length') or \
             headers.get('Content-Range').split('/')[-1]
         fileModel = ModelImporter.model('file')


### PR DESCRIPTION
Most of http servers are clever enough to serve you compressed content, and most clients are clever enough to decompress it on the fly. On the other hand our FUSE is not that clever... This PR defaults to requesting plain, uncompressed content over http(s).

To test:
1. Register raw file from e.g. GitHub
2. Create a Tale with it, run it.
3. Verify the content is all there.

Thanks to @MatthewTurk for immediately knowing what's wrong and speeding up the debug process.