### PR TITLE
Add Structured Multiple Authors to Tale. Fixes #272

### DIFF
--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -55,6 +55,19 @@ class ManifestTestCase(base.TestCase):
             self.model('user').createUser(**user) for user in self.users
         ]
 
+        self.new_authors = [
+            {
+                "firstName": self.admin['firstName'],
+                "lastName": self.admin['lastName'],
+                "orcid": 'https://orcid.org/1234'
+            },
+            {
+                "firstName": self.user['firstName'],
+                "lastName": self.user['lastName'],
+                "orcid": 'https://orcid.org/9876'
+            }
+        ]
+
         data_collection = self.model('collection').createCollection(
             'WholeTale Catalog', public=True, reuseExisting=True
         )
@@ -136,7 +149,7 @@ class ManifestTestCase(base.TestCase):
             '_id': ObjectId(),
             'name': 'Main Tale',
             'description': 'Tale Desc',
-            'authors': self.user['firstName'] + ' ' + self.user['lastName'],
+            'authors': self.new_authors,
             'creator': self.user,
             'public': True,
             'data': dataSet,
@@ -240,6 +253,11 @@ class ManifestTestCase(base.TestCase):
         parent_dataset = 'urn:uuid:100.99.xx'
         agg = manifest_doc.create_aggregation_record(uri, bundle, parent_dataset)
         self.assertEqual(agg['schema:isPartOf'], parent_dataset)
+
+    def _testAddTaleCreator(self):
+        from server.lib.manifest import Manifest
+        manifest_doc = Manifest(self.tale, self.user)
+        self.assertTrue(len(manifest_doc.manifest['schema:author']))
 
     def _testGetFolderIdentifier(self):
         from server.lib.manifest import get_folder_identifier

--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -2,7 +2,6 @@ import json
 import os
 from tests import base
 from bson import ObjectId
-from girder.exceptions import AccessException
 from girder.utility.path import lookUpPath
 
 
@@ -145,7 +144,7 @@ class ManifestTestCase(base.TestCase):
                 }
             )
 
-        tale_info = {
+        self.tale_info = {
             '_id': ObjectId(),
             'name': 'Main Tale',
             'description': 'Tale Desc',
@@ -157,23 +156,23 @@ class ManifestTestCase(base.TestCase):
         }
 
         self.tale = self.model('tale', 'wholetale').createTale(
-            {'_id': tale_info['_id']},
-            data=tale_info['data'],
-            creator=tale_info['creator'],
-            title=tale_info['name'],
-            public=tale_info['public'],
-            description=tale_info['description'],
-            authors=tale_info['authors'],
+            {'_id': self.tale_info['_id']},
+            data=self.tale_info['data'],
+            creator=self.tale_info['creator'],
+            title=self.tale_info['name'],
+            public=self.tale_info['public'],
+            description=self.tale_info['description'],
+            authors=self.tale_info['authors'],
         )
 
         self.tale2 = self.model('tale', 'wholetale').createTale(
-            {'_id': tale_info['_id']},
+            {'_id': self.tale_info['_id']},
             data=[],
-            creator=tale_info['creator'],
-            title=tale_info['name'],
-            public=tale_info['public'],
-            description=tale_info['description'],
-            authors=tale_info['authors'],
+            creator=self.tale_info['creator'],
+            title=self.tale_info['name'],
+            public=self.tale_info['public'],
+            description=self.tale_info['description'],
+            authors=self.tale_info['authors'],
         )
 
     def testManifest(self):
@@ -186,6 +185,7 @@ class ManifestTestCase(base.TestCase):
         self._testDataSet()
         self._test_different_user()
         self._testWorkspace()
+        self._testValidate()
 
     def _testCreateBasicAttributes(self):
         # Test that the basic attributes are correct
@@ -392,6 +392,38 @@ class ManifestTestCase(base.TestCase):
             Manifest(self.tale, self.userHenry)
         except AccessException:
             self.assertFalse(1)
+
+    def _testValidate(self):
+        from server.lib.manifest import Manifest
+
+        missing_orcid = {'firstName': 'Lord',
+                         'lastName': 'Kelvin'}
+        blank_orcid = {'firstName': 'Isaac',
+                       'lastName': 'Newton',
+                       'orcid': ''}
+
+        tale_missing_orcid = self.model('tale', 'wholetale').createTale(
+            {'_id': self.tale_info['_id']},
+            data=[],
+            creator=self.tale_info['creator'],
+            title=self.tale_info['name'],
+            public=self.tale_info['public'],
+            description=self.tale_info['description'],
+            authors=missing_orcid)
+
+        with self.assertRaises(ValueError):
+            Manifest(tale_missing_orcid, self.user)
+
+        tale_blank_orcid = self.model('tale', 'wholetale').createTale(
+            {'_id': self.tale_info['_id']},
+            data=[],
+            creator=self.tale_info['creator'],
+            title=self.tale_info['name'],
+            public=self.tale_info['public'],
+            description=self.tale_info['description'],
+            authors=missing_orcid)
+        with self.assertRaises(ValueError):
+            Manifest(tale_blank_orcid, self.user)
 
     def tearDown(self):
         self.model('user').remove(self.user)

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -631,12 +631,12 @@ class TaleTestCase(base.TestCase):
         new_authors = [
             {
                 "firstName": self.admin['firstName'],
-                "lastName": self.admin['firstName'],
+                "lastName": self.admin['lastName'],
                 "orcid": admin_orcid
             },
             {
-                "firstName": self.admin['firstName'],
-                "lastName": self.admin['firstName'],
+                "firstName": self.user['firstName'],
+                "lastName": self.user['lastName'],
                 "orcid": user_orcid
             }
         ]

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -79,6 +79,19 @@ class TaleTestCase(base.TestCase):
             'lastName': 'Regular',
             'password': 'secret'
         })
+
+        self.authors = [
+            {
+                'firstName': 'Charles',
+                'lastName': 'Darwmin',
+                'orcid': 'https://orcid.org/000-000'
+            },
+            {
+                'firstName': 'Thomas',
+                'lastName': 'Edison',
+                'orcid': 'https://orcid.org/111-111'
+            }
+        ]
         self.admin, self.user = [self.model('user').createUser(**user)
                                  for user in users]
 
@@ -678,6 +691,7 @@ class TaleTestCase(base.TestCase):
             path='/tale', method='POST', user=self.user,
             type='application/json',
             body=json.dumps({
+                'authors': self.authors,
                 'folderId': '1234',
                 'imageId': str(self.image['_id']),
                 'dataSet': [],
@@ -774,7 +788,7 @@ class TaleTestCase(base.TestCase):
                 'itemId': item['_id'],
                 '_modelType': 'item',
                 'mountPath': item['name']
-            }], creator=self.user, title="Export Tale", public=True)
+            }], creator=self.user, title="Export Tale", public=True, authors=self.authors)
         workspace = self.model('folder').load(tale['workspaceId'], force=True)
         with urllib.request.urlopen(
             'https://wholetale.readthedocs.io/en/stable/'
@@ -792,6 +806,7 @@ class TaleTestCase(base.TestCase):
             path='/tale', method='POST', user=self.user,
             type='application/json',
             body=json.dumps({
+                'authors': self.authors,
                 'imageId': str(self.image['_id']),
                 'dataSet': [],
                 'title': 'tale tile',

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -31,6 +31,7 @@ class Manifest:
         self.user = user
         self.expand_folders = expand_folders
 
+        self.validate()
         self.manifest = dict()
         # Create a set that represents any external data packages
         self.datasets = set()
@@ -64,6 +65,23 @@ class Manifest:
                 "Description": "A simple way to publish, discover, and access materials datasets"
             }
     }
+
+    def validate(self):
+        """
+        Checks for the presence of required tale information so
+        that we can fail early.
+        """
+        try:
+            # Check that each author has an ORCID, first name, and last name
+            for author in self.tale['authors']:
+                if not len(author['orcid']):
+                    raise ValueError('A Tale author is missing an ORCID')
+                if not len(author['firstName']):
+                    raise ValueError('A Tale author is missing a first name')
+                if not len(author['lastName']):
+                    raise ValueError('A Tale author is missing a last name')
+        except KeyError:
+            raise ValueError('A Tale author is missing an ORCID')
 
     def create_basic_attributes(self):
         """
@@ -116,8 +134,7 @@ class Manifest:
             "@id": author['orcid'],
             "@type": "schema:Person",
             "schema:givenName": author['firstName'],
-            "schema:familyName": author['lastName'],
-            "orcid": author['orcid']
+            "schema:familyName": author['lastName']
         }
 
     def create_context(self):

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -43,7 +43,7 @@ class Manifest:
         self.manifest.update(self.create_context())
         self.manifest.update(self.create_basic_attributes())
         self.add_tale_creator()
-        self.add_tale_authors()
+        self.manifest.update(self.create_author_record())
         self.add_tale_records()
         # Add any external datasets to the manifest
         self.add_dataset_records()
@@ -118,23 +118,21 @@ class Manifest:
             "schema:email": tale_user.get('email', '')
         }
 
-    def add_tale_authors(self):
-
-        self.manifest['schema:author'] = []
-        for author in self.tale['authors']:
-            self.manifest['schema:author'].append(self.create_author_record(author))
-
-    def create_author_record(self, author):
+    def create_author_record(self):
         """
-        Creates a record for an author that is associated with a Tale
-        :param author: An object that describes the author
-        :return: A dictionary listing of the author
+        Creates records for authors that are associated with a Tale
+        :return: A dictionary listing of the authors
         """
         return {
-            "@id": author['orcid'],
-            "@type": "schema:Person",
-            "schema:givenName": author['firstName'],
-            "schema:familyName": author['lastName']
+            'schema:author': [
+                {
+                    "@id": author["orcid"],
+                    "@type": "schema:Person",
+                    "schema:givenName": author["firstName"],
+                    "schema:familyName": author["lastName"]
+                }
+                for author in self.tale['authors']
+            ]
         }
 
     def create_context(self):

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -42,6 +42,7 @@ class Manifest:
         self.manifest.update(self.create_context())
         self.manifest.update(self.create_basic_attributes())
         self.add_tale_creator()
+        self.add_tale_authors()
         self.add_tale_records()
         # Add any external datasets to the manifest
         self.add_dataset_records()
@@ -92,11 +93,31 @@ class Manifest:
                                         user=self.user,
                                         force=True)
         self.manifest['createdBy'] = {
-            "@id": self.tale['authors'],
+            "@id": tale_user['email'],
             "@type": "schema:Person",
             "schema:givenName": tale_user.get('firstName', ''),
             "schema:familyName": tale_user.get('lastName', ''),
             "schema:email": tale_user.get('email', '')
+        }
+
+    def add_tale_authors(self):
+
+        self.manifest['schema:author'] = []
+        for author in self.tale['authors']:
+            self.manifest['schema:author'].append(self.create_author_record(author))
+
+    def create_author_record(self, author):
+        """
+        Creates a record for an author that is associated with a Tale
+        :param author: An object that describes the author
+        :return: A dictionary listing of the author
+        """
+        return {
+            "@id": author['orcid'],
+            "@type": "schema:Person",
+            "schema:givenName": author['firstName'],
+            "schema:familyName": author['lastName'],
+            "orcid": author['orcid']
         }
 
     def create_context(self):

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -70,7 +70,6 @@ class Tale(AccessControlledModel):
                                 'lastName': tale_creator['lastName'],
                                 'orcid': ''}]
         return tale
-        return tale
 
     def list(self, user=None, data=None, image=None, limit=0, offset=0,
              sort=None, currentUser=None, level=AccessType.READ):

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -17,7 +17,7 @@ from girder.exceptions import AccessException
 # Whenever the Tale object schema is modified (e.g. fields are added or
 # removed) increase `_currentTaleFormat` to retroactively apply those
 # changes to existing Tales.
-_currentTaleFormat = 6
+_currentTaleFormat = 7
 
 
 class Tale(AccessControlledModel):
@@ -63,6 +63,13 @@ class Tale(AccessControlledModel):
         if tale.get('config') is None:
             tale['config'] = {}
 
+        if not isinstance(tale['authors'], list):
+            # Set the authors to the Tale creator
+            tale_creator = self.model('user').load(tale['creatorId'], force=True)
+            tale['authors'] = [{'firstName': tale_creator['firstName'],
+                                'lastName': tale_creator['lastName'],
+                                'orcid': ''}]
+        return tale
         return tale
 
     def list(self, user=None, data=None, image=None, limit=0, offset=0,

--- a/server/schema/tale.py
+++ b/server/schema/tale.py
@@ -88,11 +88,12 @@ taleModel = {
             "description": "The last time when the tale was modified."
         },
         "authors": {
-            "type": "string",
-            "description": (
-                "BEWARE: it's a string for now, but in the future it should "
-                "be a map of Author/User entities"
-            )
+            "type": "array",
+            "items": {
+                'type': 'object',
+                'description': "A JSON structure representing a Tale author."
+            },
+            "description": "A list of authors that are associated with the Tale"
         },
         "category": {
             "type": "string",
@@ -122,7 +123,18 @@ taleModel = {
         "_accessLevel": 2,
         "_id": "5c4887409759c200017b2310",
         "_modelType": "tale",
-        "authors": "Kacper Kowalik",
+        "authors": [
+            {
+                "firstName": "Kacper",
+                "lastName": "Kowalik",
+                "orcid": "https://www.orcid.org/0000-0003-1709-3744"
+            },
+            {
+                "firstName": "Tommy",
+                "lastName": "Thelen",
+                "orcid": "https://www.orcid.org/0000-0003-1709-3754"
+            }
+        ],
         "category": "science",
         "config": {},
         "created": "2019-01-23T15:24:48.217000+00:00",


### PR DESCRIPTION
### Changes to server/schema/tale.py
The changes here switch the `authors` field from a string to a list of objects. The example was also updated for the swagger UI.

### Changes to server/models/tale.py
The infrastructure for handling _some_ object called 'authors' already exists, so the real changes were
1. Bumping the format up one version
2. Adding a validation check to make sure the `authors` field is a list
The most controversial part of this is setting the orcid field to `''` because we currently don't have knowledge of it in the `user` model.

### Changes to server/lib/manifest.py
The first change was to make the `@id` of the `createdBy` field the email of the Tale creator.
The second change was to add a method that loops over each object under the `tale['authors']` and create a section under `schema:authors` for them.
Potentially controversial: The `@id` and `orcid` fields are duplicated, see below

```
  "schema:author": [
    {
      "@id": "myORCID",
      "@type": "schema:Person",
      "orcid": "myORCID",
      "schema:familyName": "Lastname",
      "schema:givenName": "Firstname"
    }]
```

### Issue
The only issue that I found is that since the Tale's creator (which doesn't have an ORCID) is added to the tale['authors'] (which defaults the ORCID to ''), is then added to the manifest (that uses the oricd as the `@id`), the `@id` will be blank. 

### Testing Steps
1. Check this branch out
2. Create a Tale
3. Query the Tale and notice that the only object in `tale['authors']` is you
4. Copy the Tale object and paste it into the body for the Tale PUT query
5. Modify the `tale['authors']` section to add a record for someone else
6. PUT
7. GET the Tale again and note that the change persisted
8. Generate the manifest
9. Confirm you see the authors fields
This is attached to issue #272 