### PR TITLE
Add publishInfo as array

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -44,5 +44,6 @@ add_python_test(dataset
   EXTERNAL_DATA
   plugins/wholetale/dataset_register.txt
 )
+add_python_test(publish PLUGIN wholetale)
 add_python_style_test(python_static_analysis_wholetale
                       "${PROJECT_SOURCE_DIR}/plugins/wholetale/server")

--- a/plugin_tests/publish_test.py
+++ b/plugin_tests/publish_test.py
@@ -1,0 +1,72 @@
+import mock
+import json
+from tests import base
+
+
+def setUpModule():
+    base.enabledPlugins.append('wholetale')
+    base.startServer()
+
+    global JobStatus, Tale
+    from girder.plugins.jobs.constants import JobStatus
+    from girder.plugins.wholetale.models.tale import Tale
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class PublishTestCase(base.TestCase):
+
+    def setUp(self):
+        super(PublishTestCase, self).setUp()
+        users = ({
+            'email': 'root@dev.null',
+            'login': 'admin',
+            'firstName': 'Root',
+            'lastName': 'van Klompf',
+            'password': 'secret'
+        }, {
+            'email': 'joe@dev.null',
+            'login': 'joeregular',
+            'firstName': 'Joe',
+            'lastName': 'Regular',
+            'password': 'secret'
+        })
+        self.admin, self.user = [self.model('user').createUser(**user)
+                                 for user in users]
+
+    @mock.patch('gwvolman.tasks.publish')
+    def testPublish(self, it):
+        with mock.patch('girder_worker.task.celery.Task.apply_async', spec=True) \
+                as mock_apply_async:
+
+            taleId = 'abc123'
+            remoteMemberNode = 'remoteMemberURL'
+            authToken = 'tokenXXX'
+
+            mock_apply_async().job.return_value = json.dumps({'job': 1, 'blah': 2})
+            resp = self.request(
+                path='/publish/dataone', method='GET', user=self.user,
+                     params={
+                         'taleId': taleId,
+                         'remoteMemberNode': remoteMemberNode,
+                         'authToken': authToken
+                     })
+            self.assertStatusOk(resp)
+            job_call = mock_apply_async.call_args_list[-1][-1]
+            self.assertEqual(job_call['headers']['girder_job_title'], 'Publish Tale')
+            self.assertEqual(
+                job_call['kwargs'],
+                ({
+                    'dataone_auth_token': authToken,
+                    'dataone_node': remoteMemberNode,
+                    'tale': taleId,
+                    'user_id': str(self.user['_id'])
+                })
+            )
+
+    def tearDown(self):
+        self.model('user').remove(self.user)
+        self.model('user').remove(self.admin)
+        super(PublishTestCase, self).tearDown()

--- a/plugin_tests/publish_test.py
+++ b/plugin_tests/publish_test.py
@@ -1,5 +1,5 @@
+from bson import ObjectId
 import mock
-import json
 from tests import base
 
 
@@ -16,54 +16,80 @@ def tearDownModule():
     base.stopServer()
 
 
-class PublishTestCase(base.TestCase):
+class FakeJob:
 
+    job = {}
+
+    def delay(self, *args, **kwargs):
+        return self.job
+
+
+class PublishTestCase(base.TestCase):
     def setUp(self):
         super(PublishTestCase, self).setUp()
-        users = ({
-            'email': 'root@dev.null',
-            'login': 'admin',
-            'firstName': 'Root',
-            'lastName': 'van Klompf',
-            'password': 'secret'
-        }, {
-            'email': 'joe@dev.null',
-            'login': 'joeregular',
-            'firstName': 'Joe',
-            'lastName': 'Regular',
-            'password': 'secret'
-        })
-        self.admin, self.user = [self.model('user').createUser(**user)
-                                 for user in users]
+        users = (
+            {
+                'email': 'root@dev.null',
+                'login': 'admin',
+                'firstName': 'Root',
+                'lastName': 'van Klompf',
+                'password': 'secret',
+            },
+            {
+                'email': 'joe@dev.null',
+                'login': 'joeregular',
+                'firstName': 'Joe',
+                'lastName': 'Regular',
+                'password': 'secret',
+            },
+        )
+        self.admin, self.user = [
+            self.model('user').createUser(**user) for user in users
+        ]
 
-    @mock.patch('gwvolman.tasks.publish')
-    def testPublish(self, it):
-        with mock.patch('girder_worker.task.celery.Task.apply_async', spec=True) \
-                as mock_apply_async:
+        self.tale = self.model('tale', 'wholetale').createTale(
+            {'_id': ObjectId()},
+            data=[],
+            authors=self.user['firstName'] + ' ' + self.user['lastName'],
+            creator=self.user,
+            public=True,
+            description="blah",
+            title="Test",
+            illustration='linkToImage',
+        )
 
-            taleId = 'abc123'
+    def testPublish(self):
+        with mock.patch('gwvolman.tasks.publish.apply_async'), mock.patch(
+            'gwvolman.tasks.publish.delay'
+        ) as dl:
+
+            dl.return_value = FakeJob()
             remoteMemberNode = 'remoteMemberURL'
             authToken = 'tokenXXX'
 
-            mock_apply_async().job.return_value = json.dumps({'job': 1, 'blah': 2})
             resp = self.request(
-                path='/publish/dataone', method='GET', user=self.user,
-                     params={
-                         'taleId': taleId,
-                         'remoteMemberNode': remoteMemberNode,
-                         'authToken': authToken
-                     })
+                path='/publish/dataone',
+                method='GET',
+                user=self.user,
+                params={
+                    'taleId': str(self.tale['_id']),
+                    'remoteMemberNode': remoteMemberNode,
+                    'authToken': authToken,
+                },
+            )
             self.assertStatusOk(resp)
-            job_call = mock_apply_async.call_args_list[-1][-1]
-            self.assertEqual(job_call['headers']['girder_job_title'], 'Publish Tale')
-            self.assertEqual(
-                job_call['kwargs'],
-                ({
-                    'dataone_auth_token': authToken,
-                    'dataone_node': remoteMemberNode,
-                    'tale': taleId,
-                    'user_id': str(self.user['_id'])
-                })
+            job_call = dl.call_args_list[-1][-1]
+            job_call.pop('girder_client_token')
+            self.assertDictEqual(
+                job_call,
+                (
+                    {
+                        'dataone_auth_token': authToken,
+                        'dataone_node': remoteMemberNode,
+                        'tale': str(self.tale['_id']),
+                        'user_id': str(self.user['_id']),
+                    }
+                ),
             )
 
     def tearDown(self):

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -168,11 +168,16 @@ class TaleTestCase(base.TestCase):
                 'title': 'new name',
                 'description': 'new description',
                 'config': {'memLimit': '2g'},
-                'public': True,
-                'published': False,
-                'doi': 'doi:10.x.x.xx',
-                'publishedURI': 'publishedURI_URL',
-                'licenseSPDX': taleLicense
+                'public': False,
+                'licenseSPDX': taleLicense,
+                'publishInfo': [
+                    {
+                
+                       'pid': 'published_pid',
+                       'uri': 'published_url',
+                       'date': '2019-01-23T15:48:17.476000+00:00',
+                    }
+                ]
             })
         )
         self.assertStatusOk(resp)
@@ -512,7 +517,7 @@ class TaleTestCase(base.TestCase):
             "folderId": data_dir['_id'],
             "imageId": "5873dcdbaec030000144d233",
             "public": True,
-            "published": False,
+            "publishInfo": [],
             "title": "Fake Unvalidated Tale"
         }
         tale = self.model('tale', 'wholetale').save(tale)  # get's id
@@ -572,9 +577,6 @@ class TaleTestCase(base.TestCase):
         description = 'new description'
         config = {'memLimit': '2g'}
         public = True
-        published = True
-        doi = 'doi:10.x.zz'
-        published_uri = 'atestURI'
         tale_licenses = WholeTaleLicense()
         taleLicense = tale_licenses.supported_spdxes().pop()
 
@@ -592,10 +594,14 @@ class TaleTestCase(base.TestCase):
                 'description': 'description',
                 'config': {},
                 'public': False,
-                'published': False,
-                'doi': 'doi',
-                'publishedURI': 'published_uri',
-                'licenseSPDX': taleLicense
+                'licenseSPDX': taleLicense,
+                'publishInfo': [
+                    {
+                       'pid': 'published_pid',
+                       'uri': 'published_url',
+                       'date': '2019-01-23T15:48:17.476000+00:00',
+                    }
+                ]
             })
         )
 
@@ -618,10 +624,14 @@ class TaleTestCase(base.TestCase):
                 'description': description,
                 'config': config,
                 'public': public,
-                'published': published,
-                'doi': doi,
-                'publishedURI': published_uri,
-                'licenseSPDX': newLicense
+                'licenseSPDX': newLicense,
+                'publishInfo': [
+                    {
+                        'pid': 'published_pid',
+                        'uri': 'published_url',
+                        'date': '2019-01-23T15:48:17.476000+00:00',
+                    }
+                ]
             })
         )
 
@@ -632,9 +642,9 @@ class TaleTestCase(base.TestCase):
         self.assertEqual(resp.json['description'], description)
         self.assertEqual(resp.json['config'], config)
         self.assertEqual(resp.json['public'], public)
-        self.assertEqual(resp.json['published'], published)
-        self.assertEqual(resp.json['doi'], doi)
-        self.assertEqual(resp.json['publishedURI'], published_uri)
+        self.assertEqual(resp.json['publishInfo'][0]['pid'], 'published_pid')
+        self.assertEqual(resp.json['publishInfo'][0]['uri'], 'published_url')
+        self.assertEqual(resp.json['publishInfo'][0]['date'], '2019-01-23T15:48:17.476000+00:00')
         self.assertEqual(resp.json['licenseSPDX'], newLicense)
 
     def testManifest(self):
@@ -650,9 +660,7 @@ class TaleTestCase(base.TestCase):
                 'description': 'description',
                 'config': {},
                 'public': False,
-                'published': False,
-                'doi': 'doi',
-                'publishedURI': 'published_uri',
+                'publishInfo': [],
                 'licenseSPDX': WholeTaleLicense.default_spdx()
             })
         )
@@ -661,7 +669,7 @@ class TaleTestCase(base.TestCase):
         pth = '/tale/{}/manifest'.format(str(resp.json['_id']))
         resp = self.request(
             path=pth, method='GET', user=self.user)
-        # The contents of the manifes are checked in the manifest tests, so
+        # The contents of the manifest are checked in the manifest tests, so
         # just make sure that we get the right response
         self.assertStatus(resp, 200)
 
@@ -765,9 +773,7 @@ class TaleTestCase(base.TestCase):
                 'description': 'description',
                 'config': {},
                 'public': False,
-                'published': False,
-                'doi': 'doi',
-                'publishedURI': 'published_uri',
+                'publishInfo': [],
                 'licenseSPDX': WholeTaleLicense.default_spdx()
             })
         )

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -31,16 +31,15 @@ class Tale(AccessControlledModel):
         })
         self.modifiableFields = {
             'title', 'description', 'public', 'config', 'updated', 'authors',
-            'category', 'icon', 'iframe', 'illustration', 'dataSet',
-            'published', 'doi', 'publishedURI', 'licenseSPDX', 'workspaceModified'
+            'category', 'icon', 'iframe', 'illustration', 'dataSet', 'licenseSPDX',
+            'workspaceModified', 'publishInfo'
         }
         self.exposeFields(
             level=AccessType.READ,
             fields=({'_id', 'folderId', 'imageId', 'creatorId', 'created',
                      'format', 'dataSet', 'narrative', 'narrativeId', 'licenseSPDX',
-                     'imageInfo', 'doi', 'publishedURI', 'workspaceId',
+                     'imageInfo', 'publishInfo', 'workspaceId',
                      'workspaceModified'} | self.modifiableFields))
-        self.exposeFields(level=AccessType.ADMIN, fields={'published'})
 
     def validate(self, tale):
         if 'iframe' not in tale:
@@ -49,11 +48,8 @@ class Tale(AccessControlledModel):
         if '_id' not in tale:
             return tale
 
-        if 'doi' not in tale:
-            tale['doi'] = None
-
-        if 'publishedURI' not in tale:
-            tale['publishedURI'] = None
+        if 'publishInfo' not in tale:
+            tale['publishInfo'] = []
 
         if 'dataSet' not in tale:
             tale['dataSet'] = []
@@ -64,13 +60,6 @@ class Tale(AccessControlledModel):
         if tale['licenseSPDX'] not in tale_licenses.supported_spdxes():
             tale['licenseSPDX'] = WholeTaleLicense.default_spdx()
 
-        return tale
-
-    def setPublished(self, tale, publish, save=False):
-        assert isinstance(publish, bool)
-        tale['published'] = publish or tale['published']
-        if save:
-            tale = self.save(tale)
         return tale
 
     def list(self, user=None, data=None, image=None, limit=0, offset=0,
@@ -104,9 +93,8 @@ class Tale(AccessControlledModel):
             yield r
 
     def createTale(self, image, data, creator=None, save=True, title=None,
-                   description=None, public=None, config=None, published=False,
-                   authors=None, icon=None, category=None, illustration=None,
-                   narrative=None, doi=None, publishedURI=None,
+                   description=None, public=None, config=None, authors=None,
+                   icon=None, category=None, illustration=None, narrative=None,
                    licenseSPDX=WholeTaleLicense.default_spdx()):
 
         if creator is None:
@@ -136,10 +124,7 @@ class Tale(AccessControlledModel):
             'narrative': narrative or [],
             'title': title,
             'public': public,
-            'published': published,
             'updated': now,
-            'doi': doi,
-            'publishedURI': publishedURI,
             'licenseSPDX': licenseSPDX
         }
         if public is not None and isinstance(public, bool):

--- a/server/rest/publish.py
+++ b/server/rest/publish.py
@@ -5,7 +5,6 @@ from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.constants import TokenScope
 from girder.api.rest import Resource
-from girder.plugins.jobs.models.job import Job
 
 from gwvolman.tasks import publish
 

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -239,8 +239,7 @@ class Tale(Resource):
                                      'images/demo-graph2.jpg')),
                 authors=tale.get('authors', default_author),
                 category=tale.get('category', 'science'),
-                published=False, narrative=tale.get('narrative'),
-                doi=tale.get('doi'), publishedURI=tale.get('publishedURI'),
+                narrative=tale.get('narrative'),
                 licenseSPDX=tale.get('licenseSPDX')
             )
 

--- a/server/schema/misc.py
+++ b/server/schema/misc.py
@@ -2,6 +2,37 @@
 # -*- coding: utf-8 -*-
 from girder.api.docs import addModel
 
+publishInfoSchema = {
+    'title': 'publishInfo',
+    '$schema': 'http://json-schema.org/draft-04/schema#',
+    'description': 'A schema representing publishing information',
+    'type': 'object',
+    'properties': {
+        "pid": {
+            "type": ["string", "null"],
+            "description": "A unique identifier assigned to this tale from a "
+                           "publishing source."
+        },
+        "uri": {
+            "type": ["string", "null"],
+            "description": "A URI pointing to the location of the published "
+                           "Tale."
+        },
+        "date": {
+            'type': 'string',
+            'format': 'date-time',
+            "description": "Date Tale was published."
+        }
+    },
+    'required': ['pid', 'uri', 'date']
+}
+
+publishInfoListSchema = {
+    'title': 'list of publishInfos',
+    '$schema': 'http://json-schema.org/draft-04/schema#',
+    'type': 'array',
+    'items': publishInfoSchema,
+}
 
 dataResourceSchema = {
     'title': 'dataResource',

--- a/server/schema/tale.py
+++ b/server/schema/tale.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from .misc import containerConfigSchema, dataSetSchema, imageInfoSchema
+from .misc import containerConfigSchema, \
+    dataSetSchema, \
+    imageInfoSchema, \
+    publishInfoListSchema
 
 taleModel = {
     "definitions": {
         "containerConfig": containerConfigSchema,
         "dataSet": dataSetSchema,
-        'imageInfo': imageInfoSchema
+        'imageInfo': imageInfoSchema,
+        "publishInfo": publishInfoListSchema,
     },
     "description": "Object representing a Tale.",
     "required": [
@@ -66,11 +70,6 @@ taleModel = {
             "description": "If set to true the Tale is accessible by anyone.",
             "default": True
         },
-        "published": {
-            "type": "boolean",
-            "default": False,
-            "description": "If set to true the Tale cannot be deleted or made unpublished."
-        },
         "config": {
             "$ref": "#/definitions/containerConfig"
         },
@@ -115,15 +114,8 @@ taleModel = {
             "type": "string",
             "description": "The license that the Tale is under"
         },
-        "doi": {
-            "type": ["string", "null"],
-            "description": "A unique identifier assigned to this tale from a "
-                           "publishing source."
-        },
-        "publishedURI": {
-            "type": ["string", "null"],
-            "description": "A URI pointing to the location of the published "
-                           "Tale."
+        "publishInfo": {
+            "$ref": "#/definitions/publishInfo"
         }
     },
     'example': {
@@ -159,9 +151,13 @@ taleModel = {
         "narrative": [],
         "narrativeId": "5c4887409759c200017b2319",
         "public": False,
-        "published": False,
-        "publishedURI": "https://dev.nceas.ucsb.edu/view/urn:uuid:939e48ec-1107-45d9"
-                        "-baa7-05cef08e51cd",
+        "publishInfo": [
+            {
+                "pid": "urn:uuid:939e48ec-1107-45d9-baa7-05cef08e51cd",
+                "uri": "https://dev.nceas.ucsb.edu/view/urn:uuid:8ec-1107-45d9-baa7-05cef08e51cd",
+                "date": "2019-01-23T15:48:17.476000+00:00"
+            }
+        ],
         "title": "My Tale",
         "license": "CC0-1.0",
         "updated": "2019-01-23T15:48:17.476000+00:00"


### PR DESCRIPTION
The current publishing implementation stores a single PID (DOI) on the Tale object, but allows the user to publish multiple times, losing track of previously published versions.  Supporting re-publishing of a Tale seems like a desirable feature, so this PR updates the Tale model and schema to support an array of objects representing published Tale packages.   I also changed the job creation to match the other gwvolman tasks (i.e., use `delay()`) 

To test:
* Checkout `dashboard` `dataone_publishing` (optional)
* Checkout `gwvolman` `dataone_publishing` (required)
* Publish a Tale
* Inspect the Tale object, note a single entry in `publishInfo`
* Publish Tale again
* Inspect the Tale object, note two entries with latest entry at the end

