### PR TITLE
Sanitize location of http resources in WT Catalog. Fixes #193

### DIFF
--- a/plugin_tests/harvester_test.py
+++ b/plugin_tests/harvester_test.py
@@ -284,7 +284,7 @@ class DataONEHarversterTestCase(base.TestCase):
         # TODO: check if it's that method is still used anywhere
         resp = self.request('/folder/registered', method='GET', user=self.user)
         self.assertStatusOk(resp)
-        self.assertEqual(len(resp.json), 1)
+        self.assertEqual(len(resp.json), 4)
         # self.assertEqual(folder, resp.json[0])
 
         ds_item = next((_ for _ in datasets if _['_modelType'] == 'item'), None)

--- a/scripts/http_files_migrate.py
+++ b/scripts/http_files_migrate.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env girder-shell
+# -*- coding: utf-8 -*-
+
+"""Migrate HTTP(S) registered data to new format.
+
+This script should be used to migrate registered HTTP(s) resources from the root of the Catalog
+into folder hierarchy based on url path.
+See https://github.com/whole-tale/girder_wholetale/pull/266
+
+Example:
+
+    $ ./http_files_migrate.py
+
+"""
+
+from girder.models.folder import Folder
+from girder.models.item import Item
+from girder.models.user import User
+from girder.utility.progress import ProgressContext
+from girder.plugins.wholetale.models.tale import Tale
+from girder.plugins.wholetale.rest.repository import Repository
+from girder.plugins.wholetale.utils import getOrCreateRootFolder
+from girder.plugins.wholetale.constants import CATALOG_NAME
+from girder.plugins.wholetale.lib import IMPORT_PROVIDERS
+
+
+CAT_ROOT = getOrCreateRootFolder(CATALOG_NAME)
+base_url = 'https://dev.nceas.ucsb.edu/knb/d1/mn/v2'
+
+
+def migrate_item(item):
+    _file = list(Item().childFiles(item))[0]
+    url = _file['linkUrl']
+    if url.startswith('https://dashboard.wholetale.org'):
+        return 0
+    creator = User().load(item['creatorId'], force=True)
+
+    # register url
+    entity = Repository._buildAndResolveEntity(url, base_url, creator)
+    provider = IMPORT_PROVIDERS.getProvider(entity)
+    if not provider.getName().lower().startswith('http'):
+        print("  -> WRONG PROVIDER!!! ({})".format(provider.getName()))
+        print("  -> Item '{}' removed".format(item['name']))
+        return 0
+
+    dataMap = provider.lookup(entity)
+    ds = dataMap.toDict()
+
+    if not ds['name']:
+        print("  -> Item has no name!!!")
+        print(ds)
+        return 0
+
+    with ProgressContext(True, user=creator, title='Registering resources') as ctx:
+        objType, new_item = provider.register(
+            CAT_ROOT, 'folder', ctx, creator, dataMap, base_url=base_url
+        )
+
+    # find userData and replace with new id
+    for user in User().find({'myData': item['_id']}):
+        print(
+            '  Updating {} in myData for user "{}"'.format(item['name'], user['login'])
+        )
+        user['myData'][user['myData'].index(item['_id'])] = new_item['_id']
+        user = User().save(user)
+
+    # find tale dataset and switch id
+    for tale in Tale().find({'dataSet.itemId': str(item['_id'])}):
+        print(
+            '  Updating {} in dataSet of Tale: "{}"'.format(item['name'], tale['title'])
+        )
+        for i, ds in enumerate(tale['dataSet']):
+            if ds['itemId'] == str(item['_id']):
+                tale['dataSet'][i]['itemId'] = str(new_item['_id'])
+                Tale().save(tale)
+
+    return 1
+
+
+migrated_items = 0
+for item in Folder().childItems(CAT_ROOT):
+    migrated_items += migrate_item(item)
+    Item().remove(item)
+
+for item in Item().find(
+    {'meta.provider': 'HTTP', 'meta.identifier': {'$in': ["unknown", None]}}
+):
+    migrated_items += migrate_item(item)
+    Item().remove(item)
+
+print("TOTAL MIGRATED ITEMS = {}".format(migrated_items))

--- a/server/lib/http_provider.py
+++ b/server/lib/http_provider.py
@@ -1,9 +1,11 @@
 import os
+import pathlib
 import re
 import requests
 
-from urllib.parse import urlparse
+from urllib.parse import urlparse, unquote
 from girder.utility.model_importer import ModelImporter
+from girder.models.folder import Folder
 
 from .import_providers import ImportProvider
 from .resolvers import DOIResolver
@@ -41,7 +43,7 @@ class HTTPImportProvider(ImportProvider):
             if fname:
                 fname = fname.groups()[0]
         else:
-            fname = os.path.basename(url.path.rstrip('/'))
+            fname = unquote(os.path.basename(url.path.rstrip('/')))
 
         size = headers.get('Content-Length') or \
             headers.get('Content-Range').split('/')[-1]
@@ -59,15 +61,57 @@ class HTTPImportProvider(ImportProvider):
 
     def register(self, parent: object, parentType: str, progress, user, dataMap: DataMap,
                  base_url: str = None):
-        url = dataMap.getDataId()
-        progress.update(increment=1, message='Processing file {}.'.format(url))
+        uri = dataMap.getDataId()
+        url = urlparse(uri)
+        progress.update(increment=1, message='Processing file {}.'.format(uri))
         headers = requests.head(
-            url, headers={'Accept-Encoding': 'identity'}).headers
+            uri, headers={'Accept-Encoding': 'identity'}).headers
         size = headers.get('Content-Length') or \
             headers.get('Content-Range').split('/')[-1]
+
+        parent = Folder().createFolder(
+            parent,
+            url.netloc,
+            description='',
+            parentType=parentType,
+            creator=user,
+            reuseExisting=True,
+        )
+        parentType = 'folder'
+        parent = Folder().setMetadata(
+            parent,
+            {
+                'identifier': '{}://{}'.format(url.scheme, url.netloc),
+                'provider': url.scheme.upper(),
+            }
+        )
+
+        path = pathlib.Path(url.path)
+        for part in path.parts:
+            parent_url = parent['meta']['identifier']
+            new_url = parent_url + '/' + part
+            part = unquote(part)
+            if part in {'/', dataMap.getName()}:
+                continue
+            parent = Folder().createFolder(
+                parent,
+                part,
+                description='',
+                parentType=parentType,
+                creator=user,
+                            reuseExisting=True,
+            )
+            parent = Folder().setMetadata(
+                parent,
+                {
+                    'identifier': new_url,
+                    'provider': url.scheme.upper(),
+                }
+            )
+
         fileModel = ModelImporter.model('file')
         fileDoc = fileModel.createLinkFile(
-            url=url, parent=parent, name=dataMap.getName(), parentType=parentType,
+            url=uri, parent=parent, name=dataMap.getName(), parentType=parentType,
             creator=user, size=int(size),
             mimeType=headers.get('Content-Type', 'application/octet-stream'),
             reuseExisting=True)
@@ -75,6 +119,6 @@ class HTTPImportProvider(ImportProvider):
 
         gc_item = ModelImporter.model('item').load(
             gc_file['itemId'], force=True)
-        gc_item['meta'] = {'identifier': None, 'provider': 'HTTP'}
+        gc_item['meta'] = {'identifier': uri, 'provider': url.scheme.upper()}
         gc_item = ModelImporter.model('item').updateItem(gc_item)
         return ('item', gc_item)

--- a/server/rest/dataset.py
+++ b/server/rest/dataset.py
@@ -7,6 +7,7 @@ from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import Resource
 from girder.constants import AccessType, SortDir, TokenScope
 from girder.exceptions import ValidationException
+from girder.models.item import Item
 from girder.models.user import User
 from girder.utility.progress import ProgressContext
 from ..constants import CATALOG_NAME
@@ -126,11 +127,13 @@ class Dataset(Resource):
             folder['_modelType'] = 'folder'
             datasets.append(_itemOrFolderToDataset(folder))
 
-        for item in folderModel.childItems(
-                folder=parent, limit=limit, offset=offset, sort=sort,
-                filters=filters):
-            item['_modelType'] = 'item'
-            datasets.append(_itemOrFolderToDataset(item))
+        if myData:
+            cursor = Item().find(filters)
+            for item in Item().filterResultsByPermission(
+                    cursor, user, AccessType.READ, limit=limit, offset=offset
+            ):
+                item['_modelType'] = 'item'
+                datasets.append(_itemOrFolderToDataset(item))
         return datasets
 
     def _getResource(self, id, type):


### PR DESCRIPTION
Currently, files registered via the *http* provider end up within the root of the *Whole Tale Catalog*. Since we "reuse" Girder objects during the registration to avoid duplicates, it quickly leads to name collisions, e.g. if two users register a file called README.md, only one of those can be stored in WT.

### Approach
In order to assign a pseudo-unique identifier to http resources we can map a url to a folder structure (using `/` as a separator) and register the file as a leaf item underneath it. E.g. 

- `http://example.com/level1/level2/file.zip` -> `/collection/WholeTale Catalog/WholeTale Catalog/example.com/level1/level2/file.zip`
- `http://use.yt/upload/4166454f` -> `/collection/WholeTale Catalog/WholeTale Catalog/use.yt/upload/4166454f/axis_test.zip` (uses `Content-Disposition` for deriving file name)

### How to test?
1. Deploy locally
2. Register LIGO Tale using provided [script](https://github.com/whole-tale/deploy-dev/blob/dev/register_ligo.py)
3. In Girder UI navigate to `/collection/WholeTale Catalog/WholeTale Catalog` and confirm that `/collection/WholeTale Catalog/WholeTale Catalog/www.gw-openscience.org/s/events/` exists

#### Testing migration script
1. Deploy locally with a production database migrated to v0.6 (remember to fix gridfs assetstore by removing replicaSet and setting a proper mongo uri).
1. Execute `girder-shell scripts/http_files_migrate.py` within Girder container.
1. Confirm that there are no items in `/collection/WholeTale Catalog/WholeTale Catalog`
1. Launch "Ligo Tale" and confirm it's still working properly.

TODO:

- [x] Provide description and "how to test?" here
- [x] Provide migration script for existing *http/https* resources
- [x] Possibly fix tests