### PR TITLE
Add 'workspace' resource. Fixes #225

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -32,5 +32,8 @@ add_python_test(integration PLUGIN wholetale)
 add_python_test(repository
   PLUGIN wholetale
 )
+add_python_test(workspace
+  PLUGIN wholetale
+)
 add_python_style_test(python_static_analysis_wholetale
                       "${PROJECT_SOURCE_DIR}/plugins/wholetale/server")

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -537,7 +537,6 @@ class TaleTestCase(base.TestCase):
             }
         )
 
-        public_folder = resp.json[1]
         title = 'new name'
         description = 'new description'
         config = {'memLimit': '2g'}
@@ -577,7 +576,7 @@ class TaleTestCase(base.TestCase):
             body=json.dumps({
                 'folderId': '1234',
                 'imageId': str(self.image['_id']),
-                                'dataSet': [
+                'dataSet': [
                     {'mountPath': '/' + 'folder', 'itemId': '123456'}
                 ],
                 'title': title,

--- a/plugin_tests/workspace_test.py
+++ b/plugin_tests/workspace_test.py
@@ -42,9 +42,9 @@ class WorkspaceTestCase(base.TestCase):
     def testLookup(self):
         resp = self.request(path='/workspace', method='GET', user=self.user)
         self.assertStatus(resp, 200)
-        self.assertEqual(resp.json[1]['lowerName'], self.tale_one['title'].lower())
-        self.assertEqual(resp.json[0]['name'], self.tale_two['title'])
-        workspace_two = resp.json[0]
+        self.assertEqual(resp.json[0]['lowerName'], self.tale_one['title'].lower())
+        self.assertEqual(resp.json[1]['name'], self.tale_two['title'])
+        workspace_two = resp.json[1]
 
         resp = self.request(
             path='/workspace/{_id}'.format(**self.tale_two),

--- a/plugin_tests/workspace_test.py
+++ b/plugin_tests/workspace_test.py
@@ -1,5 +1,6 @@
 from bson import ObjectId
 from tests import base
+from girder.constants import AccessType
 
 
 def setUpModule():
@@ -44,6 +45,7 @@ class WorkspaceTestCase(base.TestCase):
         self.assertStatus(resp, 200)
         self.assertEqual(resp.json[0]['lowerName'], self.tale_one['title'].lower())
         self.assertEqual(resp.json[1]['name'], self.tale_two['title'])
+        workspace_one = resp.json[0]
         workspace_two = resp.json[1]
 
         resp = self.request(
@@ -63,6 +65,17 @@ class WorkspaceTestCase(base.TestCase):
         self.assertStatus(resp, 200)
         self.assertEqual(len(resp.json), 1)
         self.assertEqual(resp.json[0], workspace_two)
+
+        # Get Tales that I have write access to
+        resp = self.request(
+            path='/workspace',
+            method='GET',
+            user=self.user,
+            params={'level': AccessType.WRITE},
+        )
+        self.assertStatus(resp, 200)
+        self.assertEqual(len(resp.json), 1)
+        self.assertEqual(resp.json[0], workspace_one)
 
     def tearDown(self):
         for user in (self.user, self.admin):

--- a/plugin_tests/workspace_test.py
+++ b/plugin_tests/workspace_test.py
@@ -1,0 +1,61 @@
+from bson import ObjectId
+from tests import base
+
+
+def setUpModule():
+    base.enabledPlugins.append('wholetale')
+    base.startServer()
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class WorkspaceTestCase(base.TestCase):
+    def setUp(self):
+        users = (
+            {
+                'email': 'root@dev.null',
+                'login': 'admin',
+                'firstName': 'Root',
+                'lastName': 'van Klompf',
+                'password': 'secret',
+            },
+            {
+                'email': 'joe@dev.null',
+                'login': 'joeregular',
+                'firstName': 'Joe',
+                'lastName': 'Regular',
+                'password': 'secret',
+            },
+        )
+        self.admin, self.user = [
+            self.model('user').createUser(**user) for user in users
+        ]
+        self.tale_one = self.model('tale', 'wholetale').createTale(
+            {'_id': ObjectId()}, [], creator=self.user, title='Tale One', public=True
+        )
+        self.tale_two = self.model('tale', 'wholetale').createTale(
+            {'_id': ObjectId()}, [], creator=self.admin, title='Tale Two', public=True
+        )
+
+    def testLookup(self):
+        resp = self.request(path='/workspace', method='GET', user=self.user)
+        self.assertStatus(resp, 200)
+        self.assertEqual(resp.json[1]['lowerName'], self.tale_one['title'].lower())
+        self.assertEqual(resp.json[0]['name'], self.tale_two['title'])
+        workspace_two = resp.json[0]
+
+        resp = self.request(
+            path='/workspace/{_id}'.format(**self.tale_two),
+            method='GET',
+            user=self.user,
+        )
+        self.assertStatus(resp, 200)
+        self.assertEqual(resp.json, workspace_two)
+
+    def tearDown(self):
+        for user in (self.user, self.admin):
+            self.model('user').remove(user)
+        for tale in (self.tale_one, self.tale_two):
+            self.model('tale', 'wholetale').remove(tale)

--- a/plugin_tests/workspace_test.py
+++ b/plugin_tests/workspace_test.py
@@ -39,7 +39,7 @@ class WorkspaceTestCase(base.TestCase):
             {'_id': ObjectId()}, [], creator=self.admin, title='Tale Two', public=True
         )
 
-    def testLookup(self):
+    def testListingWorkspaces(self):
         resp = self.request(path='/workspace', method='GET', user=self.user)
         self.assertStatus(resp, 200)
         self.assertEqual(resp.json[0]['lowerName'], self.tale_one['title'].lower())
@@ -53,6 +53,16 @@ class WorkspaceTestCase(base.TestCase):
         )
         self.assertStatus(resp, 200)
         self.assertEqual(resp.json, workspace_two)
+
+        resp = self.request(
+            path='/workspace',
+            method='GET',
+            user=self.user,
+            params={'userId': str(self.admin['_id'])},
+        )
+        self.assertStatus(resp, 200)
+        self.assertEqual(len(resp.json), 1)
+        self.assertEqual(resp.json[0], workspace_two)
 
     def tearDown(self):
         for user in (self.user, self.admin):

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -29,6 +29,7 @@ from .rest.harvester import listImportedData
 from .rest.tale import Tale
 from .rest.instance import Instance
 from .rest.wholetale import wholeTale
+from .rest.workspace import Workspace
 from .models.instance import finalizeInstance
 
 
@@ -335,6 +336,7 @@ def load(info):
     info['apiRoot'].repository = Repository()
     info['apiRoot'].publish = Publish()
     info['apiRoot'].integration = Integration()
+    info['apiRoot'].workspace = Workspace()
     info['apiRoot'].folder.route('GET', ('registered',), listImportedData)
     info['apiRoot'].folder.route('GET', (':id', 'listing'), listFolder)
     info['apiRoot'].folder.route('GET', (':id', 'dataset'), getDataSet)

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -99,7 +99,7 @@ class Tale(AccessControlledModel):
         return tale
 
     def list(self, user=None, data=None, image=None, limit=0, offset=0,
-             sort=None, currentUser=None):
+             sort=None, currentUser=None, level=AccessType.READ):
         """
         List a page of jobs for a given user.
 
@@ -124,7 +124,7 @@ class Tale(AccessControlledModel):
 
         cursor = self.find(cursor_def, sort=sort)
         for r in self.filterResultsByPermission(
-                cursor=cursor, user=currentUser, level=AccessType.READ,
+                cursor=cursor, user=currentUser, level=level,
                 limit=limit, offset=offset):
             yield r
 

--- a/server/rest/workspace.py
+++ b/server/rest/workspace.py
@@ -23,10 +23,18 @@ class Workspace(Resource):
     @autoDescribeRoute(
         Description(('Returns all workspaces that user has access to'))
         .param('userId', "The ID of the parent Tale's creator.", required=False)
+        .param(
+            'level',
+            'The minimum access level to the Tale.',
+            required=False,
+            dataType='integer',
+            default=AccessType.READ,
+            enum=[AccessType.NONE, AccessType.READ, AccessType.WRITE, AccessType.ADMIN],
+        )
         .pagingParams(defaultSort='name', defaultSortDir=SortDir.ASCENDING)
         .responseClass('folder', array=True)
     )
-    def listWorkspaces(self, userId, limit, offset, sort):
+    def listWorkspaces(self, userId, level, limit, offset, sort):
         workspaces = []
         parent = getOrCreateRootFolder(WORKSPACE_NAME)
 
@@ -43,6 +51,7 @@ class Workspace(Resource):
             limit=limit,
             offset=offset,
             sort=sort,
+            level=level,
             currentUser=self.getCurrentUser(),
         ):
             q = {'parentId': parent['_id'], 'name': str(tale['_id'])}

--- a/server/rest/workspace.py
+++ b/server/rest/workspace.py
@@ -5,6 +5,7 @@ from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import Resource, RestException
 from girder.constants import AccessType, SortDir
 from girder.models.folder import Folder
+from girder.models.user import User
 from ..constants import WORKSPACE_NAME
 from ..models.tale import Tale
 from ..utils import getOrCreateRootFolder
@@ -21,19 +22,28 @@ class Workspace(Resource):
     @access.public
     @autoDescribeRoute(
         Description(('Returns all workspaces that user has access to'))
-        .responseClass('folder', array=True)
+        .param('userId', "The ID of the parent Tale's creator.", required=False)
         .pagingParams(defaultSort='name', defaultSortDir=SortDir.ASCENDING)
+        .responseClass('folder', array=True)
     )
-    def listWorkspaces(self, limit, offset, sort):
-        user = self.getCurrentUser()
+    def listWorkspaces(self, userId, limit, offset, sort):
         workspaces = []
         parent = getOrCreateRootFolder(WORKSPACE_NAME)
+
+        if userId:
+            user = User().load(userId, force=True, exc=True)
+        else:
+            user = None
 
         if sort[0][0] in {'name', 'lowerName'}:
             sort = [('title', sort[0][1])]
 
         for tale in Tale().list(
-            limit=limit, offset=offset, sort=sort, currentUser=user
+            user=user,
+            limit=limit,
+            offset=offset,
+            sort=sort,
+            currentUser=self.getCurrentUser(),
         ):
             q = {'parentId': parent['_id'], 'name': str(tale['_id'])}
             folder = Folder().findOne(q)

--- a/server/rest/workspace.py
+++ b/server/rest/workspace.py
@@ -47,10 +47,11 @@ class Workspace(Resource):
 
     @access.public
     @autoDescribeRoute(
-        Description('Get any workspace by ID.')
-        .modelParam('id', model='tale', plugin='wholetale', level=AccessType.READ)
+        Description('Get the workspace associated with a Tale ID')
+        .modelParam('id', description='The ID of a Tale', model='tale',
+                    plugin='wholetale', level=AccessType.READ)
         .responseClass('folder')
-        .errorResponse('ID was invalid.')
+        .errorResponse('Tale ID was invalid.')
         .errorResponse('Read access was denied for the resource.', 403)
     )
     def getWorkspace(self, tale):

--- a/server/rest/workspace.py
+++ b/server/rest/workspace.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from girder.api import access
+from girder.api.describe import Description, autoDescribeRoute
+from girder.api.rest import Resource, RestException
+from girder.constants import AccessType, SortDir
+from girder.models.folder import Folder
+from ..constants import WORKSPACE_NAME
+from ..models.tale import Tale
+from ..utils import getOrCreateRootFolder
+
+
+class Workspace(Resource):
+    def __init__(self):
+        super(Workspace, self).__init__()
+        self.resourceName = 'workspace'
+
+        self.route('GET', (), self.listWorkspaces)
+        self.route('GET', (':id',), self.getWorkspace)
+
+    @access.public
+    @autoDescribeRoute(
+        Description(('Returns all workspaces that user has access to'))
+        .responseClass('folder', array=True)
+        .pagingParams(defaultSort='created', defaultSortDir=SortDir.DESCENDING)
+    )
+    def listWorkspaces(self, limit, offset, sort):
+        user = self.getCurrentUser()
+        workspaces = []
+        parent = getOrCreateRootFolder(WORKSPACE_NAME)
+        for folder in Folder().childFolders(
+            parentType='folder',
+            parent=parent,
+            user=user,
+            limit=limit,
+            offset=offset,
+            sort=sort,
+        ):
+            tale = Tale().load(folder['meta']['taleId'], user=user,
+                               level=AccessType.READ)
+            if tale:
+                folder['_modelType'] = 'folder'
+                folder['name'] = tale['title']
+                folder['lowerName'] = folder['name'].lower()
+                workspaces.append(folder)
+        return workspaces
+
+    @access.public
+    @autoDescribeRoute(
+        Description('Get any workspace by ID.')
+        .modelParam('id', model='tale', plugin='wholetale', level=AccessType.READ)
+        .responseClass('folder')
+        .errorResponse('ID was invalid.')
+        .errorResponse('Read access was denied for the resource.', 403)
+    )
+    def getWorkspace(self, tale):
+        user = self.getCurrentUser()
+
+        parent = getOrCreateRootFolder(WORKSPACE_NAME)
+        filters = {'name': str(tale['_id'])}
+        try:
+            folder = next(
+                Folder().childFolders(
+                    parentType='folder', parent=parent, user=user, filters=filters
+                )
+            )
+        except StopIteration:
+            raise RestException(
+                "Tale ({}) doesn't have a workspace".format(tale['_id'])
+            )
+
+        folder['_modelType'] = 'folder'
+        folder['name'] = tale['title']
+        folder['lowerName'] = folder['name'].lower()
+        return folder


### PR DESCRIPTION
This PR introduces `GET /workspace` and `GET /workspace/{:id}` as a convenience method of retrieving workspace folder with a proper name and a `_modelType`. For rationale see https://github.com/whole-tale/dashboard/issues/364

### How to test?
1. Create a bunch of Tales
1. Using Girder's Swagger page call `GET /workspace`. Verify that:
   * each returned object's `_id` corresponds to a proper folderId in `/collections/WholeTale Workspaces/WholeTale Workspaces`
   * each returned name/lowerName corresponds to a Tale's title, rather than Tale's id.