### PR TITLE
Default to ascending order for datasets. Fixes #257

### DIFF
--- a/server/rest/dataset.py
+++ b/server/rest/dataset.py
@@ -108,7 +108,7 @@ class Dataset(Resource):
                required=False, dataType='boolean', default=False)
         .responseClass('dataset', array=True)
         .pagingParams(defaultSort='lowerName',
-                      defaultSortDir=SortDir.DESCENDING)
+                      defaultSortDir=SortDir.ASCENDING)
     )
     def listDatasets(self, myData, limit, offset, sort, params):
         user = self.getCurrentUser()


### PR DESCRIPTION
Change default sort order.

### How to tests?

1. Register multiple datasets.
2. Navigate to Manage > Data
3. Confirm A->Z sorting