### PR TITLE
Refactor code related to registration

### DIFF
--- a/server/lib/__init__.py
+++ b/server/lib/__init__.py
@@ -27,6 +27,14 @@ IMPORT_PROVIDERS.addProvider(NullImportProvider())
 
 
 def pids_to_entities(pids, user=None, base_url=None, lookup=True):
+    """
+    Resolve unique external identifiers into WholeTale Entities or file listings
+
+    :param pids: list of external identifiers
+    :param user: User performing the resolution
+    :param base_url: DataONE's node endpoint url
+    :param lookup: If false, a list of remote files is returned instead of Entities
+    """
     results = []
     try:
         for pid in pids:
@@ -51,6 +59,16 @@ def pids_to_entities(pids, user=None, base_url=None, lookup=True):
 
 
 def register_dataMap(dataMaps, parent, parentType, user=None, base_url=None):
+    """
+    Register a list of Data Maps into a given Girder object
+
+    :param dataMaps: list of dataMaps
+    :param parent: A Collection or a Folder where data should be registered
+    :param parentType: Either a 'collection' or a 'folder'
+    :param user: User performing the registration
+    :param base_url: DataONE's node endpoint url
+    :return: List of ids of registered objects
+    """
     progress = True
     importedData = []
     with ProgressContext(progress, user=user, title='Registering resources') as ctx:

--- a/server/rest/repository.py
+++ b/server/rest/repository.py
@@ -6,11 +6,9 @@ from girder.api.docs import addModel
 from girder.api.rest import Resource, RestException
 
 from girder.plugins.wholetale.lib.dataone import DataONELocations
-from ..lib import RESOLVERS, IMPORT_PROVIDERS
-from ..lib.entity import Entity
-from ..lib.resolvers import ResolutionException
 from ..lib.data_map import dataMapDoc
 from ..lib.file_map import fileMapDoc
+from ..lib import pids_to_entities
 
 
 addModel('dataMap', dataMapDoc)
@@ -25,76 +23,70 @@ class Repository(Resource):
         self.route('GET', ('lookup',), self.lookupData)
         self.route('GET', ('listFiles',), self.listFiles)
 
-    @staticmethod
-    def _buildAndResolveEntity(dataId, base_url, user):
-        entity = Entity(dataId, user)
-        entity['base_url'] = base_url
-        # resolve DOIs, etc.
-        return RESOLVERS.resolve(entity)
-
     @access.public
     @autoDescribeRoute(
         Description('Create data mapping to an external repository.')
-        .notes('Given a list of external data identifiers, '
-               'returns mapping to specific repository '
-               'along with a basic metadata, such as size, name.')
-        .jsonParam('dataId', paramType='query', required=True,
-                   description='List of external datasets identificators.')
-        .param('base_url', 'The node endpoint url. This can be used '
-                           'to register datasets from custom networks, '
-                           'such as the DataONE development network. This can '
-                           'be passed in as an ordinary string. Examples '
-                           'include https://dev.nceas.ucsb.edu/knb/d1/mn/v2 and '
-                           'https://cn.dataone.org/cn/v2',
-               required=False, dataType='string', default=DataONELocations.prod_cn)
-        .responseClass('dataMap', array=True))
+        .notes(
+            'Given a list of external data identifiers, returns mapping to specific repository '
+            'along with a basic metadata, such as size, name.'
+        )
+        .jsonParam(
+            'dataId',
+            paramType='query',
+            required=True,
+            description='List of external datasets identificators.',
+        )
+        .param(
+            'base_url',
+            'The node endpoint url. This can be used to register datasets from custom networks, '
+            'such as the DataONE development network. This can be passed in as '
+            'an ordinary string. Examples include https://dev.nceas.ucsb.edu/knb/d1/mn/v2 and '
+            'https://cn.dataone.org/cn/v2',
+            required=False,
+            dataType='string',
+            default=DataONELocations.prod_cn,
+        )
+        .responseClass('dataMap', array=True)
+    )
     def lookupData(self, dataId, base_url):
-        # methinks all logic should be in the model or lib and the resource should only
-        # delegate to the model/lib.
-        # also, why is size required at this point?
-        results = []
         try:
-            for pid in dataId:
-                entity = Repository._buildAndResolveEntity(
-                    pid.strip(), base_url, self.getCurrentUser())
-                provider = IMPORT_PROVIDERS.getProvider(entity)
-                results.append(provider.lookup(entity))
-        except ResolutionException:
-            raise RestException(
-                'Id "{}" was categorized as DOI, but its resolution failed.'.format(pid))
-        except Exception as exc:
-            raise RestException(
-                'Lookup for "{}" failed with: {}'.format(pid, str(exc)))
-
-        results = [x.toDict() for x in results]
+            results = pids_to_entities(
+                dataId, user=self.getCurrentUser(), base_url=base_url, lookup=True
+            )
+        except RuntimeError as exc:
+            raise RestException(exc.args[0])
         return sorted(results, key=lambda k: k['name'])
 
     @access.public
     @autoDescribeRoute(
-        Description('Retrieve a list of files and nested packages in a DataONE repository')
-        .notes('Given a list of external data identifiers, '
-               'returns a list of files inside along with '
-               'their sizes')
-        .jsonParam('dataId', paramType='query', required=True,
-                   description='List of external datasets identificators.')
-        .param('base_url', 'The member node base url. This can be used '
-                           'to search datasets from custom networks ,'
-                           'such as the DataONE development network.',
-               required=False, dataType='string',
-               default=DataONELocations.prod_cn)
-        .responseClass('fileMap', array=True))
+        Description(
+            'Retrieve a list of files and nested packages in a DataONE repository'
+        )
+        .notes(
+            'Given a list of external data identifiers, returns a list of files inside '
+            'along with their sizes'
+        )
+        .jsonParam(
+            'dataId',
+            paramType='query',
+            required=True,
+            description='List of external datasets identificators.',
+        )
+        .param(
+            'base_url',
+            'The member node base url. This can be used to search datasets from custom networks ,'
+            'such as the DataONE development network.',
+            required=False,
+            dataType='string',
+            default=DataONELocations.prod_cn,
+        )
+        .responseClass('fileMap', array=True)
+    )
     def listFiles(self, dataId, base_url):
-        results = []
         try:
-            for pid in dataId:
-                entity = Repository._buildAndResolveEntity(
-                    pid.strip(), base_url, self.getCurrentUser())
-                provider = IMPORT_PROVIDERS.getProvider(entity)
-                results.append(provider.listFiles(entity))
-        except ResolutionException:
-            raise RestException(
-                'Id "{}" was categorized as DOI, but its resolution failed.'.format(pid))
-        except Exception as exc:
-            raise RestException(
-                'Listing files at "{}" failed with: {}'.format(pid, str(exc)))
-        return sorted([x.toDict() for x in results], key=lambda k: list(k))
+            results = pids_to_entities(
+                dataId, user=self.getCurrentUser(), base_url=base_url, lookup=False
+            )
+        except RuntimeError as exc:
+            raise RestException(exc.args[0])
+        return sorted(results, key=lambda k: list(k))


### PR DESCRIPTION
This PR extracts some logic and functionality from `Repository` and `Dataset` resources, which shouldn't be there in the first place. As result, it's now possible to programmatically resolve and register DOIs without going through the REST layer.

### How to test?
It's basically a noop. It should be good to go if tests are passing.