### PR TITLE
Allow to copy Tales

### DIFF
--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -999,6 +999,7 @@ class TaleWithWorkspaceTestCase(base.TestCase):
 
     def testTaleCopy(self):
         from girder.plugins.wholetale.models.tale import Tale
+        from girder.plugins.wholetale.constants import TaleStatus
         from girder.plugins.jobs.models.job import Job
         from girder.plugins.jobs.constants import JobStatus
         tale = Tale().createTale(
@@ -1033,6 +1034,8 @@ class TaleWithWorkspaceTestCase(base.TestCase):
         self.assertEqual(new_tale['copyOfTale'], str(tale['_id']))
         self.assertEqual(new_tale['imageId'], str(tale['imageId']))
         self.assertEqual(new_tale['creatorId'], str(self.user['_id']))
+        # TODO: Delay job execution somehow
+        # self.assertEqual(new_tale['status'], TaleStatus.PREPARING)
 
         copied_file_path = re.sub(workspace['name'], new_tale['_id'], fullPath)
         job = Job().findOne({'type': 'wholetale.copy_workspace'})
@@ -1062,6 +1065,7 @@ class TaleWithWorkspaceTestCase(base.TestCase):
 
             time.sleep(0.1)
         self.assertTrue(os.path.isfile(copied_file_path))
+        self.assertEqual(new_tale['status'], TaleStatus.READY)
 
         Tale().remove(new_tale)
         Tale().remove(tale)

--- a/server/constants.py
+++ b/server/constants.py
@@ -65,3 +65,9 @@ class ImageStatus(object):
 
         return status in (ImageStatus.INVALID, ImageStatus.UNAVAILABLE,
                           ImageStatus.BUILDING, ImageStatus.AVAILABLE)
+
+
+class TaleStatus(object):
+    PREPARING = 0
+    READY = 1
+    ERROR = 2

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -41,7 +41,7 @@ class Tale(AccessControlledModel):
             fields=({'_id', 'folderId', 'imageId', 'creatorId', 'created',
                      'format', 'dataSet', 'narrative', 'narrativeId', 'licenseSPDX',
                      'imageInfo', 'publishInfo', 'workspaceId',
-                     'workspaceModified', 'dataSetCitation'} | self.modifiableFields))
+                     'workspaceModified', 'dataSetCitation', 'copyOfTale'} | self.modifiableFields))
 
     def validate(self, tale):
         if 'iframe' not in tale:
@@ -67,6 +67,11 @@ class Tale(AccessControlledModel):
 
         if tale.get('dataSetCitation') is None:
             tale['dataSetCitation'] = []
+
+        if 'copyOfTale' not in tale:
+            tale['copyOfTale'] = None
+
+        tale['format'] = _currentTaleFormat
 
         if not isinstance(tale['authors'], list):
             tale['authors'] = []
@@ -122,6 +127,7 @@ class Tale(AccessControlledModel):
             'authors': authors,
             'category': category,
             'config': config or {},
+            'copyOfTale': None,
             'creatorId': creatorId,
             'dataSet': data or [],
             'description': description,

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -406,6 +406,7 @@ class Tale(Resource):
         .errorResponse('ID was invalid.')
         .errorResponse('You are not authorized to copy this tale.', 403)
     )
+    @filtermodel(model='tale', plugin='wholetale')
     def copyTale(self, tale):
         user = self.getCurrentUser()
         image = self.model('image', 'wholetale').load(

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -13,6 +13,7 @@ from girder.utility.path import getResourcePath
 from girder.utility.progress import ProgressContext
 from girder.models.token import Token
 from girder.models.folder import Folder
+from girder.plugins.jobs.models.job import Job
 from girder.plugins.jobs.constants import REST_CREATE_JOB_TOKEN_SCOPE
 from gwvolman.tasks import import_tale
 
@@ -45,6 +46,7 @@ class Tale(Resource):
         self.route('PUT', (':id',), self.updateTale)
         self.route('POST', (), self.createTale)
         self.route('POST', ('import', ), self.createTaleFromDataset)
+        self.route('POST', (':id', 'copy'), self.copyTale)
         self.route('DELETE', (':id',), self.deleteTale)
         self.route('GET', (':id', 'access'), self.getTaleAccess)
         self.route('PUT', (':id', 'access'), self.updateTaleAccess)
@@ -395,3 +397,47 @@ class Tale(Resource):
             tale = self.model('tale', 'wholetale').load(taleId, force=True)
             tale['workspaceModified'] = int(time.time())
             self.model('tale', 'wholetale').save(tale)
+
+    @access.user
+    @autoDescribeRoute(
+        Description('Copy a tale.')
+        .modelParam('id', model='tale', plugin='wholetale', level=AccessType.READ)
+        .responseClass('tale')
+        .errorResponse('ID was invalid.')
+        .errorResponse('You are not authorized to copy this tale.', 403)
+    )
+    def copyTale(self, tale):
+        user = self.getCurrentUser()
+        image = self.model('image', 'wholetale').load(
+            tale['imageId'], user=user, level=AccessType.READ, exc=True)
+        default_author = ' '.join((user['firstName'], user['lastName']))
+        new_tale = self._model.createTale(
+            image, tale['dataSet'], creator=user, save=True,
+            title=tale.get('title'), description=tale.get('description'),
+            public=False, config=tale.get('config'),
+            icon=image.get('icon', ('https://raw.githubusercontent.com/'
+                                    'whole-tale/dashboard/master/public/'
+                                    'images/whole_tale_logo.png')),
+            illustration=tale.get(
+                'illustration', ('https://raw.githubusercontent.com/'
+                                 'whole-tale/dashboard/master/public/'
+                                 'images/demo-graph2.jpg')),
+            authors=tale.get('authors', default_author),
+            category=tale.get('category', 'science'),
+            narrative=tale.get('narrative'),
+            licenseSPDX=tale.get('licenseSPDX'),
+        )
+        new_tale['copyOfTale'] = tale['_id']
+        new_tale = self._model.save(new_tale)
+        # asynchronously copy the workspace of a source Tale
+        tale_workspaceId = self._model.createWorkspace(tale)['_id']
+        new_tale_workspaceId = self._model.createWorkspace(new_tale)['_id']
+        job = Job().createLocalJob(
+            title='Copy "{title}" workspace'.format(**tale), user=user,
+            type='wholetale.copy_workspace', public=False, async=True,
+            module='girder.plugins.wholetale.tasks.copy_workspace',
+            args=(tale_workspaceId, new_tale_workspaceId),
+            kwargs={'user': user}
+        )
+        Job().scheduleJob(job)
+        return new_tale

--- a/server/schema/tale.py
+++ b/server/schema/tale.py
@@ -117,7 +117,11 @@ taleModel = {
         },
         "publishInfo": {
             "$ref": "#/definitions/publishInfo"
-        }
+        },
+        "copyOfTale": {
+            "type": ["string", "null"],
+            "description": "An ID of a source Tale, if the Tale is a copy."
+        },
     },
     'example': {
         "_accessLevel": 2,
@@ -137,6 +141,7 @@ taleModel = {
         ],
         "category": "science",
         "config": {},
+        "copyOfTale": "5c4887409759c200017b231f",
         "created": "2019-01-23T15:24:48.217000+00:00",
         "creatorId": "5c4887149759c200017b22c0",
         "dataSet": [

--- a/server/tasks/copy_workspace.py
+++ b/server/tasks/copy_workspace.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+import traceback
+from girder.constants import AccessType
+from girder.models.folder import Folder
+from girder.plugins.jobs.constants import JobStatus
+from girder.plugins.jobs.models.job import Job
+
+
+def run(job):
+    jobModel = Job()
+    jobModel.updateJob(job, status=JobStatus.RUNNING)
+
+    src_workspace_id, dest_workspace_id = job['args']
+    user = job['kwargs']['user']
+
+    try:
+        parent = Folder().load(src_workspace_id, user=user, exc=True, level=AccessType.READ)
+        workspace = Folder().load(dest_workspace_id, user=user, exc=True)
+        Folder().copyFolderComponents(parent, workspace, user, None)
+        jobModel.updateJob(job, status=JobStatus.SUCCESS, log="Copying finished")
+    except Exception:
+        t, val, tb = sys.exc_info()
+        log = '%s: %s\n%s' % (t.__name__, repr(val), traceback.extract_tb(tb))
+        jobModel.updateJob(job, status=JobStatus.ERROR, log=log)
+        raise

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,4 +54,4 @@ exclude: girder/external/*
 #     N803 - Argument name should be lowercase.
 #     N806 - Variable in function should be lowercase.
 #     N812 - Lowercase imported as non lowercase.
-ignore: D100,D101,D102,D103,D104,D105,D107,D200,D201,D202,D203,D204,D205,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812
+ignore: D100,D101,D102,D103,D104,D105,D107,D200,D201,D202,D203,D204,D205,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812, W606


### PR DESCRIPTION
This PR implements required backend functionality for "Copy on Launch" feature. It:
1. adds `POST /tale/:id/copy` endpoint
1. introduces TaleStatus:
    * `PREPARING` - workspace is being copied
    * `READY` - workspace has been copied
    * `ERROR` - workspace failed to be copied

### How to test?
1. Deploy https://github.com/whole-tale/wt_home_dirs/pull/22
1. Create a Tale (preferably as user A)
1. Upload/create some content in the workspace
1. Call `POST /tale/:id/copy` using API (preferably as user B)
1. Confirm that new tale is created and:
    * it's not public
    * it's created and owned by user issuing POST request (user B)
    * its workspace has the same content as the original tale's workspace

### Notes
1. UI can determine whether the operation of copying has finished by:
    1. Listening for `job_status` event and filtering using `type` (*"wholetale.copy_workspace"*) and job's 2nd argument (needs to match new tale's "workspaceId")
    1. Polling Tale status
1. It would be useful to merge https://github.com/whole-tale/girder_wholetale/pull/228 prior to this PR