### PR TITLE
Allow to specify model type in dataSetItem

### DIFF
--- a/server/schema/misc.py
+++ b/server/schema/misc.py
@@ -67,6 +67,11 @@ dataSetItemSchema = {
     'description': 'A schema representing data elements used in DMS dataSets',
     'type': 'object',
     'properties': {
+        '_modelType': {
+            'type': 'string',
+            'enum': ['item', 'folder'],
+            'description': 'Either a Girder item or a Girder folder'
+        },
         'itemId': {
             'type': 'string',
             'description': 'ID of a Girder item or a Girder folder'


### PR DESCRIPTION
It's a convenience that will save us a few calls to the db, e.g. while tackling https://github.com/whole-tale/dashboard/issues/368