### PR TITLE
Refactor the export endpoint to conform to new spec

### DIFF
--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -320,8 +320,8 @@ class ManifestTestCase(base.TestCase):
                 },
             },
             {'uri': '../LICENSE', 'schema:license': 'CC-BY-4.0'},
-            # {'uri': '../README.txt', '@type': 'schema:HowTo'},
-            # {'uri': '../environment.txt'},
+            {'uri': '../README.txt', '@type': 'schema:HowTo'},
+            {'uri': '../environment.txt'},
         ]
         from operator import itemgetter
 

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -325,10 +325,10 @@ class Manifest:
                                                 self.tale.get('licenseSPDX',
                                                               WholeTaleLicense.default_spdx())})
 
-        # self.manifest['aggregates'].append({'uri': '../README.txt',
-        #                                     '@type': 'schema:HowTo'})
+        self.manifest['aggregates'].append({'uri': '../README.txt',
+                                            '@type': 'schema:HowTo'})
 
-        # self.manifest['aggregates'].append({'uri': '../environment.txt'})
+        self.manifest['aggregates'].append({'uri': '../environment.txt'})
 
 
 def clean_workspace_path(tale_id, path):

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -287,7 +287,9 @@ class Tale(Resource):
             zip_generator = ziputil.ZipGenerator(zip_name)
 
             # Add files from the workspace
-            folder = self.model('folder').load(tale['workspaceId'], user=user)
+            folder = self.model('folder').load(tale['workspaceId'],
+                                               user=user,
+                                               force=True)
             for (path, f) in self.model('folder').fileList(folder,
                                                            user=user,
                                                            subpath=False):

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import re
 import json
 
 from girder.api import access
@@ -324,7 +323,7 @@ class Tale(Resource):
             for data in zip_generator.addFile(lambda: next(license_object)['text'],
                                               'LICENSE'):
                 yield data
-                
+
             yield zip_generator.footer()
 
         return stream

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -275,7 +275,7 @@ class Tale(Resource):
 
         # Construct a sanitized name for the ZIP archive using a whitelist
         # approach
-        zip_name = re.sub('[^a-zA-Z0-9-]', '_', tale['title'])
+        zip_name = str(tale['_id'])
 
         setResponseHeader('Content-Type', 'application/zip')
         setContentDisposition(zip_name + '.zip')


### PR DESCRIPTION
This PR builds off of the work done in `tale_manifest` that creates a structured zip file that represents a Tale.

I'm not sure how to unit test this, but I'm open to suggestions.

To Use:
   1. Create a tale with a workspace and external data
   2. Navigate to the Girder API page
   3. Scroll down to the export endpoint under tale
   4. Paste your Tale ID in the box
   5. Request the zip
   6. Copy + Paste the curl command into the terminal
   7. Add -JO before -X
   8. Execute the command and unzip the Tale

To DO:
- [x] Rename folder to the Tale's ID
- [x] Unit Tests