### PR TITLE
Ensure that images are build on head node. Fixes #237

### DIFF
--- a/server/rest/image.py
+++ b/server/rest/image.py
@@ -297,7 +297,8 @@ class Image(Resource):
             title=jobTitle, type='build_image', handler='worker_handler',
             user=user, public=False, args=args, kwargs={},
             otherFields={
-                'celeryTaskName': 'gwvolman.tasks.build_image'
+                'celeryTaskName': 'gwvolman.tasks.build_image',
+                'celeryQueue': 'manager'
             })
         jobModel.scheduleJob(job)
         return job


### PR DESCRIPTION
Use proper queue.

### How to test?
1. Set up a proper docker swarm with at least one master and one slave.
2. Run celery_worker with proper queues on each of them (manager on master, celery on slave).
3. Build an image.