### PR TITLE
Switch to urllib for testing instance readiness. Fixes #201

### DIFF
--- a/plugin_tests/instance_test.py
+++ b/plugin_tests/instance_test.py
@@ -152,22 +152,18 @@ class TaleTestCase(base.TestCase):
             str(SettingDefault.defaults[PluginSettings.INSTANCE_CAP]))
 
         with mock.patch('celery.Celery') as celeryMock:
-            with mock.patch('tornado.httpclient.HTTPClient') as tornadoMock:
-                instance = celeryMock.return_value
-                instance.send_task.return_value = FakeAsyncResult()
+            instance = celeryMock.return_value
+            instance.send_task.return_value = FakeAsyncResult()
 
-                req = tornadoMock.return_value
-                req.fetch.return_value = {}
-
-                current_cap = setting.get(PluginSettings.INSTANCE_CAP)
-                setting.set(PluginSettings.INSTANCE_CAP, '0')
-                resp = self.request(
-                    path='/instance', method='POST', user=self.user,
-                    params={'imageId': str(self.image['_id'])})
-                self.assertStatus(resp, 400)
-                self.assertEqual(
-                    resp.json['message'], instanceCapErrMsg.format('0'))
-                setting.set(PluginSettings.INSTANCE_CAP, current_cap)
+            current_cap = setting.get(PluginSettings.INSTANCE_CAP)
+            setting.set(PluginSettings.INSTANCE_CAP, '0')
+            resp = self.request(
+                path='/instance', method='POST', user=self.user,
+                params={'imageId': str(self.image['_id'])})
+            self.assertStatus(resp, 400)
+            self.assertEqual(
+                resp.json['message'], instanceCapErrMsg.format('0'))
+            setting.set(PluginSettings.INSTANCE_CAP, current_cap)
 
     @mock.patch('gwvolman.tasks.create_volume')
     @mock.patch('gwvolman.tasks.launch_container')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 rdflib
-tornado
 celery[redis]
 idna==2.7  # pin for requests
 requests==2.20.1  # https://github.com/requests/requests/issues/4890


### PR DESCRIPTION
This should be tested on `.dev` deployment before merging.

Test case:

1. Deploy on `.dev`, either via custom image or by using bind mount
1. Launch any tale
1. Confirm that `~girder/.girder/logs/error.log` doesn't have requests log
1. Confirm that `~girder/.girder/logs/info.log` has some output from `_wait_for_server`