### PR TITLE
Use '_modelType' in dataset model for consistency

### DIFF
--- a/plugin_tests/harvester_test.py
+++ b/plugin_tests/harvester_test.py
@@ -303,8 +303,8 @@ class DataONEHarversterTestCase(base.TestCase):
         resp = self.request('/dataset', method='GET', user=self.user)
         self.assertStatusOk(resp)
         self.assertEqual(len(resp.json), 2)
-        folder_ds = next(_ for _ in resp.json if _['modelType'] == 'folder')
-        item_ds = next(_ for _ in resp.json if _['modelType'] == 'item')
+        folder_ds = next(_ for _ in resp.json if _['_modelType'] == 'folder')
+        item_ds = next(_ for _ in resp.json if _['_modelType'] == 'item')
 
         resp = self.request('/dataset/{}'.format(item_ds['_id']), method='GET',
                             user=self.user)

--- a/server/rest/dataset.py
+++ b/server/rest/dataset.py
@@ -21,7 +21,7 @@ datasetModel = {
     "description": "Object representing registered data.",
     "required": [
         "_id",
-        "modelType"
+        "_modelType"
     ],
     "properties": {
         "_id": {
@@ -35,7 +35,7 @@ datasetModel = {
         "description": {
             "type": "string"
         },
-        "modelType": {
+        "_modelType": {
             "type": "string",
             "description": "Model of the object.",
             "enum": [
@@ -84,7 +84,6 @@ def _itemOrFolderToDataset(obj):
     ds = {key: obj[key] for key in obj.keys() & datasetModelKeys}
     ds['provider'] = obj['meta'].get('provider', 'unknown')
     ds['identifier'] = obj['meta'].get('identifier', 'unknown')
-    ds['modelType'] = obj['_modelType']
     return ds
 
 
@@ -160,7 +159,7 @@ class Dataset(Resource):
     )
     def copyDatasetToHome(self, id, dataset, params):
         user = self.getCurrentUser()
-        modelType = dataset['modelType']
+        modelType = dataset['_modelType']
         user_target_resource = path_util.lookUpPath(
             '/user/%s/Data' % user['login'], user)
         user_folder = user_target_resource['document']


### PR DESCRIPTION
It seems that `dataset` is the only model that uses a `modelType` field instead of a `_modelType` like everything else. Not sure what I had in mind when I wrote it down...