### PR TITLE
Remove the license and entry point parameters for the publishing endpoint

### DIFF
--- a/server/rest/publish.py
+++ b/server/rest/publish.py
@@ -37,25 +37,12 @@ class Publish(Resource):
                description='The user\'s authentication token for interacting with the '
                            'DataONE API. In DataONE\'s case, this is the user\'s JWT'
                            'token.',
-               required=True)
-        .param('licenseSPDX',
-               description='The SPDX of the license that the package is under.',
-               required=True)
-        .jsonParam('provInfo',
-                   description='A string representation of a dictionary that can describe '
-                               'additional information about the tale. The contents of '
-                               'this query are placed in the tale.yaml file.\n'
-                               'Example: '
-                               '{\"entryPoint\": \"/home/data/main.py\"}',
-                   required=False)
-    )
+               required=True))
     def dataonePublish(self,
                        itemIds,
                        taleId,
                        remoteMemberNode,
-                       authToken,
-                       licenseSPDX,
-                       provInfo=dict()):
+                       authToken):
 
         user = self.getCurrentUser()
         token = self.getCurrentToken()
@@ -68,9 +55,7 @@ class Publish(Resource):
                 remoteMemberNode,
                 authToken,
                 str(token['_id']),
-                str(user['_id']),
-                provInfo,
-                licenseSPDX)
+                str(user['_id']))
         job = jobModel.createJob(
             title=jobTitle, type='publish', handler='worker_handler',
             user=user, public=False, args=args, kwargs={},


### PR DESCRIPTION
We removed the need to specify the license in the publishing modal and endpoint. We also decided to hold off on the entry point idea.

This PR removes the license and optional prov field from the endpoint.