### PR TITLE
Set proper ACLs on Tale folders

### DIFF
--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -325,9 +325,8 @@ class TaleTestCase(base.TestCase):
             user=self.user, params={'access': json.dumps(input_tale_access)})
         self.assertStatusOk(resp)
         # Check that the returned access control list for the tale is as expected
+        tale = resp.json
         result_tale_access = resp.json['access']
-        result_image_id = resp.json['imageId']
-        result_folder_id = resp.json['folderId']
         expected_tale_access = {
             "groups": [],
             "users": [
@@ -346,23 +345,24 @@ class TaleTestCase(base.TestCase):
         self.assertEqual(result_tale_access, expected_tale_access)
         # Check that the access control list propagated to the image that the tale
         # was built from
-        resp = self.request(
-            path='/image/%s/access' % result_image_id, method='GET',
-            user=self.user)
-        self.assertStatusOk(resp)
-        result_image_access = resp.json
-        expected_image_access = input_tale_access
-        self.assertEqual(result_image_access, expected_image_access)
+        # resp = self.request(
+        #     path='/image/%s/access' % result_image_id, method='GET',
+        #     user=self.user)
+        # self.assertStatusOk(resp)
+        # result_image_access = resp.json
+        # expected_image_access = input_tale_access
+        # self.assertEqual(result_image_access, expected_image_access)
 
         # Check that the access control list propagated to the folder that the tale
         # is associated with
-        resp = self.request(
-            path='/folder/%s/access' % result_folder_id, method='GET',
-            user=self.user)
-        self.assertStatusOk(resp)
-        result_folder_access = resp.json
-        expected_folder_access = input_tale_access
-        self.assertEqual(result_folder_access, expected_folder_access)
+        for key in ('folderId', 'workspaceId'):
+            resp = self.request(
+                path='/folder/%s/access' % tale[key], method='GET',
+                user=self.user)
+            self.assertStatusOk(resp)
+            result_folder_access = resp.json
+            expected_folder_access = input_tale_access
+            self.assertEqual(result_folder_access, expected_folder_access)
 
         # Update the access control list of a tale that was generated from an image that the user
         # does not have admin access to
@@ -494,14 +494,14 @@ class TaleTestCase(base.TestCase):
         tale = self.model('tale', 'wholetale').save(tale)  # get's id
         tale = self.model('tale', 'wholetale').save(tale)  # migrate to new format
 
-        path = os.path.join(
-            '/collection', DATADIRS_NAME, DATADIRS_NAME, str(tale['_id']))
-        resp = self.request(
-            path='/resource/lookup', method='GET', user=self.user,
-            params={'path': path})
-        self.assertStatusOk(resp)
-        new_data_dir = resp.json
-        self.assertEqual(str(tale['folderId']), str(new_data_dir['_id']))
+        # path = os.path.join(
+        #     '/collection', DATADIRS_NAME, DATADIRS_NAME, str(tale['_id']))
+        # resp = self.request(
+        #    path='/resource/lookup', method='GET', user=self.user,
+        #    params={'path': path})
+        # self.assertStatusOk(resp)
+        # new_data_dir = resp.json
+        # self.assertEqual(str(tale['folderId']), str(new_data_dir['_id']))
         self.assertEqual(tale['dataSet'], [])
         # self.assertEqual(str(tale['dataSet'][0]['itemId']), data_dir['_id'])
         # self.assertEqual(tale['dataSet'][0]['mountPath'], '/' + data_dir['name'])

--- a/scripts/tale_acls_fix.py
+++ b/scripts/tale_acls_fix.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env girder-shell
+# -*- coding: utf-8 -*-
+
+"""Ensure that Tales' ACLs match Tale's folders ACLs.
+
+See https://github.com/whole-tale/girder_wholetale/pull/243
+
+Example:
+
+    $ ./tale_acls_fix.py
+
+"""
+
+from girder.models.folder import Folder
+from girder.models.user import User
+from girder.plugins.wholetale.models.tale import Tale
+
+
+for tale in list(Tale().find()):
+    creator = User().load(tale['creatorId'], force=True)
+    access = Tale().getFullAccessList(tale)
+    currentFlags = tale.get('publicFlags', [])
+    if 'workspaceId' not in tale:
+        workspace = Tale().createWorkspace(tale, creator=creator)
+        tale['workspaceId'] = workspace['_id']
+        tale = Tale().save(tale)
+    else:
+        workspace = Folder().load(tale['workspaceId'], force=True)
+        workspace = Folder().setAccessList(
+            workspace, access, user=creator, save=True, force=True, recurse=True,
+            setPublic=tale['public'], publicFlags=currentFlags)
+
+    if 'narrativeId' not in tale:
+        narrative_folder = Tale().createNarrativeFolder(
+            tale, creator=creator, default=not bool(tale.get('narrative', [])))
+        tale['narrativeId'] = narrative_folder['_id']
+        tale = Tale().save(tale)
+    else:
+        narrative_folder = Folder().load(tale['narrativeId'], force=True)
+        if narrative_folder['name'] != 'default':
+            narrative_folder = Folder().setAccessList(
+                narrative_folder, access, user=creator, save=True, force=True, recurse=True,
+                setPublic=tale['public'], publicFlags=currentFlags)
+    # 'folderId' is obsolete ignore it.

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -4,16 +4,13 @@ import datetime
 
 from bson.objectid import ObjectId
 
-from .image import Image
 from ..constants import WORKSPACE_NAME, DATADIRS_NAME, SCRIPTDIRS_NAME
 from ..utils import getOrCreateRootFolder
 from girder.models.model_base import AccessControlledModel
 from girder.models.item import Item
 from girder.models.folder import Folder
-from girder.models.user import User
 from girder.constants import AccessType
-from girder.exceptions import \
-    AccessException, GirderException, ValidationException
+from girder.exceptions import AccessException
 
 
 # Whenever the Tale object schema is modified (e.g. fields are added or
@@ -252,17 +249,5 @@ class Tale(AccessControlledModel):
                 Folder().setAccessList(
                     folder, access, user=user, save=save, force=force, recurse=True,
                     setPublic=setPublic, publicFlags=publicFlags)
-
-        try:
-            image = Image().load(
-                doc['imageId'], user=user, level=AccessType.ADMIN)
-            Image().setAccessList(
-                image, access, user=user, save=save, force=force,
-                setPublic=setPublic, publicFlags=publicFlags)
-        except AccessException:
-            # TODO: Information about that should be returned to the user,
-            # For now we allow this operation to succeed since all our Images
-            # are public.
-            pass
 
         return doc


### PR DESCRIPTION
This PR:
1. Ensures that ACLs on `workspaceId`, `narrativeId` and `folderId` are the same as on Tale itself.
1. No longer changes ACLs on Images.
1. Disables automatic Tale format migration. Required changes are usually a one time things, and this adds unnecessary complexity to `Tale().validate()` method.

### How to test?
1. Create a private Tale as user A, put something into workspace directory.
2. Make it public.
3. Try running a Tale as user B.
4. Access Workspace and confirm it's readonly.
