### PR TITLE
Manifest fixes

### DIFF
--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -237,7 +237,7 @@ class Manifest:
                 objects from external_objects
 
         """
-        if not dataSet:
+        if dataSet is None:
             dataSet = self.tale['dataSet']
 
         dataset_top_identifiers = set()

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -202,6 +202,31 @@ class Manifest:
             record = self.create_aggregation_record(obj['uri'], bundle, obj['dataset_identifier'])
             self.manifest['aggregates'].append(record)
 
+    def _handle_http_folder(self, folder, user, relpath=''):
+        """
+        Recursively handle HTTP folder and return all child items as ext objs
+
+        In a perfect world there should be a better place for this...
+        """
+        curpath = os.path.join(relpath, folder['name'])
+        dataSet = []
+        ext = []
+        for item in Folder().childItems(folder, user=user):
+            dataSet.append({
+                'itemId': item['_id'],
+                '_modelType': 'item',
+                'mountPath': os.path.join(curpath, item['name'])
+            })
+
+        if dataSet:
+            ext, _ = self._parse_dataSet(dataSet=dataSet, relpath=curpath)
+
+        for subfolder in Folder().childFolders(
+            folder, parentType='folder', user=user
+        ):
+            ext += self._handle_http_folder(subfolder, user, relpath=curpath)
+        return ext
+
     def _parse_dataSet(self, dataSet=None, relpath=''):
         """
         Get the basic info about the contents of `dataSet`
@@ -212,29 +237,6 @@ class Manifest:
                 objects from external_objects
 
         """
-
-        def _handle_http_folder(folder, user, relpath=''):
-            """
-            Recursively handle HTTP folder and return all child items as ext objs
-
-            In a perfect world there should be a better place for this...
-            """
-            curpath = os.path.join(relpath, folder['name'])
-            dataSet = []
-            for item in Folder().childItems(folder, user=user):
-                dataSet.append({
-                    'itemId': item['_id'],
-                    '_modelType': 'item',
-                    'mountPath': os.path.join(curpath, item['name'])
-                })
-            ext, _ = self._parse_dataSet(dataSet=dataSet, relpath=curpath)
-
-            for subfolder in Folder().childFolders(
-                    folder, parentType='folder', user=user
-            ):
-                ext += _handle_http_folder(subfolder, user, relpath=curpath)
-            return ext
-
         if not dataSet:
             dataSet = self.tale['dataSet']
 
@@ -263,7 +265,7 @@ class Manifest:
                     ext_obj['name'] = doc['name']
 
                     if provider_name == 'HTTP':
-                        external_objects += _handle_http_folder(doc, self.user)
+                        external_objects += self._handle_http_folder(doc, self.user)
                         continue
 
                     if doc['meta'].get('identifier') == top_identifier:

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -277,7 +277,8 @@ class Tale(Resource):
             zip_generator = ziputil.ZipGenerator(zip_name)
 
             # Add files from the workspace
-            folder = self.model('folder').load(tale['workspaceId'], user=user)
+            folder = self.model('folder').load(tale['workspaceId'], user=user,
+                                               level=AccessType.READ)
             for (path, f) in self.model('folder').fileList(folder,
                                                            user=user,
                                                            subpath=False):


### PR DESCRIPTION
While testing manifest export locally I found two issues:
1. We were trying to access workspace as an owner, which failed if you tried to export a Tale you didn't own.
2. A method responsible for identifying all the http files in the Tale's `dataSet` was hitting an infinite recursion loop if an http folder from the `dataSet` contained no items.

### How to test?
1. Deploy locally
1. Register Ligo Tale
1. Export Ligo Tale (without this PR zip is malformed...)