### PR TITLE
[WIP] Better event handling for Instance related tasks

### DIFF
--- a/plugin_tests/instance_test.py
+++ b/plugin_tests/instance_test.py
@@ -1,6 +1,5 @@
 import time
 import json
-import copy
 import mock
 import httmock
 import six
@@ -168,7 +167,7 @@ class InstanceTestCase(base.TestCase):
             self.assertEqual(
                 resp.json['message'], instanceCapErrMsg.format('0'))
             setting.set(PluginSettings.INSTANCE_CAP, current_cap)
-        
+
     @mock.patch('gwvolman.tasks.create_volume')
     @mock.patch('gwvolman.tasks.launch_container')
     @mock.patch('gwvolman.tasks.update_container')
@@ -245,7 +244,7 @@ class InstanceTestCase(base.TestCase):
         self.assertEqual(resp.json['containerInfo']['nodeId'], '123456')
         self.assertEqual(resp.json['containerInfo']['volumeName'], 'blah_volume')
         self.assertEqual(resp.json['status'], InstanceStatus.RUNNING)
-        
+
         # Save this response to populate containerInfo
         instance = resp.json
 
@@ -261,7 +260,7 @@ class InstanceTestCase(base.TestCase):
         # Update/restart the instance
         with mock.patch('girder_worker.task.celery.Task.apply_async', spec=True) \
                 as mock_apply_async:
-                    
+
             # PUT /instance/:id (currently a no-op)
             resp = self.request(
                 path='/instance/{_id}'.format(**instance), method='PUT', user=self.user,
@@ -275,12 +274,12 @@ class InstanceTestCase(base.TestCase):
                     'sessionId': instance['status'],
                     'url': instance['url'],
                     'containerInfo': {
-                       'digest': instance['containerInfo']['digest'],
-                       'imageId': instance['containerInfo']['imageId'],
-                       'mountPoint': instance['containerInfo']['mountPoint'],
-                       'name': instance['containerInfo']['name'],
-                       'nodeId': instance['containerInfo']['nodeId'],
-                       'urlPath': instance['containerInfo']['urlPath'],
+                        'digest': instance['containerInfo']['digest'],
+                        'imageId': instance['containerInfo']['imageId'],
+                        'mountPoint': instance['containerInfo']['mountPoint'],
+                        'name': instance['containerInfo']['name'],
+                        'nodeId': instance['containerInfo']['nodeId'],
+                        'urlPath': instance['containerInfo']['urlPath'],
                     }
                 })
             )
@@ -301,6 +300,18 @@ class InstanceTestCase(base.TestCase):
             self.assertStatusOk(resp)
             mock_apply_async.assert_called_once()
 
+        resp = self.request(
+            path='/instance/{_id}'.format(**instance), method='GET',
+            user=self.user)
+        self.assertStatus(resp, 400)
+
+    def testForcefulRemoval(self):
+        instance = Instance().createInstance(
+            self.tale_one, self.user, None, save=True, spawn=False)
+        resp = self.request(
+            path='/instance/{_id}'.format(**instance), method='DELETE',
+            user=self.user, params={'force': True})
+        self.assertStatus(resp, 200)
         resp = self.request(
             path='/instance/{_id}'.format(**instance), method='GET',
             user=self.user)

--- a/plugin_tests/instance_test.py
+++ b/plugin_tests/instance_test.py
@@ -297,8 +297,12 @@ class InstanceTestCase(base.TestCase):
             resp = self.request(
                 path='/instance/{_id}'.format(**instance), method='DELETE',
                 user=self.user)
-            self.assertStatus(resp, 202)
+            self.assertStatusOk(resp)
             mock_apply_async.assert_called_once()
+
+        # TODO: Fix tests below, right now delete is still synchronous,
+        # so there's no easy way to test job flow
+        return
 
         # Create a job to be handled by the worker plugin
         from girder.plugins.jobs.models.job import Job
@@ -341,18 +345,6 @@ class InstanceTestCase(base.TestCase):
             Job().updateJob(job, log='job running', status=JobStatus.RUNNING)
             Job().updateJob(job, log='job ran', status=JobStatus.SUCCESS)
 
-        resp = self.request(
-            path='/instance/{_id}'.format(**instance), method='GET',
-            user=self.user)
-        self.assertStatus(resp, 400)
-
-    def testForcefulRemoval(self):
-        instance = Instance().createInstance(
-            self.tale_one, self.user, None, save=True, spawn=False)
-        resp = self.request(
-            path='/instance/{_id}'.format(**instance), method='DELETE',
-            user=self.user, params={'force': True})
-        self.assertStatus(resp, 200)
         resp = self.request(
             path='/instance/{_id}'.format(**instance), method='GET',
             user=self.user)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -30,7 +30,6 @@ from .rest.tale import Tale
 from .rest.instance import Instance
 from .rest.wholetale import wholeTale
 from .rest.workspace import Workspace
-from .models.instance import finalizeInstance
 
 
 @setting_utilities.validator(PluginSettings.DATAVERSE_EXTRA_HOSTS)
@@ -329,7 +328,6 @@ def load(info):
     image = Image()
     info['apiRoot'].image = image
     events.bind('jobs.job.update.after', 'wholetale', image.updateImageStatus)
-    events.bind('jobs.job.update.after', 'wholetale', finalizeInstance)
     events.bind('model.file.validate', 'wholetale', validateFileLink)
     events.unbind('model.user.save.created', CoreEventHandler.USER_DEFAULT_FOLDERS)
     events.bind('model.user.save.created', 'wholetale', addDefaultFolders)

--- a/server/constants.py
+++ b/server/constants.py
@@ -38,6 +38,7 @@ class InstanceStatus(object):
     LAUNCHING = 0
     RUNNING = 1
     ERROR = 2
+    DELETING = 3
 
     @staticmethod
     def isValid(status):
@@ -47,7 +48,7 @@ class InstanceStatus(object):
             return event.responses[-1]
 
         return status in (InstanceStatus.RUNNING, InstanceStatus.ERROR,
-                          InstanceStatus.LAUNCHING)
+                          InstanceStatus.LAUNCHING, InstanceStatus.DELETING)
 
 
 class ImageStatus(object):

--- a/server/constants.py
+++ b/server/constants.py
@@ -42,10 +42,10 @@ class InstanceStatus(object):
 
     # Mapping of states to valid previous states
     valid_transitions = {
-        LAUNCHING: [RUNNING, ERROR, DELETING],
-        RUNNING: [DELETING, ERROR],
+        LAUNCHING: [LAUNCHING],
+        RUNNING: [LAUNCHING, RUNNING],
         ERROR: [LAUNCHING, RUNNING, DELETING, ERROR],
-        DELETING: [LAUNCHING, RUNNING]
+        DELETING: [DELETING, LAUNCHING, RUNNING]
     }
 
     @staticmethod

--- a/server/models/instance.py
+++ b/server/models/instance.py
@@ -187,12 +187,12 @@ class Instance(AccessControlledModel):
 
         update = True
         if status == JobStatus.ERROR:
-            instance['status'] = InstanceStatus.ERROR
+            InstanceStatus.transitionTo(instance, InstanceStatus.ERROR)
         elif status in (JobStatus.QUEUED, JobStatus.RUNNING):
             if job['title'] in {'Spawn Instance', 'Create Tale Data Volume'}:
-                instance['status'] = InstanceStatus.LAUNCHING
+                InstanceStatus.transitionTo(instance, InstanceStatus.LAUNCHING)
             else:
-                instance['status'] = InstanceStatus.DELETING
+                InstanceStatus.transitionTo(instance, InstanceStatus.DELETING)
         elif job['title'] == 'Spawn Instance' and status == JobStatus.SUCCESS:
             service = getCeleryApp().AsyncResult(job['celeryTaskId']).get()
             valid_keys = set(containerInfoSchema['properties'].keys())
@@ -206,10 +206,10 @@ class Instance(AccessControlledModel):
             containerInfo['digest'] = image['digest']
             instance.update({
                 'url': url,
-                'status': InstanceStatus.RUNNING,
                 'containerInfo': containerInfo,
                 'sessionId': service.get('sessionId')
             })
+            InstanceStatus.transitionTo(instance, InstanceStatus.RUNNING),
         else:
             update = False
 

--- a/server/rest/instance.py
+++ b/server/rest/instance.py
@@ -6,7 +6,7 @@ from girder.api.docs import addModel
 from girder.api.rest import Resource, filtermodel, RestException
 from girder.constants import AccessType, SortDir
 from girder.utility import path as path_util
-from ..constants import PluginSettings
+from ..constants import PluginSettings, InstanceStatus
 
 
 instanceModel = {
@@ -218,9 +218,11 @@ class Instance(Resource):
         if existing:
             return existing
 
-        running_instances = list(
-            instanceModel.list(user=user, currentUser=user)
-        )
+        running_instances = [
+            instance
+            for instance in instanceModel.list(user=user, currentUser=user)
+            if instance['status'] in {InstanceStatus.LAUNCHING, InstanceStatus.RUNNING}
+        ]
         instance_cap = self.model('setting').get(PluginSettings.INSTANCE_CAP)
         if len(running_instances) + 1 > int(instance_cap):
             raise RestException(instanceCapErrMsg.format(instance_cap))

--- a/server/rest/instance.py
+++ b/server/rest/instance.py
@@ -159,7 +159,7 @@ class Instance(Resource):
         .errorResponse('ID was invalid.')
         .errorResponse('Write access was denied for the instance.', 403)
     )
-    def deleteInstance(self, instance, params):
+    def deleteInstance(self, instance):
         self.model('instance', 'wholetale').deleteInstance(
             instance, self.getCurrentToken())
 


### PR DESCRIPTION
~With this PR status of an *Instance* is properly updated according to status of all related tasks: `create_volume`, `launch_container`, `shutdown_container`, `remove_volume`. In particular:~

1. ~When the first task (`create_volume`) fails, instance status is updated to `ERROR`.~
2. ~When `DELETE /instance` is called, *Instance* status is set to `DELETING` whenever `shutdown_instance` and `remove_volume` are scheduled or running~
3. ~*Instance* is only removed when `remove_volume` finishes with a success.~

~Additionally, in order to indicate that `DELETE /instance` is an asynchronous task, the endpoint now returns 202 ACCEPTED code.~

With this PR status of an *Instance* is updated according to status of most related tasks:
`create_volume`, `launch_container`, `shutdown_container`. Currently all that's being done for `shutdown_container` is setting *Instance* status to `DELETING`. Instances in `DELETING` and `ERROR` state are not taken into account for calculating instance cap limit.

As [suggested](https://github.com/whole-tale/dashboard/issues/213#issuecomment-447056036) by @bodom0015, introduction of DELETING state will allow us to workaround https://github.com/whole-tale/dashboard/issues/213.

### How to test?
1. Modify `gwvolman`'s `create_volume` so that it always fails (e.g. raise any error)
2. Launch a Tale
3. Confirm that newly created instance ends up with status `ERROR` (2)
4. Revert 1.
5. Add `time.sleep(60)` to either `shutdown_instance` or `remove_volume` in `gwvolman`
6. Launch a Tale
7. Delete an Instance after it's started.
8. Confirm that instance retains `DELETING` (3) status as long as `shutdown_instance` or `remove_volume` are running.