### PR TITLE
Add Additional Fields to Tale

### DIFF
--- a/server/lib/dataone/register.py
+++ b/server/lib/dataone/register.py
@@ -175,15 +175,15 @@ def find_initial_pid(path):
     # http://blog.crossref.org/2015/08/doi-regular-expressions.html
     doi_regex = re.compile(r'(10.\d{4,9}/[-._;()/:A-Z0-9]+)', re.IGNORECASE)
     doi = doi_regex.search(path)
-    if re.search(r'^http[s]?:\/\/search.dataone.org\/[#]?view\/', path):
+    if re.search(r'^http[s]?://search.dataone.org/[#]?view/', path):
         return re.sub(
-            r'^http[s]?:\/\/search.dataone.org\/[#]?view\/', '', path)
-    elif re.search(r'\Ahttp[s]?:\/\/cn[a-z\-\d\.]*\.dataone\.org\/cn\/v\d\/[a-zA-Z]+\/.+\Z', path):
+            r'^http[s]?://search.dataone.org/[#]?view/', '', path)
+    elif re.search(r'\Ahttp[s]?://cn[a-z\-\d.]*\.dataone\.org/cn/v\d/[a-zA-Z]+/.+\Z', path):
         return re.sub(
-            r'\Ahttp[s]?:\/\/cn[a-z\-\d\.]*\.dataone\.org\/cn\/v\d\/[a-zA-Z]+\/', '', path)
-    if re.search(r'^http[s]?:\/\/dev.nceas.ucsb.edu\/[#]?view\/', path):
+            r'\Ahttp[s]?://cn[a-z\-\d.]*\.dataone\.org/cn/v\d/[a-zA-Z]+/', '', path)
+    if re.search(r'^http[s]?://dev.nceas.ucsb.edu/[#]?view/', path):
         return re.sub(
-            r'^http[s]?:\/\/dev.nceas.ucsb.edu\/[#]?view\/', '', path)
+            r'^http[s]?://dev.nceas.ucsb.edu/[#]?view/', '', path)
     if re.search(r'resolve', path):
         return path.split("resolve/", 1)[1]
     elif doi is not None:

--- a/server/models/instance.py
+++ b/server/models/instance.py
@@ -136,7 +136,6 @@ class Instance(AccessControlledModel):
         Updates an instance.
 
         :param image: The instance document to update.
-        :type image: dict
         :returns: The instance document that was edited.
         """
         instance['updated'] = datetime.datetime.utcnow()

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -33,13 +33,14 @@ class Tale(AccessControlledModel):
         })
         self.modifiableFields = {
             'title', 'description', 'public', 'config', 'updated', 'authors',
-            'category', 'icon', 'iframe', 'illustration', 'dataSet'
+            'category', 'icon', 'iframe', 'illustration', 'dataSet',
+            'published', 'doi', 'publishedURI'
         }
         self.exposeFields(
             level=AccessType.READ,
             fields=({'_id', 'folderId', 'imageId', 'creatorId', 'created',
-                     'format', 'dataSet', 'narrative',
-                     'narrativeId'} | self.modifiableFields))
+                     'format', 'dataSet', 'narrative', 'narrativeId',
+                     'doi', 'publishedURI'} | self.modifiableFields))
         self.exposeFields(level=AccessType.ADMIN, fields={'published'})
 
     def validate(self, tale):
@@ -85,7 +86,8 @@ class Tale(AccessControlledModel):
                 tale['dataSet'].append(
                     {'itemId': obj['_id'], 'mountPath': '/' + obj['name']}
                 )
-
+            tale['doi'] = None
+            tale['publishedURI'] = None
         tale['format'] = _currentTaleFormat
         return tale
 
@@ -129,7 +131,7 @@ class Tale(AccessControlledModel):
     def createTale(self, image, data, creator=None, save=True, title=None,
                    description=None, public=None, config=None, published=False,
                    authors=None, icon=None, category=None, illustration=None,
-                   narrative=None):
+                   narrative=None, doi=None, publishedURI=None):
         if creator is None:
             creatorId = None
         else:
@@ -158,7 +160,9 @@ class Tale(AccessControlledModel):
             'title': title,
             'public': public,
             'published': published,
-            'updated': now
+            'updated': now,
+            'doi': doi,
+            'publishedURI': publishedURI
         }
         if public is not None and isinstance(public, bool):
             self.setPublic(tale, public, save=False)

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -202,7 +202,8 @@ class Tale(Resource):
                                      'images/demo-graph2.jpg')),
                 authors=tale.get('authors', default_author),
                 category=tale.get('category', 'science'),
-                published=False, narrative=tale.get('narrative', [])
+                published=False, narrative=tale.get('narrative'),
+                doi=tale.get('doi'), publishedURI=tale.get('publishedURI')
             )
 
     @access.user(scope=TokenScope.DATA_OWN)

--- a/server/schema/tale.py
+++ b/server/schema/tale.py
@@ -23,7 +23,7 @@ taleModel = {
             "description": "Title of the Tale"
         },
         "description": {
-            "type": "string",
+            "type": ["string", "null"],
             "description": "The description of the Tale (Markdown)"
         },
         "imageId": {
@@ -102,6 +102,16 @@ taleModel = {
         "icon": {
             "type": "string",
             "description": "A URL to an image icon"
+        },
+        "doi": {
+            "type": ["string", "null"],
+            "description": "A unique identifier assigned to this tale from a "
+                           "publishing source."
+        },
+        "publishedURI": {
+            "type": ["string", "null"],
+            "description": "A URI pointing to the location of the published "
+                           "Tale."
         }
     },
     'example': {
@@ -120,6 +130,7 @@ taleModel = {
             }
         ],
         "description": "#### Markdown Editor",
+        "doi": "doi:x.xx.xxx",
         "folderId": "5c4887409759c200017b2316",
         "format": 4,
         "icon": ("https://raw.githubusercontent.com/whole-tale/jupyter-base/"
@@ -132,6 +143,8 @@ taleModel = {
         "narrativeId": "5c4887409759c200017b2319",
         "public": False,
         "published": False,
+        "publishedURI": "https://dev.nceas.ucsb.edu/view/urn:uuid:939e48ec-1107-45d9"
+                        "-baa7-05cef08e51cd",
         "title": "My Tale",
         "updated": "2019-01-23T15:48:17.476000+00:00"
     }


### PR DESCRIPTION
### Add Fields to Tale Model
Published Tales should have a record that they were
1. Published
2. Have a DOI
3. A URI to locate the Tale

The following parameters are added to the Tale
`published`
`doi`
`publishedURI`


The change in `server/lib/dataone/dataone_register.py` was done to satisfy the linter.




### Testing

Using the Girder API,
1. Create a new Tale
2. Update the Tale, changing the values of `published`, `doi`, and `publishedURI`.
3. Get the Tale and confirm the changes were saved

## To Do:

### Clean up Commit Log
- [x] Done
I had issues squashing the previous merge commits, but was able to get the relevant changes into a single commit, [here](https://github.com/whole-tale/girder_wholetale/pull/203/commits/3a4eb478cc6447df96560a45e5f8248346f3437c)

### Get Up to Date with Master
- [x] Done
I have some merge conflicts that I need to resolve before I can merge this PR conflict-free.

### Add Testing Steps
- [x] Done
Right now I'd like a glace over at the code, but before this is merged I'll write a few test cases to make sure Tale creation is working properly with the new fields.





