### PR TITLE
Changed build_tale_image tasks to pass queue=manager

### DIFF
--- a/server/models/instance.py
+++ b/server/models/instance.py
@@ -159,7 +159,7 @@ class Instance(AccessControlledModel):
             Token().addScope(token, scope=REST_CREATE_JOB_TOKEN_SCOPE)
 
             buildTask = build_tale_image.signature(
-                args=[str(tale['_id'])], queue='manager', immutable=True,
+                args=[str(tale['_id'])], immutable=True,
                 kwargs={'girder_client_token': str(token['_id'])}
             )
             volumeTask = create_volume.si(

--- a/server/models/instance.py
+++ b/server/models/instance.py
@@ -158,9 +158,9 @@ class Instance(AccessControlledModel):
             # Create single job
             Token().addScope(token, scope=REST_CREATE_JOB_TOKEN_SCOPE)
 
-            buildTask = build_tale_image.si(
-                str(tale['_id']),
-                girder_client_token=str(token['_id'])
+            buildTask = build_tale_image.signature(
+                args=[str(tale['_id'])], queue='manager', immutable=True,
+                kwargs={'girder_client_token': str(token['_id'])}
             )
             volumeTask = create_volume.si(
                 str(instance['_id']),

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -327,7 +327,7 @@ class Tale(Resource):
         token = self.getCurrentToken()
 
         buildTask = build_tale_image.signature(
-            args=[str(tale['_id'])], queue='manager',
+            args=[str(tale['_id'])],
             kwargs={
                 'girder_client_token': str(token['_id'])
             }

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -326,10 +326,12 @@ class Tale(Resource):
     def buildImage(self, tale, params):
         token = self.getCurrentToken()
 
-        buildTask = build_tale_image.delay(
-            str(tale['_id']),
-            girder_client_token=str(token['_id'])
-        )
+        buildTask = build_tale_image.signature(
+            args=[str(tale['_id'])], queue='manager',
+            kwargs={
+                'girder_client_token': str(token['_id'])
+            }
+        ).apply_async()
         return buildTask.job
 
     def updateBuildStatus(self, event):


### PR DESCRIPTION
Fixes #289.

To test:
* On a single-node and multi-node deployment
* Launch a new Tale, confirm the image build during instance launch succeeds
* Build an existing Tale, confirm the image build succeeds
