### PR TITLE
Http provider lookup bugfixes. Fixes #246

### DIFF
--- a/server/lib/http_provider.py
+++ b/server/lib/http_provider.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 from girder.utility.model_importer import ModelImporter
 
 from .import_providers import ImportProvider
+from .resolvers import DOIResolver
 from .entity import Entity
 from .data_map import DataMap
 from .file_map import FileMap
@@ -20,7 +21,7 @@ class HTTPImportProvider(ImportProvider):
         return re.compile(r'^http(s)?://.*')
 
     def lookup(self, entity: Entity) -> DataMap:
-        pid = entity.getValue()
+        pid = DOIResolver.follow_redirects(entity.getValue())
         url = urlparse(pid)
         if url.scheme not in ('http', 'https'):
             # This should be redundant. This should only be called if matches()

--- a/server/lib/http_provider.py
+++ b/server/lib/http_provider.py
@@ -30,9 +30,7 @@ class HTTPImportProvider(ImportProvider):
         headers = requests.head(
             pid, headers={'Accept-Encoding': 'identity'}).headers
 
-        valid_target = headers.get('Content-Type') is not None
-        valid_target = valid_target and \
-            ('Content-Length' in headers or 'Content-Range' in headers)
+        valid_target = 'Content-Length' in headers or 'Content-Range' in headers
         if not valid_target:
             raise Exception('Failed to get size for %s' % pid)
 


### PR DESCRIPTION
This PR introduces 2 changes to http resolver:

1. *Content-Type* header is no longer a hard requirement for looking up urls, since we already default to `application-octet/stream` if header is not present during the registration stage.
1. Url provided by the user is checked for http redirects and only final url is used for creating a dataMap.

NOTE: This PR is necessary to properly recreate the LIGO Tale.

### How to test?
1. Try registering: `https://losc.ligo.org/s/events/GW170104/H-H1_LOSC_4_V1-1167559920-32.hdf5`