### PR TITLE
Temporary hack to build up the correct image format when restarting

### DIFF
--- a/server/models/instance.py
+++ b/server/models/instance.py
@@ -85,12 +85,22 @@ class Instance(AccessControlledModel):
         :type image: dict
         :returns: The instance document that was edited.
         """
+        
+        # Strip the registry info out (instance launcher now adds this)
+        segments = digest.split('/')
+        registry = segments[0]
+        
+        # Make sure to include imgId, patchNumber, and shaHash
+        imgId = segments[1]
+        segments = segments[2].split('@')
+        patchNumber = segments[0]           # this is new
+        shaHash = segments[1]
 
         instanceTask = update_container.signature(
             args=[str(instance['_id'])], queue='manager',
             kwargs={
                 'girder_client_token': str(token['_id']),
-                'image': str(imageId) + '@' + str(digest)
+                'image': str(imgId) + '/' + str(patchNumber) + '@' + str(shaHash)
             }
         ).apply_async()
         instanceTask.get(timeout=TASK_TIMEOUT)

--- a/server/rest/instance.py
+++ b/server/rest/instance.py
@@ -148,7 +148,7 @@ class Instance(Resource):
             instance,
             self.getCurrentToken(),
             image['_id'],
-            image['digest'])
+            tale['imageInfo']['digest'])
         return instance
 
     @access.user


### PR DESCRIPTION
### Problem
Our current restart endpoint expects the `image` to have a `digest` field. @craig-willis' upcoming PR will move this to be a part of the `tale.imageInfo` object instead.

Furthermore, the `gwvolman` restart task assumes and injects the registry info (as a precaution to prevent arbitrary containers from launching). 

### Approach
This quick hack updates the `PUT /tale/:id` endpoint to accommodate this change. This also temporarily strips out the registry info before sending it to `gwvolman`.

We should probably discuss the expected long-term format for these operations, as we seem to have digressed.

### How to Test
Prerequisites:
1. Have at least 1 running Tale image
2. Run https://github.com/whole-tale/deploy-dev/tree/repo2docker
3. Comment out or remove all calls to `/image/:id/build`, as this endpoint no longer exists
4. `make clean && make dev`

Test Steps:
1. Checkout and run this branch locally, alongside https://github.com/whole-tale/gwvolman/pull/43
2. Hit the `PUT /instance/:id` endpoint via API
    * You should get a 200 back, instead of a stack trace