### PR TITLE
Set identifier on the root folder of imported Globus dataset. Fixes #261

### DIFF
--- a/server/lib/globus/globus_provider.py
+++ b/server/lib/globus/globus_provider.py
@@ -76,7 +76,7 @@ class GlobusImportProvider(ImportProvider):
     def _listRecursive(self, user, pid: str, name: str, base_url: str = None, progress=None):
         doc = self._getDocument(pid)
         (endpoint, path, doi, title) = self._extractMeta(doc)
-        yield ImportItem(ImportItem.FOLDER, name=title)
+        yield ImportItem(ImportItem.FOLDER, name=title, identifier='doi:' + doi)
         tc = self.clients.getUserTransferClient(user)
         yield from self._listRecursive2(tc, endpoint, path, progress)
         yield ImportItem(ImportItem.END_FOLDER)


### PR DESCRIPTION
### How to test?

1. Import Globus dataset (e.g. `doi:10.18126/M2301J`)
1. Using Girder UI, navigate to `/collection/WholeTale Catalog/WholeTale Catalog/Twin-mediated Crystal Growth: an Enigma Resolved` and confirm that `meta.identifier` is present and equal to `doi:10.18126/M2301J`

Note: Depends on #263 

