### PR TITLE
Add a method for removing entries from the user's myData field

### DIFF
--- a/plugin_tests/dataset_test.py
+++ b/plugin_tests/dataset_test.py
@@ -96,3 +96,13 @@ class DatasetTestCase(base.TestCase):
         self.assertStatusOk(resp)
         ds = resp.json
         self.assertEqual(len(ds), 2)
+
+        resp = self.request(
+            path='/dataset/{_id}'.format(**ds[0]), method='DELETE', user=self.user)
+        self.assertStatusOk(resp)
+
+        resp = self.request(
+            path='/dataset', method='GET', user=self.user, params={'myData': True})
+        self.assertStatusOk(resp)
+        ds = resp.json
+        self.assertEqual(len(ds), 1)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -347,4 +347,4 @@ def load(info):
     info['apiRoot'].user.route('PUT', ('settings',), setUserMetadata)
     info['apiRoot'].user.route('GET', ('settings',), getUserMetadata)
     ModelImporter.model('user').exposeFields(
-        level=AccessType.WRITE, fields=('meta',))
+        level=AccessType.WRITE, fields=('meta', 'myData'))


### PR DESCRIPTION
Allow to remove entries from user's `myData` via `DELETE /dataset/:id`

### How to test?
1. Register two datasets
2. Confirm they're linked to user model by using `GET /dataset?myData=true`
3. Use `DELETE /dataset/:id` with one of the ids from 2.
4. Confirm that `GET /dataset?myData=true` returns one dataset

Alternative:
1. Enable "Remove" in Manage > Data and see if it works :-)