### PR TITLE
Fetch a citation for dataSets every time Tale is updated. Fixes #291

### DIFF
--- a/plugin_tests/instance_test.py
+++ b/plugin_tests/instance_test.py
@@ -80,7 +80,7 @@ class InstanceTestCase(base.TestCase):
             self.user, 'PublicFolder', parentType='user', public=True,
             creator=self.user)
 
-        data = [{'type': 'folder', 'id': self.userPrivateFolder['_id']}]
+        data = []
         self.tale_one = self.model('tale', 'wholetale').createTale(
             self.image, data, creator=self.user,
             title='tale one', public=True, config={'memLimit': '2g'})
@@ -98,7 +98,7 @@ class InstanceTestCase(base.TestCase):
         self.tale_one["imageInfo"] = fake_imageInfo
         self.model('tale', 'wholetale').save(self.tale_one)
 
-        data = [{'type': 'folder', 'id': self.userPublicFolder['_id']}]
+        data = []
         self.tale_two = self.model('tale', 'wholetale').createTale(
             self.image, data, creator=self.user,
             title='tale two', public=True, config={'memLimit': '1g'})

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -143,9 +143,7 @@ class TaleTestCase(base.TestCase):
             type='application/json',
             body=json.dumps({
                 'imageId': str(self.image['_id']),
-                'dataSet': [
-                    {'mountPath': '/' + publicFolder['name'], 'itemId': publicFolder['_id']}
-                ]
+                'dataSet': []
             })
         )
         self.assertStatusOk(resp)
@@ -201,10 +199,7 @@ class TaleTestCase(base.TestCase):
             type='application/json',
             body=json.dumps({
                 'imageId': str(self.image['_id']),
-                'dataSet': [{
-                    'mountPath': '/' + privateFolder['name'],
-                    'itemId': privateFolder['_id']
-                }]
+                'dataSet': [],
             })
         )
         self.assertStatusOk(resp)
@@ -215,10 +210,7 @@ class TaleTestCase(base.TestCase):
             type='application/json',
             body=json.dumps({
                 'imageId': str(self.image['_id']),
-                'dataSet': [{
-                    'mountPath': '/' + privateFolder['name'],
-                    'itemId': adminPublicFolder['_id']
-                }],
+                'dataSet': [],
                 'public': False
             })
         )
@@ -297,9 +289,7 @@ class TaleTestCase(base.TestCase):
                 body=json.dumps(
                     {
                         'imageId': str(self.image['_id']),
-                        'dataSet': [
-                            {'mountPath': '/' + folder['name'], 'itemId': folder['_id']}
-                        ],
+                        'dataSet': [],
                         'public': True
                     })
             )
@@ -312,9 +302,7 @@ class TaleTestCase(base.TestCase):
                 body=json.dumps(
                     {
                         'imageId': str(self.image_admin['_id']),
-                        'dataSet': [
-                            {'mountPath': '/' + folder['name'], 'itemId': folder['_id']}
-                        ]
+                        'dataSet': [],
                     })
             )
             self.assertStatusOk(resp)
@@ -471,9 +459,7 @@ class TaleTestCase(base.TestCase):
             type='application/json',
             body=json.dumps({
                 'imageId': str(self.image['_id']),
-                'dataSet': [
-                    {'mountPath': '/' + sub_home_dir['name'], 'itemId': sub_home_dir['_id']}
-                ],
+                'dataSet': [],
                 'narrative': [str(my_narrative['_id'])]
             })
         )
@@ -604,9 +590,7 @@ class TaleTestCase(base.TestCase):
             body=json.dumps({
                 'folderId': '1234',
                 'imageId': str(self.image['_id']),
-                'dataSet': [
-                    {'mountPath': '/' + 'folder', 'itemId': '123456'}
-                ],
+                'dataSet': [],
                 'title': 'tale tile',
                 'description': 'description',
                 'config': {},
@@ -648,9 +632,7 @@ class TaleTestCase(base.TestCase):
                 'authors': new_authors,
                 'folderId': '1234',
                 'imageId': str(self.image['_id']),
-                'dataSet': [
-                    {'mountPath': '/' + 'folder', 'itemId': '123456'}
-                ],
+                'dataSet': [],
                 'title': title,
                 'description': description,
                 'config': config,

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -842,6 +842,21 @@ class TaleTestCase(base.TestCase):
         except bagit.BagValidationError:
             pass  # TODO: Goes without saying that we should not be doing that...
         shutil.rmtree(dirpath)
+
+        # Test dataSetCitation
+        resp = self.request(
+            path='/tale/{_id}'.format(**tale), method='PUT',
+            type='application/json',
+            user=self.user, body=json.dumps({
+                'dataSet': [],
+                'imageId': str(tale['imageId']),
+                'public': tale['public'],
+            })
+        )
+        self.assertStatusOk(resp)
+        tale = resp.json
+        self.assertEqual(tale['dataSetCitation'], [])
+
         self.model('tale', 'wholetale').remove(tale)
         self.model('collection').remove(self.data_collection)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ dataone.common==3.2.0
 dataone.libclient==3.2.0
 dataone.cli==3.2.0
 validators
+html2markdown

--- a/server/lib/__init__.py
+++ b/server/lib/__init__.py
@@ -95,7 +95,8 @@ def update_citation(event):
     dataset_top_identifiers = set()
     for obj in tale.get('dataSet', []):
         doc = ModelImporter.model(obj['_modelType']).load(
-            obj['itemId'], user=user, level=AccessType.READ, exc=True)
+            obj['itemId'], user=user, level=AccessType.READ, exc=True
+        )
         provider_name = doc['meta']['provider']
         if provider_name.startswith('HTTP'):
             provider_name = 'HTTP'  # TODO: handle HTTPS to make it unnecessary
@@ -109,7 +110,10 @@ def update_citation(event):
         if doi.startswith('doi:'):
             doi = doi[4:]
         try:
-            url = 'https://api.datacite.org/dois/text/x-bibliography/{}?style=harvard'
+            url = (
+                'https://api.datacite.org/dois/'
+                'text/x-bibliography/{}?style=harvard-cite-them-right'
+            )
             citations.append(urlopen(url.format(doi)).read().decode())
         except Exception as ex:
             logger.info('Unable to get a citation for %s, getting "%s"', doi, str(ex))

--- a/server/lib/__init__.py
+++ b/server/lib/__init__.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from urllib.request import urlopen
+
+from girder import events, logger
+from girder.constants import AccessType
+from girder.utility.model_importer import ModelImporter
 from girder.utility.progress import ProgressContext
 from .data_map import DataMap
 from .entity import Entity
@@ -81,3 +86,36 @@ def register_dataMap(dataMaps, parent, parentType, user=None, base_url=None):
             )
             importedData.append(obj['_id'])
     return importedData
+
+
+def update_citation(event):
+    tale = event.info['tale']
+    user = event.info['user']
+
+    dataset_top_identifiers = set()
+    for obj in tale.get('dataSet', []):
+        doc = ModelImporter.model(obj['_modelType']).load(
+            obj['itemId'], user=user, level=AccessType.READ, exc=True)
+        provider_name = doc['meta']['provider']
+        if provider_name.startswith('HTTP'):
+            provider_name = 'HTTP'  # TODO: handle HTTPS to make it unnecessary
+        provider = IMPORT_PROVIDERS.providerMap[provider_name]
+        top_identifier = provider.getDatasetUID(doc, user)
+        if top_identifier:
+            dataset_top_identifiers.add(top_identifier)
+
+    citations = []
+    for doi in dataset_top_identifiers:
+        if doi.startswith('doi:'):
+            doi = doi[4:]
+        try:
+            url = 'https://api.datacite.org/dois/text/x-bibliography/{}?style=harvard'
+            citations.append(urlopen(url.format(doi)).read().decode())
+        except Exception as ex:
+            logger.info('Unable to get a citation for %s, getting "%s"', doi, str(ex))
+
+    tale['dataSetCitation'] = citations
+    event.preventDefault().addResponse(tale)
+
+
+events.bind('tale.update_citation', 'wholetale', update_citation)

--- a/server/lib/__init__.py
+++ b/server/lib/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import html2markdown
 from urllib.request import urlopen
 
 from girder import events, logger
@@ -114,7 +115,9 @@ def update_citation(event):
                 'https://api.datacite.org/dois/'
                 'text/x-bibliography/{}?style=harvard-cite-them-right'
             )
-            citations.append(urlopen(url.format(doi)).read().decode())
+            citations.append(
+                html2markdown.convert(urlopen(url.format(doi)).read().decode())
+            )
         except Exception as ex:
             logger.info('Unable to get a citation for %s, getting "%s"', doi, str(ex))
 

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 
+from bson.objectid import ObjectId
 import datetime
 
-from bson.objectid import ObjectId
-
-from ..constants import WORKSPACE_NAME, DATADIRS_NAME, SCRIPTDIRS_NAME
-from ..utils import getOrCreateRootFolder
-from ..lib.license import WholeTaleLicense
+from girder import events
 from girder.models.model_base import AccessControlledModel
 from girder.models.item import Item
 from girder.models.folder import Folder
 from girder.constants import AccessType
 from girder.exceptions import AccessException
+from ..constants import WORKSPACE_NAME, DATADIRS_NAME, SCRIPTDIRS_NAME
+from ..utils import getOrCreateRootFolder
+from ..lib.license import WholeTaleLicense
 
 
 # Whenever the Tale object schema is modified (e.g. fields are added or
@@ -39,7 +39,7 @@ class Tale(AccessControlledModel):
             fields=({'_id', 'folderId', 'imageId', 'creatorId', 'created',
                      'format', 'dataSet', 'narrative', 'narrativeId', 'licenseSPDX',
                      'imageInfo', 'publishInfo', 'workspaceId',
-                     'workspaceModified'} | self.modifiableFields))
+                     'workspaceModified', 'dataSetCitation'} | self.modifiableFields))
 
     def validate(self, tale):
         if 'iframe' not in tale:
@@ -62,6 +62,9 @@ class Tale(AccessControlledModel):
 
         if tale.get('config') is None:
             tale['config'] = {}
+
+        if tale.get('dataSetCitation') is None:
+            tale['dataSetCitation'] = []
 
         if not isinstance(tale['authors'], list):
             # Set the authors to the Tale creator
@@ -144,6 +147,12 @@ class Tale(AccessControlledModel):
         if creator is not None:
             self.setUserAccess(tale, user=creator, level=AccessType.ADMIN,
                                save=False)
+        if tale['dataSet']:
+            eventParams = {'tale': tale, 'user': creator}
+            event = events.trigger('tale.update_citation', eventParams)
+            if len(event.responses):
+                tale = event.responses[-1]
+
         if save:
             tale = self.save(tale)
             workspace = self.createWorkspace(tale, creator=creator)
@@ -157,6 +166,7 @@ class Tale(AccessControlledModel):
                 Item().copyItem(item, creator, folder=narrative_folder)
             tale['narrativeId'] = narrative_folder['_id']
             tale = self.save(tale)
+
         return tale
 
     def createNarrativeFolder(self, tale, creator=None, default=False):

--- a/server/rest/wholetale.py
+++ b/server/rest/wholetale.py
@@ -1,23 +1,37 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from girder import events
 from girder.api import access
-from girder.api.describe import Description, describeRoute
+from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import Resource
 
 from ..constants import API_VERSION
+from ..models.tale import Tale
 
 
 class wholeTale(Resource):
-
     def __init__(self):
         super(wholeTale, self).__init__()
         self.resourceName = 'wholetale'
 
         self.route('GET', (), self.get_wholetale_info)
+        self.route('PUT', ('citations',), self.regenerate_citations)
 
     @access.public
-    @describeRoute(
-        Description('Return basic info about Whole Tale plugin')
-    )
+    @autoDescribeRoute(Description('Return basic info about Whole Tale plugin'))
     def get_wholetale_info(self, params):
         return {'api_version': API_VERSION}
+
+    @access.admin
+    @autoDescribeRoute(
+        Description('Regenerate dataSetCitation for all Tales').notes(
+            'Hopefully DataCite will still love us, after we hammer their API'
+        )
+    )
+    def regenerate_citations(self):
+        user = self.getCurrentUser()
+        for tale in Tale().find({'dataSet': {'$ne': []}}):
+            eventParams = {'tale': tale, 'user': user}
+            event = events.trigger('tale.update_citation', eventParams)
+            if len(event.responses):
+                Tale().save(event.responses[-1])


### PR DESCRIPTION
In order to facilitate https://github.com/whole-tale/dashboard/issues/450, this PR introduces `dataSetCitation` field on a `Tale` object. It's regenerated every time Tale's `dataSet` changes.

### Aproach
During `PUT /tale/{id}` and `POST /tale` trigger an event that:
1. creates a set of DOIs based on `dataSet`
2. fetches citation string from DataCite
3. returns a Tale with an updated `dataSetCitation` field

### How to test?
1. Create a Tale with data registered using DOI
2. Confirm that Tale's `dataSetCitation` contains a citation.

### TODO
- [x] Add tests