### PR TITLE
Filter Workspace fields in a same way as Folders. Fixes #242

### DIFF
--- a/plugin_tests/workspace_test.py
+++ b/plugin_tests/workspace_test.py
@@ -43,7 +43,7 @@ class WorkspaceTestCase(base.TestCase):
     def testListingWorkspaces(self):
         resp = self.request(path='/workspace', method='GET', user=self.user)
         self.assertStatus(resp, 200)
-        self.assertEqual(resp.json[0]['lowerName'], self.tale_one['title'].lower())
+        self.assertEqual(resp.json[0]['name'], self.tale_one['title'])
         self.assertEqual(resp.json[1]['name'], self.tale_two['title'])
         workspace_one = resp.json[0]
         workspace_two = resp.json[1]

--- a/server/rest/workspace.py
+++ b/server/rest/workspace.py
@@ -60,6 +60,7 @@ class Workspace(Resource):
                 folder['_modelType'] = 'folder'
                 folder['name'] = tale['title']
                 folder['lowerName'] = folder['name'].lower()
+                folder = Folder().filter(folder, self.getCurrentUser())
                 workspaces.append(folder)
 
         return workspaces
@@ -97,4 +98,4 @@ class Workspace(Resource):
         folder['_modelType'] = 'folder'
         folder['name'] = tale['title']
         folder['lowerName'] = folder['name'].lower()
-        return folder
+        return Folder().filter(folder, user)


### PR DESCRIPTION
Workspace endpoints were returning raw, instead of filtered by user's access level, objects. It's fixed by applying native Folder's `filter()` method. This may (or may not) affect https://github.com/whole-tale/dashboard/pull/406.

### How to test?
1. Inspect output of `GET /workspace` and make sure:
   1. `_accessLevel` is present
   1. `access` is not present
