### PR TITLE
Allow to expand dataSet folders in the Tale's manifest

### DIFF
--- a/server/lib/exporters/__init__.py
+++ b/server/lib/exporters/__init__.py
@@ -53,7 +53,7 @@ class TaleExporter:
     default_top_readme = "Instructions on running the docker container"
     default_bagit = "BagIt-Version: 0.97\nTag-File-Character-Encoding: UTF-8\n"
 
-    def __init__(self, tale, user, algs=None):
+    def __init__(self, tale, user, algs=None, expand_folders=False):
         if algs is None:
             self.algs = ["md5", "sha256"]
         self.tale = tale
@@ -68,7 +68,7 @@ class TaleExporter:
         self.workspace = Folder().load(
             tale['workspaceId'], user=user, level=AccessType.READ
         )
-        self.manifest = Manifest(tale, user).manifest
+        self.manifest = Manifest(tale, user, expand_folders).manifest
         self.zip_generator = ziputil.ZipGenerator(str(tale['_id']))
         self.tale_license = WholeTaleLicense().license_from_spdx(
             tale.get('licenseSPDX', WholeTaleLicense.default_spdx())

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -298,9 +298,12 @@ class Tale(Resource):
     @autoDescribeRoute(
         Description('Generate the Tale manifest')
         .modelParam('id', model='tale', plugin='wholetale', level=AccessType.READ)
+        .param('expandFolders', "If True, folders in Tale's dataSet are recursively "
+               "expanded to items in the 'aggregates' section",
+               required=False, dataType='boolean', default=False)
         .errorResponse('ID was invalid.')
     )
-    def generateManifest(self, tale):
+    def generateManifest(self, tale, expandFolders):
         """
         Creates a manifest document and returns the contents.
         :param tale: The Tale whose information is being used
@@ -309,7 +312,7 @@ class Tale(Resource):
         """
 
         user = self.getCurrentUser()
-        manifest_doc = Manifest(tale, user)
+        manifest_doc = Manifest(tale, user, expand_folders=expandFolders)
         return manifest_doc.manifest
 
     @access.user

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -286,7 +286,7 @@ class Tale(Resource):
         zip_name = str(tale['_id'])
 
         if taleFormat == 'bagit':
-            exporter = BagTaleExporter(tale, user)
+            exporter = BagTaleExporter(tale, user, expand_folders=True)
         elif taleFormat == 'native':
             exporter = NativeTaleExporter(tale, user)
 


### PR DESCRIPTION
This PR enables expanding Tale's dataSet folders into items recursively (similarly to the way we were treating folders created by HTTP(S) provider already).

### How to test?
1. Deploy locally
2. Register `doi:10.5065/D6862DM8`
3. Create a Tale and select `Humans and Hydrology...` as data source in Run > External Data
4. Export the Tale as BagIt
5. Verify that `manifest.json` in `aggregates` section and `fetch.txt` contain only files.