### PR TITLE
[tests] properly parse query since order of args is not guaranteed

### DIFF
--- a/plugin_tests/integration_test.py
+++ b/plugin_tests/integration_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from tests import base
+from urllib.parse import urlparse, parse_qs
 
 
 def setUpModule():
@@ -50,8 +51,7 @@ class IntegrationTestCase(base.TestCase):
                     'title': 'dataset title',
                     'environment': 'rstudio'})
         self.assertStatus(resp, 303)
-        self.assertEqual(
-            resp.headers['Location'],
-            'https://dashboard.wholetale.org/compose?name=dataset+title&'
-            'uri=urn%3Auuid%3A12345.6789&environment=rstudio'
-        )
+        query = parse_qs(urlparse(resp.headers['Location']).query)
+        self.assertEqual(query['name'][0], 'dataset title')
+        self.assertEqual(query['uri'][0], 'urn:uuid:12345.6789')
+        self.assertEqual(query['environment'][0], 'rstudio')


### PR DESCRIPTION
Fixes random failures on CirceCI:

```
16: ======================================================================
16: FAIL: testDataoneIntegration (plugin_tests.integration_test.IntegrationTestCase)
16: ----------------------------------------------------------------------
16: Traceback (most recent call last):
16:   File "/girder/plugins/wholetale/plugin_tests/integration_test.py", line 55, in testDataoneIntegration
16:     'https://dashboard.wholetale.org/compose?name=dataset+title&'
16: AssertionError: 'http[31 chars]pose?environment=rstudio&uri=urn%3Auuid%3A1234[21 chars]itle' != 'http[31 chars]pose?name=dataset+title&uri=urn%3Auuid%3A12345[21 chars]udio'
16: - https://dashboard.wholetale.org/compose?environment=rstudio&uri=urn%3Auuid%3A12345.6789&name=dataset+title
16: ?                                         - ^^^^^  ^ ^^  ^^ ^                              ^    -------- ^^^
16: + https://dashboard.wholetale.org/compose?name=dataset+title&uri=urn%3Auuid%3A12345.6789&environment=rstudio
16: ?                                          ^  ^^^ ^ + ^^ ^^^                             + ^^^^^  ++ ++++  ^
```