### PR TITLE
Use dataSet object as 'involatileData'. Fixes #209

### DIFF
--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -69,7 +69,7 @@ class TaleTestCase(base.TestCase):
         self.assertStatus(resp, 400)
         self.assertEqual(resp.json, {
             'message': ("Invalid JSON object for parameter tale: "
-                        "'involatileData' "
+                        "'dataSet' "
                         "is a required property"),
             'type': 'rest'
         })
@@ -100,7 +100,7 @@ class TaleTestCase(base.TestCase):
             type='application/json',
             body=json.dumps({
                 'imageId': str(self.image['_id']),
-                'involatileData': [
+                'dataSet': [
                     {'mountPath': '/' + publicFolder['name'], 'itemId': publicFolder['_id']}
                 ]
             })
@@ -132,7 +132,7 @@ class TaleTestCase(base.TestCase):
             type='application/json',
             user=self.user, body=json.dumps({
                 'folderId': tale['folderId'],
-                'involatileData': tale['involatileData'],
+                'dataSet': tale['dataSet'],
                 'imageId': tale['imageId'],
                 'title': 'new name',
                 'description': 'new description',
@@ -150,7 +150,7 @@ class TaleTestCase(base.TestCase):
             type='application/json',
             body=json.dumps({
                 'imageId': str(self.image['_id']),
-                'involatileData': [{
+                'dataSet': [{
                     'mountPath': '/' + privateFolder['name'],
                     'itemId': privateFolder['_id']
                 }]
@@ -164,7 +164,7 @@ class TaleTestCase(base.TestCase):
             type='application/json',
             body=json.dumps({
                 'imageId': str(self.image['_id']),
-                'involatileData': [{
+                'dataSet': [{
                     'mountPath': '/' + privateFolder['name'],
                     'itemId': adminPublicFolder['_id']
                 }],
@@ -256,7 +256,7 @@ class TaleTestCase(base.TestCase):
                 body=json.dumps(
                     {
                         'imageId': str(self.image['_id']),
-                        'involatileData': [
+                        'dataSet': [
                             {'mountPath': '/' + folder['name'], 'itemId': folder['_id']}
                         ],
                         'public': True
@@ -271,7 +271,7 @@ class TaleTestCase(base.TestCase):
                 body=json.dumps(
                     {
                         'imageId': str(self.image_admin['_id']),
-                        'involatileData': [
+                        'dataSet': [
                             {'mountPath': '/' + folder['name'], 'itemId': folder['_id']}
                         ]
                     })
@@ -430,7 +430,7 @@ class TaleTestCase(base.TestCase):
             type='application/json',
             body=json.dumps({
                 'imageId': str(self.image['_id']),
-                'involatileData': [
+                'dataSet': [
                     {'mountPath': '/' + sub_home_dir['name'], 'itemId': sub_home_dir['_id']}
                 ],
                 'narrative': [str(my_narrative['_id'])]
@@ -499,8 +499,8 @@ class TaleTestCase(base.TestCase):
         self.assertStatusOk(resp)
         new_data_dir = resp.json
         self.assertEqual(str(tale['folderId']), str(new_data_dir['_id']))
-        self.assertEqual(str(tale['involatileData'][0]['itemId']), data_dir['_id'])
-        self.assertEqual(tale['involatileData'][0]['mountPath'], '/' + data_dir['name'])
+        self.assertEqual(str(tale['dataSet'][0]['itemId']), data_dir['_id'])
+        self.assertEqual(tale['dataSet'][0]['mountPath'], '/' + data_dir['name'])
         self.model('tale', 'wholetale').remove(tale)
 
     @mock.patch('gwvolman.tasks.import_tale')

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -101,7 +101,7 @@ class TaleTestCase(base.TestCase):
             body=json.dumps({
                 'imageId': str(self.image['_id']),
                 'involatileData': [
-                    {'type': 'folder', 'id': publicFolder['_id']}
+                    {'mountPath': '/' + publicFolder['name'], 'itemId': publicFolder['_id']}
                 ]
             })
         )
@@ -150,9 +150,10 @@ class TaleTestCase(base.TestCase):
             type='application/json',
             body=json.dumps({
                 'imageId': str(self.image['_id']),
-                'involatileData': [
-                    {'type': 'folder', 'id': privateFolder['_id']}
-                ]
+                'involatileData': [{
+                    'mountPath': '/' + privateFolder['name'],
+                    'itemId': privateFolder['_id']
+                }]
             })
         )
         self.assertStatusOk(resp)
@@ -163,9 +164,10 @@ class TaleTestCase(base.TestCase):
             type='application/json',
             body=json.dumps({
                 'imageId': str(self.image['_id']),
-                'involatileData': [
-                    {'type': 'folder', 'id': adminPublicFolder['_id']}
-                ],
+                'involatileData': [{
+                    'mountPath': '/' + privateFolder['name'],
+                    'itemId': adminPublicFolder['_id']
+                }],
                 'public': False
             })
         )
@@ -255,7 +257,7 @@ class TaleTestCase(base.TestCase):
                     {
                         'imageId': str(self.image['_id']),
                         'involatileData': [
-                            {'type': 'folder', 'id': folder['_id']}
+                            {'mountPath': '/' + folder['name'], 'itemId': folder['_id']}
                         ],
                         'public': True
                     })
@@ -270,7 +272,7 @@ class TaleTestCase(base.TestCase):
                     {
                         'imageId': str(self.image_admin['_id']),
                         'involatileData': [
-                            {'type': 'folder', 'id': folder['_id']}
+                            {'mountPath': '/' + folder['name'], 'itemId': folder['_id']}
                         ]
                     })
             )
@@ -429,7 +431,7 @@ class TaleTestCase(base.TestCase):
             body=json.dumps({
                 'imageId': str(self.image['_id']),
                 'involatileData': [
-                    {'type': 'folder', 'id': sub_home_dir['_id']}
+                    {'mountPath': '/' + sub_home_dir['name'], 'itemId': sub_home_dir['_id']}
                 ],
                 'narrative': [str(my_narrative['_id'])]
             })
@@ -497,8 +499,8 @@ class TaleTestCase(base.TestCase):
         self.assertStatusOk(resp)
         new_data_dir = resp.json
         self.assertEqual(str(tale['folderId']), str(new_data_dir['_id']))
-        self.assertEqual(tale['involatileData'],
-                         [{'id': str(data_dir['_id']), 'type': 'folder'}])
+        self.assertEqual(str(tale['involatileData'][0]['itemId']), data_dir['_id'])
+        self.assertEqual(tale['involatileData'][0]['mountPath'], '/' + data_dir['name'])
         self.model('tale', 'wholetale').remove(tale)
 
     @mock.patch('gwvolman.tasks.import_tale')

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -33,12 +33,12 @@ class Tale(AccessControlledModel):
         })
         self.modifiableFields = {
             'title', 'description', 'public', 'config', 'updated', 'authors',
-            'category', 'icon', 'iframe', 'illustration'
+            'category', 'icon', 'iframe', 'illustration', 'dataSet'
         }
         self.exposeFields(
             level=AccessType.READ,
             fields=({'_id', 'folderId', 'imageId', 'creatorId', 'created',
-                     'format', 'involatileData', 'narrative',
+                     'format', 'dataSet', 'narrative',
                      'narrativeId'} | self.modifiableFields))
         self.exposeFields(level=AccessType.ADMIN, fields={'published'})
 
@@ -76,13 +76,13 @@ class Tale(AccessControlledModel):
                 tale['narrative'] = []
         if tale.get('format', 0) < 4:
             old_data = tale.pop('involatileData')
-            tale['involatileData'] = []
+            tale['dataSet'] = []
             for entry in old_data:
                 if entry['type'] == 'folder':
                     obj = Folder().load(entry['id'], force=True)
                 elif entry['type'] == 'item':
                     obj = Item().load(entry['id'], force=True)
-                tale['involatileData'].append(
+                tale['dataSet'].append(
                     {'itemId': obj['_id'], 'mountPath': '/' + obj['name']}
                 )
 
@@ -116,7 +116,7 @@ class Tale(AccessControlledModel):
         if user is not None:
             cursor_def['creatorId'] = user['_id']
         if data is not None:
-            cursor_def['involatileData'] = data
+            cursor_def['dataSet'] = data
         if image is not None:
             cursor_def['imageId'] = image['_id']
 
@@ -146,7 +146,7 @@ class Tale(AccessControlledModel):
             'category': category,
             'config': config,
             'creatorId': creatorId,
-            'involatileData': data or [],
+            'dataSet': data or [],
             'description': description,
             'format': _currentTaleFormat,
             'created': now,

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -190,7 +190,7 @@ class Tale(Resource):
                 tale['imageId'], user=user, level=AccessType.READ, exc=True)
             default_author = ' '.join((user['firstName'], user['lastName']))
             return self._model.createTale(
-                image, tale['involatileData'], creator=user, save=True,
+                image, tale['dataSet'], creator=user, save=True,
                 title=tale.get('title'), description=tale.get('description'),
                 public=tale.get('public'), config=tale.get('config'),
                 icon=image.get('icon', ('https://raw.githubusercontent.com/'

--- a/server/schema/misc.py
+++ b/server/schema/misc.py
@@ -61,6 +61,31 @@ dataMapListSchema = {
     'items': dataMapSchema,
 }
 
+dataSetItemSchema = {
+    'title': 'dataSetItem',
+    '$schema': 'http://json-schema.org/draft-04/schema#',
+    'description': 'A schema representing data elements used in DMS dataSets',
+    'type': 'object',
+    'properties': {
+        'itemId': {
+            'type': 'string',
+            'description': 'ID of a Girder item or a Girder folder'
+        },
+        'mountPath': {
+            'type': 'string',
+            'description': 'An absolute path where the item/folder are mounted in the EFS'
+        }
+    },
+    'required': ['itemId', 'mountPath']
+}
+
+dataSetSchema = {
+    'title': 'A list of resources with a corresponding mount points in the ESF',
+    '$schema': 'http://json-schema.org/draft-04/schema#',
+    'type': 'array',
+    'items': dataSetItemSchema,
+}
+
 tagsSchema = {
     'title': 'tags',
     '$schema': 'http://json-schema.org/draft-04/schema#',
@@ -147,3 +172,4 @@ containerInfoSchema = {
 }
 
 addModel('containerConfig', containerConfigSchema)
+addModel('dataSet', dataSetSchema)

--- a/server/schema/tale.py
+++ b/server/schema/tale.py
@@ -10,7 +10,7 @@ taleModel = {
     },
     "description": "Object representing a Tale.",
     "required": [
-        "involatileData",
+        "dataSet",
         "imageId"
     ],
     "properties": {
@@ -32,13 +32,13 @@ taleModel = {
         },
         "folderId": {
             "type": "string",
-            "description": "ID of a folder containing copy of tale['involatileData']"
+            "description": "ID of a folder containing copy of tale['dataSet']"
         },
         "narrativeId": {
             "type": "string",
             "description": "ID of a folder containing copy of tale['narrative']"
         },
-        "involatileData": {
+        "dataSet": {
             "$ref": "#/definitions/dataSet"
         },
         "narrative": {

--- a/server/schema/tale.py
+++ b/server/schema/tale.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from .misc import containerConfigSchema
-from girder.plugins.wt_data_manager.schema.dataset import dataSetSchema
+from .misc import containerConfigSchema, dataSetSchema
 
 taleModel = {
     "definitions": {

--- a/server/schema/tale.py
+++ b/server/schema/tale.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from .misc import containerConfigSchema, dataResourceSchema
+from .misc import containerConfigSchema
+from girder.plugins.wt_data_manager.schema.dataset import dataSetSchema
 
 taleModel = {
     "definitions": {
-        'containerConfig': containerConfigSchema
+        "containerConfig": containerConfigSchema,
+        "dataSet": dataSetSchema
     },
     "description": "Object representing a Tale.",
     "required": [
@@ -38,9 +40,7 @@ taleModel = {
             "description": "ID of a folder containing copy of tale['narrative']"
         },
         "involatileData": {
-            "type": "array",
-            "items": dataResourceSchema,
-            "description": "Resources used to create Tale's data folder"
+            "$ref": "#/definitions/dataSet"
         },
         "narrative": {
             "type": "array",

--- a/server/schema/tale.py
+++ b/server/schema/tale.py
@@ -105,18 +105,34 @@ taleModel = {
         }
     },
     'example': {
-        '_accessLevel': 2,
-        '_id': '5873dcdbaec030000144d233',
-        'creatorId': '5873dcdbaec030000144d233',
-        'imageId': '5873dcdbaec030000144d233',
-        'folderId': '5873dcdbaec030000144d233',
-        'config': 'null',
-        '_modelType': 'tale',
-        'created': '2017-01-09T18:56:27.262000+00:00',
-        'title': 'Jupyter Lab',
-        'description': 'Run Jupyter Lab',
-        'public': True,
-        'published': True,
-        'updated': '2017-01-10T16:15:17.313000+00:00',
-    },
+        "_accessLevel": 2,
+        "_id": "5c4887409759c200017b2310",
+        "_modelType": "tale",
+        "authors": "Kacper Kowalik",
+        "category": "science",
+        "config": {},
+        "created": "2019-01-23T15:24:48.217000+00:00",
+        "creatorId": "5c4887149759c200017b22c0",
+        "dataSet": [
+            {
+                "itemId": "5c4887389759c200017b230e",
+                "mountPath": "illustris.jpg"
+            }
+        ],
+        "description": "#### Markdown Editor",
+        "folderId": "5c4887409759c200017b2316",
+        "format": 4,
+        "icon": ("https://raw.githubusercontent.com/whole-tale/jupyter-base/"
+                 "master/squarelogo-greytext-orangebody-greymoons.png"),
+        "iframe": True,
+        "illustration": ("https://raw.githubusercontent.com/whole-tale/dashboard/"
+                         "master/public/images/demo-graph2.jpg"),
+        "imageId": "5c4886279759c200017b22a3",
+        "narrative": [],
+        "narrativeId": "5c4887409759c200017b2319",
+        "public": False,
+        "published": False,
+        "title": "My Tale",
+        "updated": "2019-01-23T15:48:17.476000+00:00"
+    }
 }


### PR DESCRIPTION
Converts `involatileData` to use `dataSet` instead of custom format.

### TODO:

- [ ] Update [gwvolman](https://github.com/whole-tale/gwvolman) to match changes in `involatileData` format (*create_tale*)

### How to test?
1. Create a Tale with at least one folder/item as external data
2. Use `GET /tale/{id}` to check whether `involatileData` matches the new format.
3. (Optionally) Look at existing Tales using `GET /tale` and see if `involatileData` migrated cleanly.