### PR TITLE
jsTree Integration

### DIFF
--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -340,7 +340,8 @@ class Tale(Resource):
         current_user = self.getCurrentUser()
         # Generate the Workspace Tree
         workspace_folder = self.model('folder').load(tale['workspaceId'],
-                                                     user=current_user)
+                                                     user=current_user,
+                                                     level=AccessType.READ))
 
         # This folder doesn't have a name, so set it to the Workspace name
         workspace_folder['name'] = 'Workspace'
@@ -352,8 +353,8 @@ class Tale(Resource):
         data_folder = create_tree_record(None, 'Data', 'linkify', None)
         for data_item in tale['dataSet']:
             loaded_obj = self.model(data_item['_modelType']).load(data_item['itemId'],
-                                                                  force=True,
-                                                                  user=current_user)
+                                                                  user=current_user,
+                                                                  level=AccessType.READ)
             data_folder['children'].append(create_tree_from_root(loaded_obj,
                                                                  current_user,
                                                                  data_item['_modelType'],

--- a/server/utils.py
+++ b/server/utils.py
@@ -39,3 +39,72 @@ def esc(value):
     :rtype: str
     """
     return urllib.parse.quote_plus(value)
+
+
+def create_tree_record(object_id, name, model, parent_id):
+    """
+    Node records make up the jsTree, and are added to the 'children'
+    attribute. This method takes the needed parameters to make a
+    full node. The icon attribute maps to an icon in the dashboard,
+    which is why we append icon to the end. The possibilites are
+    'folder icon', 'file icon', and 'linkify icon' (for the data directory)
+
+    :param object_id: The ID of the node
+    :param name: The name of the node
+    :param model: The node's model
+    :param parent_id: The potential parent
+    :return: A record describing a node
+    """
+    if model == 'item':
+        model = 'file'
+    record = {
+        'id': object_id,
+        'text': name,
+        'icon': model + ' icon',
+        'state': {
+            'opened': False,
+            'disabled': False,
+            'selected': True
+        },
+        'children': [],
+        'li_attr': {},
+        'a_attr': {}
+    }
+
+    if parent_id:
+        record['parent'] = parent_id
+    return record
+
+
+def create_tree_from_root(root, user, model_type, is_root=False):
+    """
+    Recursively constructs a tree conforming to jsTree's JSON format
+    :param root: The root node that the tree starts at
+    :param user: The logged in user
+    :param model_type: The type of object being described
+    :param model_type: The type of object being described
+    :param is_root: Set to true when there shouldn't be a parent node
+    :return: A record for a node
+    """
+
+    record = create_tree_record(str(root['_id']),
+                                root['name'],
+                                model_type,
+                                None if is_root else str(root['parentId']))
+    records = list()
+    records.append(record)
+    folders = ModelImporter.model('folder').childFolders(root,
+                                                         parentType='folder',
+                                                         user=user)
+    for folder in folders:
+        record['children'].append(create_tree_from_root(folder,
+                                                        user,
+                                                        'folder'))
+    child_files = ModelImporter.model('folder').childItems(folder=root, user=user)
+    for child_file in child_files:
+        file_record = create_tree_record(str(child_file['_id']),
+                                         child_file['name'],
+                                         'file',
+                                         str(child_file['folderId']))
+        record['children'].append(file_record)
+    return record


### PR DESCRIPTION
I put the logic in the Tale rest endpoint, but I'm open to suggestions about moving `create_tree_from_root` and `create_tree_record` elsewhere (maybe utils?). Linked to #248 


## Test Steps
The most sensible way to test this to use the UI however, the file picker is only used in publishing (but the original code resides in master). 
![u1lm1mkvym](https://user-images.githubusercontent.com/9289652/53615826-ade25280-3b94-11e9-9788-2facd68fd9dc.gif)


The JSON can still be checked by directly querying the endpoint.
   1. Create a Tale with a single folder in the workspace
   2. Add a file to the folder
   3. Add a dataset to the Tale
   4. Navigate to the `treeStructure` in Girder 
      Or `curl -X GET --header 'Accept: application/json' --header 'Girder-Token:<TOKEN>' 'https://girder.local.wholetale.org/api/v1/tale/<TALE_ID>/treeStructure'`
   5. Make sure that the nodes have the proper `children` attributes as well as names



## To Do:
I still need to write unit tests for this, which should consist of creating some mock folders with children and ensuring the output was expected.
- [x] Unit Tests


Tests are completed- I think the failure was a false positive on Dataverse integration?