### PR TITLE
Add 'workspaceId' reference to Tale model. Fixes #225

### DIFF
--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -501,8 +501,9 @@ class TaleTestCase(base.TestCase):
         self.assertStatusOk(resp)
         new_data_dir = resp.json
         self.assertEqual(str(tale['folderId']), str(new_data_dir['_id']))
-        self.assertEqual(str(tale['dataSet'][0]['itemId']), data_dir['_id'])
-        self.assertEqual(tale['dataSet'][0]['mountPath'], '/' + data_dir['name'])
+        self.assertEqual(tale['dataSet'], [])
+        # self.assertEqual(str(tale['dataSet'][0]['itemId']), data_dir['_id'])
+        # self.assertEqual(tale['dataSet'][0]['mountPath'], '/' + data_dir['name'])
         self.model('tale', 'wholetale').remove(tale)
 
     @mock.patch('gwvolman.tasks.import_tale')

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -112,8 +112,12 @@ class Tale(AccessControlledModel):
             if 'narrative' not in tale:
                 tale['narrative'] = []
 
-        if tale.get('format', 0) < 4:
-            tale = self._migrate_format_lt_4(tale)
+        # TODO: migrate via external script
+        # if tale.get('format', 0) < 4:
+        #    tale = self._migrate_format_lt_4(tale)
+
+        if 'dataSet' not in tale:
+            tale['dataSet'] = []
 
         tale['format'] = _currentTaleFormat
         return tale

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -43,6 +43,44 @@ class Tale(AccessControlledModel):
                      'doi', 'publishedURI', 'workspaceId'} | self.modifiableFields))
         self.exposeFields(level=AccessType.ADMIN, fields={'published'})
 
+    @staticmethod
+    def _migrate_format_lt_2(tale):
+        data_folder = getOrCreateRootFolder(DATADIRS_NAME)
+        try:
+            origFolder = Folder().load(tale['folderId'], force=True, exc=True)
+        except ValidationException:
+            raise GirderException(
+                ('Tale ({_id}) references folder ({folderId}) '
+                 'that does not exist').format(**tale))
+        if origFolder.get('creatorId'):
+            creator = User().load(origFolder['creatorId'], force=True)
+        else:
+            creator = None
+        tale['involatileData'] = [
+            {'type': 'folder', 'id': tale.pop('folderId')}
+        ]
+        newFolder = Folder().copyFolder(
+            origFolder, parent=data_folder, parentType='folder',
+            name=str(tale['_id']), creator=creator, progress=False)
+        tale['folderId'] = newFolder['_id']
+        return tale
+
+    @staticmethod
+    def _migrate_format_lt_4(tale):
+        old_data = tale.pop('involatileData')
+        tale['dataSet'] = []
+        for entry in old_data:
+            if entry['type'] == 'folder':
+                obj = Folder().load(entry['id'], force=True)
+            elif entry['type'] == 'item':
+                obj = Item().load(entry['id'], force=True)
+            tale['dataSet'].append({
+                'itemId': obj['_id'],
+                'mountPath': '/' + obj['name'],
+                '_modelType': entry['type']}
+            )
+        return tale
+
     def validate(self, tale):
         if 'iframe' not in tale:
             tale['iframe'] = False
@@ -58,44 +96,25 @@ class Tale(AccessControlledModel):
             workspace = self.createWorkspace(tale, creator=creator)
             tale['workspaceId'] = workspace['_id']
 
+        if 'doi' not in tale:
+            tale['doi'] = None
+
+        if 'publishedURI' not in tale:
+            tale['publishedURI'] = None
+
         if tale.get('format', 0) < 2:
-            data_folder = getOrCreateRootFolder(DATADIRS_NAME)
-            try:
-                origFolder = Folder().load(tale['folderId'], force=True, exc=True)
-            except ValidationException:
-                raise GirderException(
-                    ('Tale ({_id}) references folder ({folderId}) '
-                     'that does not exist').format(**tale))
-            if origFolder.get('creatorId'):
-                creator = User().load(origFolder['creatorId'], force=True)
-            else:
-                creator = None
-            tale['involatileData'] = [
-                {'type': 'folder', 'id': tale.pop('folderId')}
-            ]
-            newFolder = Folder().copyFolder(
-                origFolder, parent=data_folder, parentType='folder',
-                name=str(tale['_id']), creator=creator, progress=False)
-            tale['folderId'] = newFolder['_id']
+            tale = self._migrate_format_lt_2(tale)
+
         if tale.get('format', 0) < 3:
             if 'narrativeId' not in tale:
                 default = self.createNarrativeFolder(tale, default=True)
                 tale['narrativeId'] = default['_id']
             if 'narrative' not in tale:
                 tale['narrative'] = []
+
         if tale.get('format', 0) < 4:
-            old_data = tale.pop('involatileData')
-            tale['dataSet'] = []
-            for entry in old_data:
-                if entry['type'] == 'folder':
-                    obj = Folder().load(entry['id'], force=True)
-                elif entry['type'] == 'item':
-                    obj = Item().load(entry['id'], force=True)
-                tale['dataSet'].append(
-                    {'itemId': obj['_id'], 'mountPath': '/' + obj['name']}
-                )
-            tale['doi'] = None
-            tale['publishedURI'] = None
+            tale = self._migrate_format_lt_4(tale)
+
         tale['format'] = _currentTaleFormat
         return tale
 

--- a/server/schema/tale.py
+++ b/server/schema/tale.py
@@ -41,6 +41,10 @@ taleModel = {
         "dataSet": {
             "$ref": "#/definitions/dataSet"
         },
+        "workspaceId": {
+            "type": "string",
+            "description": "ID of a folder containing Tale's workspace"
+        },
         "narrative": {
             "type": "array",
             "items": {


### PR DESCRIPTION
This is alternative approach to fix #225. Instead of creating a separate `/workspace` endpoint, we might as well query Tales directly as long as we get what we need: the id of a workspace.

### How to test?
1. Create a bunch of Tales
1. Using Girder's Swagger page call GET /tale. Verify that:
each returned object's `workspaceId` corresponds to a proper folder `_id` in `/collections/WholeTale Workspaces/WholeTale Workspaces`.