### PR TITLE
Add Tale licenses

### DIFF
--- a/plugin_tests/license_test.py
+++ b/plugin_tests/license_test.py
@@ -26,8 +26,7 @@ class RecipeTestCase(base.TestCase):
         resp = self.request(
             path='/license', method='GET',
             type='application/json')
-        print(resp.json)
-
+        
         # Make sure that we support CC0
         is_supported = all(x for x in resp.json if (x['spdx'] == 'CCO-1.0'))
         self.assertTrue(is_supported)

--- a/plugin_tests/license_test.py
+++ b/plugin_tests/license_test.py
@@ -1,0 +1,39 @@
+import httmock
+import json
+import os
+from girder.constants import AccessType
+from tests import base
+from .tests_helpers import \
+    GOOD_REPO, GOOD_COMMIT, \
+    mockOtherRequest, mockCommitRequest, mockReposRequest
+
+
+def setUpModule():
+    base.enabledPlugins.append('wholetale')
+    base.startServer()
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class RecipeTestCase(base.TestCase):
+
+    def setUp(self):
+        super(RecipeTestCase, self).setUp()
+
+    def testGetLicenses(self):
+        resp = self.request(
+            path='/license', method='GET',
+            type='application/json')
+        print(resp.json)
+
+        # Make sure that we support CC0
+        is_supported = all(x for x in resp.json if (x['spdx'] == 'CCO-1.0'))
+        self.assertTrue(is_supported)
+        # Make sure that we support CC-BY
+        is_supported = all(x for x in resp.json if (x['spdx'] == 'CC-BY-4.0'))
+        self.assertTrue(is_supported)
+
+    def tearDown(self):
+        super(RecipeTestCase, self).tearDown()

--- a/plugin_tests/license_test.py
+++ b/plugin_tests/license_test.py
@@ -1,11 +1,4 @@
-import httmock
-import json
-import os
-from girder.constants import AccessType
 from tests import base
-from .tests_helpers import \
-    GOOD_REPO, GOOD_COMMIT, \
-    mockOtherRequest, mockCommitRequest, mockReposRequest
 
 
 def setUpModule():
@@ -17,10 +10,10 @@ def tearDownModule():
     base.stopServer()
 
 
-class RecipeTestCase(base.TestCase):
+class LicenseTestCase(base.TestCase):
 
     def setUp(self):
-        super(RecipeTestCase, self).setUp()
+        super(LicenseTestCase, self).setUp()
 
     def testGetLicenses(self):
         resp = self.request(
@@ -34,5 +27,13 @@ class RecipeTestCase(base.TestCase):
         is_supported = all(x for x in resp.json if (x['spdx'] == 'CC-BY-4.0'))
         self.assertTrue(is_supported)
 
+    def testMinimumLicenses(self):
+        from server.lib.license import WholeTaleLicense
+        # Test that we're supporting a non-zero number of licenses
+        wholetale_license = WholeTaleLicense()
+        self.assertTrue(len(wholetale_license.get_defaults()) > 0)
+        self.assertTrue(len(wholetale_license.get_spdx() > 0))
+        self.assertTrue(len(WholeTaleLicense.default_spdx()) > 0)
+
     def tearDown(self):
-        super(RecipeTestCase, self).tearDown()
+        super(LicenseTestCase, self).tearDown()

--- a/plugin_tests/license_test.py
+++ b/plugin_tests/license_test.py
@@ -28,7 +28,7 @@ class RecipeTestCase(base.TestCase):
             type='application/json')
         
         # Make sure that we support CC0
-        is_supported = all(x for x in resp.json if (x['spdx'] == 'CCO-1.0'))
+        is_supported = all(x for x in resp.json if (x['spdx'] == 'CC0-1.0'))
         self.assertTrue(is_supported)
         # Make sure that we support CC-BY
         is_supported = all(x for x in resp.json if (x['spdx'] == 'CC-BY-4.0'))

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -127,7 +127,7 @@ class TaleTestCase(base.TestCase):
             '/collection/{cname}/{fname}/{_id}'.format(**sc)
         )
 
-        license = 'CCO-1.0'
+        license = 'CC0-1.0'
         resp = self.request(
             path='/tale/{_id}'.format(**tale), method='PUT',
             type='application/json',

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -62,6 +62,7 @@ class TaleTestCase(base.TestCase):
             public=True)
 
     def testTaleFlow(self):
+        from server.lib.license import WholeTaleLicense
         resp = self.request(
             path='/tale', method='POST', user=self.user,
             type='application/json',
@@ -127,7 +128,7 @@ class TaleTestCase(base.TestCase):
             '/collection/{cname}/{fname}/{_id}'.format(**sc)
         )
 
-        license = 'CC0-1.0'
+        taleLicense = WholeTaleLicense.default_spdx()
         resp = self.request(
             path='/tale/{_id}'.format(**tale), method='PUT',
             type='application/json',
@@ -142,12 +143,12 @@ class TaleTestCase(base.TestCase):
                 'published': False,
                 'doi': 'doi:10.x.x.xx',
                 'publishedURI': 'publishedURI_URL',
-                'license': license
+                'licenseSPDX': taleLicense
             })
         )
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['title'], 'new name')
-        self.assertEqual(resp.json['license'], license)
+        self.assertEqual(resp.json['licenseSPDX'], taleLicense)
         tale = resp.json
 
         resp = self.request(
@@ -461,6 +462,7 @@ class TaleTestCase(base.TestCase):
         self.assertEqual(Folder().load(tale['workspaceId'], force=True), None)
 
     def testTaleValidation(self):
+        from server.lib.license import WholeTaleLicense
         resp = self.request(
             path='/resource/lookup', method='GET', user=self.user,
             params={'path': '/user/{login}/Home'.format(**self.user)})
@@ -506,8 +508,12 @@ class TaleTestCase(base.TestCase):
         # new_data_dir = resp.json
         # self.assertEqual(str(tale['folderId']), str(new_data_dir['_id']))
         self.assertEqual(tale['dataSet'], [])
+        self.assertEqual(tale['licenseSPDX'], WholeTaleLicense.default_spdx())
         # self.assertEqual(str(tale['dataSet'][0]['itemId']), data_dir['_id'])
         # self.assertEqual(tale['dataSet'][0]['mountPath'], '/' + data_dir['name'])
+        tale['licenseSPDX']='unsupportedLicense'
+        tale = self.model('tale', 'wholetale').save(tale)
+        self.assertEqual(tale['licenseSPDX'], WholeTaleLicense.default_spdx())
         self.model('tale', 'wholetale').remove(tale)
 
     @mock.patch('gwvolman.tasks.import_tale')
@@ -531,6 +537,7 @@ class TaleTestCase(base.TestCase):
             self.assertEqual(job_call['headers']['girder_job_title'], 'Import Tale')
 
     def testTaleUpdate(self):
+        from server.lib.license import WholeTaleLicense
         # Test that Tale updating works
 
         resp = self.request(
@@ -549,7 +556,8 @@ class TaleTestCase(base.TestCase):
         published = True
         doi = 'doi:10.x.zz'
         published_uri = 'atestURI'
-        license = 'CC-BY'
+        tale_licenses=WholeTaleLicense()
+        taleLicense = tale_licenses.supported_spdxes().pop()
 
         # Create a new Tale
         resp = self.request(
@@ -567,12 +575,14 @@ class TaleTestCase(base.TestCase):
                 'public': False,
                 'published': False,
                 'doi': 'doi',
-                'publishedURI': 'published_uri'
+                'publishedURI': 'published_uri',
+                'licenseSPDX': taleLicense
             })
         )
 
         self.assertStatus(resp, 200)
 
+        newLicense = tale_licenses.supported_spdxes().pop()
         # Update the Tale with new values
         resp = self.request(
             path='/tale/{}'.format(str(resp.json['_id'])),
@@ -592,7 +602,7 @@ class TaleTestCase(base.TestCase):
                 'published': published,
                 'doi': doi,
                 'publishedURI': published_uri,
-                'license': license
+                'licenseSPDX': newLicense
             })
         )
 
@@ -606,7 +616,7 @@ class TaleTestCase(base.TestCase):
         self.assertEqual(resp.json['published'], published)
         self.assertEqual(resp.json['doi'], doi)
         self.assertEqual(resp.json['publishedURI'], published_uri)
-        self.assertEqual(resp.json['license'], license)
+        self.assertEqual(resp.json['licenseSPDX'], newLicense)
 
     def tearDown(self):
         self.model('user').remove(self.user)

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -127,6 +127,7 @@ class TaleTestCase(base.TestCase):
             '/collection/{cname}/{fname}/{_id}'.format(**sc)
         )
 
+        license = 'CCO-1.0'
         resp = self.request(
             path='/tale/{_id}'.format(**tale), method='PUT',
             type='application/json',
@@ -140,11 +141,13 @@ class TaleTestCase(base.TestCase):
                 'public': True,
                 'published': False,
                 'doi': 'doi:10.x.x.xx',
-                'publishedURI': 'publishedURI_URL'
+                'publishedURI': 'publishedURI_URL',
+                'license': license
             })
         )
         self.assertStatusOk(resp)
         self.assertEqual(resp.json['title'], 'new name')
+        self.assertEqual(resp.json['license'], license)
         tale = resp.json
 
         resp = self.request(
@@ -546,6 +549,7 @@ class TaleTestCase(base.TestCase):
         published = True
         doi = 'doi:10.x.zz'
         published_uri = 'atestURI'
+        license = 'CC-BY'
 
         # Create a new Tale
         resp = self.request(
@@ -587,7 +591,8 @@ class TaleTestCase(base.TestCase):
                 'public': public,
                 'published': published,
                 'doi': doi,
-                'publishedURI': published_uri
+                'publishedURI': published_uri,
+                'license': license
             })
         )
 
@@ -601,6 +606,7 @@ class TaleTestCase(base.TestCase):
         self.assertEqual(resp.json['published'], published)
         self.assertEqual(resp.json['doi'], doi)
         self.assertEqual(resp.json['publishedURI'], published_uri)
+        self.assertEqual(resp.json['license'], license)
 
     def tearDown(self):
         self.model('user').remove(self.user)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -30,6 +30,7 @@ from .rest.tale import Tale
 from .rest.instance import Instance
 from .rest.wholetale import wholeTale
 from .rest.workspace import Workspace
+from .rest.license import License
 from .models.instance import finalizeInstance
 
 
@@ -335,6 +336,7 @@ def load(info):
     events.bind('model.user.save.created', 'wholetale', addDefaultFolders)
     info['apiRoot'].repository = Repository()
     info['apiRoot'].publish = Publish()
+    info['apiRoot'].license = License()
     info['apiRoot'].integration = Integration()
     info['apiRoot'].workspace = Workspace()
     info['apiRoot'].folder.route('GET', ('registered',), listImportedData)

--- a/server/lib/license.py
+++ b/server/lib/license.py
@@ -1,0 +1,49 @@
+"""
+Class representing the available licenses. For specific providers, methods that filter
+the list of global licences can be added.
+"""
+
+
+class WholeTaleLicense:
+    def __init__(self):
+        super().__init__()
+
+        # List of all the licenses that are supported.
+        self.licenses = [
+            {
+                'name': 'Creative Commons Zero v1.0 Universal',
+                'spdx': 'CC0-1.0',
+                'text': 'This work is dedicated to the public domain under the Creative Commons '
+                        'Universal 1.0 Public Domain Dedication. To view a copy of this '
+                        'dedication, visit https://creativecommons.org/publicdomain/zero/1.0/.'
+            },
+            {
+                'name': 'Creative Commons Attribution 4.0 International',
+                'spdx': 'CC-BY-4.0',
+                'text': 'This work is licensed under the Creative Commons Attribution 4.0 '
+                        'International License. To view a copy of this license, '
+                        'visit http://creativecommons.org/licenses/by/4.0/.'
+            }
+        ]
+
+    def supported_licenses(self):
+        """
+        Returns all of the supported licenses
+        :return: List of default licenses
+        """
+        return self.licenses
+
+    def supported_spdxes(self):
+        """
+        Returns the SPDX of the supported licenses
+        :return: A list of SPDXs for each supported license
+        """
+        return {tale_license['spdx'] for tale_license in self.licenses}
+
+    @staticmethod
+    def default_spdx():
+        """
+        Returns the default Tale spdx
+        :return: The spdx that is applied to a Tale on default
+        """
+        return 'CC-BY-4.0'

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -16,7 +16,7 @@ from girder.exceptions import AccessException
 # Whenever the Tale object schema is modified (e.g. fields are added or
 # removed) increase `_currentTaleFormat` to retroactively apply those
 # changes to existing Tales.
-_currentTaleFormat = 5
+_currentTaleFormat = 6
 
 
 class Tale(AccessControlledModel):
@@ -31,12 +31,12 @@ class Tale(AccessControlledModel):
         self.modifiableFields = {
             'title', 'description', 'public', 'config', 'updated', 'authors',
             'category', 'icon', 'iframe', 'illustration', 'dataSet',
-            'published', 'doi', 'publishedURI'
+            'published', 'doi', 'publishedURI', 'license'
         }
         self.exposeFields(
             level=AccessType.READ,
             fields=({'_id', 'folderId', 'imageId', 'creatorId', 'created',
-                     'format', 'dataSet', 'narrative', 'narrativeId',
+                     'format', 'dataSet', 'narrative', 'narrativeId', 'license',
                      'doi', 'publishedURI', 'workspaceId'} | self.modifiableFields))
         self.exposeFields(level=AccessType.ADMIN, fields={'published'})
 
@@ -98,7 +98,7 @@ class Tale(AccessControlledModel):
     def createTale(self, image, data, creator=None, save=True, title=None,
                    description=None, public=None, config=None, published=False,
                    authors=None, icon=None, category=None, illustration=None,
-                   narrative=None, doi=None, publishedURI=None):
+                   narrative=None, doi=None, publishedURI=None, license='CCO-1.0'):
         if creator is None:
             creatorId = None
         else:
@@ -129,7 +129,8 @@ class Tale(AccessControlledModel):
             'published': published,
             'updated': now,
             'doi': doi,
-            'publishedURI': publishedURI
+            'publishedURI': publishedURI,
+            'license': license
         }
         if public is not None and isinstance(public, bool):
             self.setPublic(tale, public, save=False)

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -98,7 +98,8 @@ class Tale(AccessControlledModel):
     def createTale(self, image, data, creator=None, save=True, title=None,
                    description=None, public=None, config=None, published=False,
                    authors=None, icon=None, category=None, illustration=None,
-                   narrative=None, doi=None, publishedURI=None, license='CCO-1.0'):
+                   narrative=None, doi=None, publishedURI=None,
+                   license='CC-BY-4.0'):
         if creator is None:
             creatorId = None
         else:

--- a/server/rest/license.py
+++ b/server/rest/license.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from girder.api import access
+from girder.api.describe import Description, describeRoute
+from girder.api.rest import Resource
+
+
+class License(Resource):
+
+    def __init__(self):
+        super(License, self).__init__()
+        self.resourceName = 'license'
+        self.route('GET', (), self.get_licenses)
+
+    @access.public
+    @describeRoute(
+        Description('Return the licenses that a Tale can be under.')
+        .notes('This endpoint returns a list of all of the Whole Tale supported licenses')
+    )
+    def get_licenses(self, params):
+        return [
+            {
+                'name': 'Creative Commons Zero v1.0 Universal',
+                'spdx': 'CCO-1.0',
+                'text': 'This work is dedicated to the public domain under the Creative Commons '
+                        'Universal 1.0 Public Domain Dedication. To view a copy of this '
+                        'dedication, visit https://creativecommons.org/publicdomain/zero/1.0/.'
+            },
+            {
+                'name': 'Creative Commons Attribution 4.0 International',
+                'spdx': 'CC-BY-4.0',
+                'text': 'This work is licensed under the Creative Commons Attribution 4.0 '
+                        'International License. To view a copy of this license, '
+                        'visit http://creativecommons.org/licenses/by/4.0/.'
+            }
+        ]

--- a/server/rest/license.py
+++ b/server/rest/license.py
@@ -21,7 +21,7 @@ class License(Resource):
         return [
             {
                 'name': 'Creative Commons Zero v1.0 Universal',
-                'spdx': 'CCO-1.0',
+                'spdx': 'CC0-1.0',
                 'text': 'This work is dedicated to the public domain under the Creative Commons '
                         'Universal 1.0 Public Domain Dedication. To view a copy of this '
                         'dedication, visit https://creativecommons.org/publicdomain/zero/1.0/.'

--- a/server/rest/license.py
+++ b/server/rest/license.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from ..lib.license import WholeTaleLicense
 from girder.api import access
 from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource
@@ -14,23 +15,8 @@ class License(Resource):
 
     @access.public
     @describeRoute(
-        Description('Return the licenses that a Tale can be under.')
+        Description('Returns all of the licenses that can be assigned to a Tale.')
         .notes('This endpoint returns a list of all of the Whole Tale supported licenses')
     )
     def get_licenses(self, params):
-        return [
-            {
-                'name': 'Creative Commons Zero v1.0 Universal',
-                'spdx': 'CC0-1.0',
-                'text': 'This work is dedicated to the public domain under the Creative Commons '
-                        'Universal 1.0 Public Domain Dedication. To view a copy of this '
-                        'dedication, visit https://creativecommons.org/publicdomain/zero/1.0/.'
-            },
-            {
-                'name': 'Creative Commons Attribution 4.0 International',
-                'spdx': 'CC-BY-4.0',
-                'text': 'This work is licensed under the Creative Commons Attribution 4.0 '
-                        'International License. To view a copy of this license, '
-                        'visit http://creativecommons.org/licenses/by/4.0/.'
-            }
-        ]
+        return WholeTaleLicense().supported_licenses()

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -228,7 +228,7 @@ class Tale(Resource):
                 category=tale.get('category', 'science'),
                 published=False, narrative=tale.get('narrative'),
                 doi=tale.get('doi'), publishedURI=tale.get('publishedURI'),
-                license=tale.get('license', 'CC0-1.0')
+                license=tale.get('license', 'CC-BY-4.0')
             )
 
     @access.user(scope=TokenScope.DATA_OWN)

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -227,7 +227,8 @@ class Tale(Resource):
                 authors=tale.get('authors', default_author),
                 category=tale.get('category', 'science'),
                 published=False, narrative=tale.get('narrative'),
-                doi=tale.get('doi'), publishedURI=tale.get('publishedURI')
+                doi=tale.get('doi'), publishedURI=tale.get('publishedURI'),
+                license=tale.get('license')
             )
 
     @access.user(scope=TokenScope.DATA_OWN)

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -228,7 +228,7 @@ class Tale(Resource):
                 category=tale.get('category', 'science'),
                 published=False, narrative=tale.get('narrative'),
                 doi=tale.get('doi'), publishedURI=tale.get('publishedURI'),
-                license=tale.get('license')
+                license=tale.get('license', 'CC0-1.0')
             )
 
     @access.user(scope=TokenScope.DATA_OWN)

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -228,7 +228,7 @@ class Tale(Resource):
                 category=tale.get('category', 'science'),
                 published=False, narrative=tale.get('narrative'),
                 doi=tale.get('doi'), publishedURI=tale.get('publishedURI'),
-                license=tale.get('license', 'CC-BY-4.0')
+                licenseSPDX=tale.get('licenseSPDX')
             )
 
     @access.user(scope=TokenScope.DATA_OWN)

--- a/server/schema/tale.py
+++ b/server/schema/tale.py
@@ -107,6 +107,10 @@ taleModel = {
             "type": "string",
             "description": "A URL to an image icon"
         },
+        "license": {
+            "type": "string",
+            "description": "The license that the Tale is under"
+        },
         "doi": {
             "type": ["string", "null"],
             "description": "A unique identifier assigned to this tale from a "
@@ -150,6 +154,7 @@ taleModel = {
         "publishedURI": "https://dev.nceas.ucsb.edu/view/urn:uuid:939e48ec-1107-45d9"
                         "-baa7-05cef08e51cd",
         "title": "My Tale",
+        "license": "CC0-1.0",
         "updated": "2019-01-23T15:48:17.476000+00:00"
     }
 }


### PR DESCRIPTION
This PR has two parts, which are separated into respective commits. 

The first adds a new field to the Tale, `license`. 
The second adds an endpoint that returns a list of supported licenses. I put three fields for each record:
   1. The common name
   2. The spdx
   3. A compliant portion of the license needed to properly attribute a work

During the dev call about this feature, we decided that a URL would be the best approach however, I wasn't able to find a suitable endpoint that returned the text of a given license, and it seems that data repositories (Dataverse and DataONE) supply legal subsets of the license along with the URL. The text was taken from packages on DataONE however, similar text can be found across other repositories.

To Test Licenses:
   1. Check this branch out
   2. Deploy
   3. Visit the Girder API page
   4. Call Get on the license endpoint

To Test Tale Licenses:
   1. Checkout this branch
   2. Deploy
   3. Create a new Tale
   4. Query the Tale from Girder
   5. See that it has a default license applied