### PR TITLE
Revert "Add Structured Multiple Authors to Tale. Fixes #272"

### DIFF
--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -2,6 +2,7 @@ import json
 import os
 from tests import base
 from bson import ObjectId
+from girder.exceptions import AccessException
 from girder.utility.path import lookUpPath
 
 
@@ -52,19 +53,6 @@ class ManifestTestCase(base.TestCase):
         )
         self.admin, self.user, self.userHenry = [
             self.model('user').createUser(**user) for user in self.users
-        ]
-
-        self.new_authors = [
-            {
-                "firstName": self.admin['firstName'],
-                "lastName": self.admin['lastName'],
-                "orcid": 'https://orcid.org/1234'
-            },
-            {
-                "firstName": self.user['firstName'],
-                "lastName": self.user['lastName'],
-                "orcid": 'https://orcid.org/9876'
-            }
         ]
 
         data_collection = self.model('collection').createCollection(
@@ -144,11 +132,11 @@ class ManifestTestCase(base.TestCase):
                 }
             )
 
-        self.tale_info = {
+        tale_info = {
             '_id': ObjectId(),
             'name': 'Main Tale',
             'description': 'Tale Desc',
-            'authors': self.new_authors,
+            'authors': self.user['firstName'] + ' ' + self.user['lastName'],
             'creator': self.user,
             'public': True,
             'data': dataSet,
@@ -156,23 +144,23 @@ class ManifestTestCase(base.TestCase):
         }
 
         self.tale = self.model('tale', 'wholetale').createTale(
-            {'_id': self.tale_info['_id']},
-            data=self.tale_info['data'],
-            creator=self.tale_info['creator'],
-            title=self.tale_info['name'],
-            public=self.tale_info['public'],
-            description=self.tale_info['description'],
-            authors=self.tale_info['authors'],
+            {'_id': tale_info['_id']},
+            data=tale_info['data'],
+            creator=tale_info['creator'],
+            title=tale_info['name'],
+            public=tale_info['public'],
+            description=tale_info['description'],
+            authors=tale_info['authors'],
         )
 
         self.tale2 = self.model('tale', 'wholetale').createTale(
-            {'_id': self.tale_info['_id']},
+            {'_id': tale_info['_id']},
             data=[],
-            creator=self.tale_info['creator'],
-            title=self.tale_info['name'],
-            public=self.tale_info['public'],
-            description=self.tale_info['description'],
-            authors=self.tale_info['authors'],
+            creator=tale_info['creator'],
+            title=tale_info['name'],
+            public=tale_info['public'],
+            description=tale_info['description'],
+            authors=tale_info['authors'],
         )
 
     def testManifest(self):
@@ -185,7 +173,6 @@ class ManifestTestCase(base.TestCase):
         self._testDataSet()
         self._test_different_user()
         self._testWorkspace()
-        self._testValidate()
 
     def _testCreateBasicAttributes(self):
         # Test that the basic attributes are correct
@@ -253,11 +240,6 @@ class ManifestTestCase(base.TestCase):
         parent_dataset = 'urn:uuid:100.99.xx'
         agg = manifest_doc.create_aggregation_record(uri, bundle, parent_dataset)
         self.assertEqual(agg['schema:isPartOf'], parent_dataset)
-
-    def _testAddTaleCreator(self):
-        from server.lib.manifest import Manifest
-        manifest_doc = Manifest(self.tale, self.user)
-        self.assertTrue(len(manifest_doc.manifest['schema:author']))
 
     def _testGetFolderIdentifier(self):
         from server.lib.manifest import get_folder_identifier
@@ -392,38 +374,6 @@ class ManifestTestCase(base.TestCase):
             Manifest(self.tale, self.userHenry)
         except AccessException:
             self.assertFalse(1)
-
-    def _testValidate(self):
-        from server.lib.manifest import Manifest
-
-        missing_orcid = {'firstName': 'Lord',
-                         'lastName': 'Kelvin'}
-        blank_orcid = {'firstName': 'Isaac',
-                       'lastName': 'Newton',
-                       'orcid': ''}
-
-        tale_missing_orcid = self.model('tale', 'wholetale').createTale(
-            {'_id': self.tale_info['_id']},
-            data=[],
-            creator=self.tale_info['creator'],
-            title=self.tale_info['name'],
-            public=self.tale_info['public'],
-            description=self.tale_info['description'],
-            authors=missing_orcid)
-
-        with self.assertRaises(ValueError):
-            Manifest(tale_missing_orcid, self.user)
-
-        tale_blank_orcid = self.model('tale', 'wholetale').createTale(
-            {'_id': self.tale_info['_id']},
-            data=[],
-            creator=self.tale_info['creator'],
-            title=self.tale_info['name'],
-            public=self.tale_info['public'],
-            description=self.tale_info['description'],
-            authors=missing_orcid)
-        with self.assertRaises(ValueError):
-            Manifest(tale_blank_orcid, self.user)
 
     def tearDown(self):
         self.model('user').remove(self.user)

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -79,19 +79,6 @@ class TaleTestCase(base.TestCase):
             'lastName': 'Regular',
             'password': 'secret'
         })
-
-        self.authors = [
-            {
-                'firstName': 'Charles',
-                'lastName': 'Darwmin',
-                'orcid': 'https://orcid.org/000-000'
-            },
-            {
-                'firstName': 'Thomas',
-                'lastName': 'Edison',
-                'orcid': 'https://orcid.org/111-111'
-            }
-        ]
         self.admin, self.user = [self.model('user').createUser(**user)
                                  for user in users]
 
@@ -531,8 +518,7 @@ class TaleTestCase(base.TestCase):
             "imageId": "5873dcdbaec030000144d233",
             "public": True,
             "publishInfo": [],
-            "title": "Fake Unvalidated Tale",
-            "authors": "Root Von Kolmph"
+            "title": "Fake Unvalidated Tale"
         }
         tale = self.model('tale', 'wholetale').save(tale)  # get's id
         tale = self.model('tale', 'wholetale').save(tale)  # migrate to new format
@@ -552,11 +538,6 @@ class TaleTestCase(base.TestCase):
         tale['licenseSPDX'] = 'unsupportedLicense'
         tale = self.model('tale', 'wholetale').save(tale)
         self.assertEqual(tale['licenseSPDX'], WholeTaleLicense.default_spdx())
-        self.assertTrue(isinstance(tale['authors'], list))
-        single_author = tale['authors'][0]
-        self.assertEqual(single_author['firstName'], self.user['firstName'])
-        self.assertEqual(single_author['lastName'], self.user['lastName'])
-        self.assertEqual(single_author['orcid'], '')
         self.model('tale', 'wholetale').remove(tale)
 
     @mock.patch('gwvolman.tasks.import_tale')
@@ -627,19 +608,6 @@ class TaleTestCase(base.TestCase):
         self.assertStatus(resp, 200)
 
         newLicense = tale_licenses.supported_spdxes().pop()
-        admin_orcid, user_orcid = 'https://orcid.org/1234', 'https://orcid.org/9876'
-        new_authors = [
-            {
-                "firstName": self.admin['firstName'],
-                "lastName": self.admin['lastName'],
-                "orcid": admin_orcid
-            },
-            {
-                "firstName": self.user['firstName'],
-                "lastName": self.user['lastName'],
-                "orcid": user_orcid
-            }
-        ]
         # Update the Tale with new values
         resp = self.request(
             path='/tale/{}'.format(str(resp.json['_id'])),
@@ -647,7 +615,6 @@ class TaleTestCase(base.TestCase):
             user=self.user,
             type='application/json',
             body=json.dumps({
-                'authors': new_authors,
                 'folderId': '1234',
                 'imageId': str(self.image['_id']),
                 'dataSet': [
@@ -679,11 +646,6 @@ class TaleTestCase(base.TestCase):
         self.assertEqual(resp.json['publishInfo'][0]['uri'], 'published_url')
         self.assertEqual(resp.json['publishInfo'][0]['date'], '2019-01-23T15:48:17.476000+00:00')
         self.assertEqual(resp.json['licenseSPDX'], newLicense)
-        self.assertTrue(isinstance(resp.json['authors'], list))
-
-        tale_authors = resp.json['authors']
-        self.assertEqual(tale_authors[0], new_authors[0])
-        self.assertEqual(tale_authors[1], new_authors[1])
 
     def testManifest(self):
         from server.lib.license import WholeTaleLicense
@@ -691,7 +653,6 @@ class TaleTestCase(base.TestCase):
             path='/tale', method='POST', user=self.user,
             type='application/json',
             body=json.dumps({
-                'authors': self.authors,
                 'folderId': '1234',
                 'imageId': str(self.image['_id']),
                 'dataSet': [],
@@ -788,7 +749,7 @@ class TaleTestCase(base.TestCase):
                 'itemId': item['_id'],
                 '_modelType': 'item',
                 'mountPath': item['name']
-            }], creator=self.user, title="Export Tale", public=True, authors=self.authors)
+            }], creator=self.user, title="Export Tale", public=True)
         workspace = self.model('folder').load(tale['workspaceId'], force=True)
         with urllib.request.urlopen(
             'https://wholetale.readthedocs.io/en/stable/'
@@ -806,7 +767,6 @@ class TaleTestCase(base.TestCase):
             path='/tale', method='POST', user=self.user,
             type='application/json',
             body=json.dumps({
-                'authors': self.authors,
                 'imageId': str(self.image['_id']),
                 'dataSet': [],
                 'title': 'tale tile',

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -31,7 +31,6 @@ class Manifest:
         self.user = user
         self.expand_folders = expand_folders
 
-        self.validate()
         self.manifest = dict()
         # Create a set that represents any external data packages
         self.datasets = set()
@@ -43,7 +42,6 @@ class Manifest:
         self.manifest.update(self.create_context())
         self.manifest.update(self.create_basic_attributes())
         self.add_tale_creator()
-        self.manifest.update(self.create_author_record())
         self.add_tale_records()
         # Add any external datasets to the manifest
         self.add_dataset_records()
@@ -65,23 +63,6 @@ class Manifest:
                 "Description": "A simple way to publish, discover, and access materials datasets"
             }
     }
-
-    def validate(self):
-        """
-        Checks for the presence of required tale information so
-        that we can fail early.
-        """
-        try:
-            # Check that each author has an ORCID, first name, and last name
-            for author in self.tale['authors']:
-                if not len(author['orcid']):
-                    raise ValueError('A Tale author is missing an ORCID')
-                if not len(author['firstName']):
-                    raise ValueError('A Tale author is missing a first name')
-                if not len(author['lastName']):
-                    raise ValueError('A Tale author is missing a last name')
-        except KeyError:
-            raise ValueError('A Tale author is missing an ORCID')
 
     def create_basic_attributes(self):
         """
@@ -111,28 +92,11 @@ class Manifest:
                                         user=self.user,
                                         force=True)
         self.manifest['createdBy'] = {
-            "@id": tale_user['email'],
+            "@id": self.tale['authors'],
             "@type": "schema:Person",
             "schema:givenName": tale_user.get('firstName', ''),
             "schema:familyName": tale_user.get('lastName', ''),
             "schema:email": tale_user.get('email', '')
-        }
-
-    def create_author_record(self):
-        """
-        Creates records for authors that are associated with a Tale
-        :return: A dictionary listing of the authors
-        """
-        return {
-            'schema:author': [
-                {
-                    "@id": author["orcid"],
-                    "@type": "schema:Person",
-                    "schema:givenName": author["firstName"],
-                    "schema:familyName": author["lastName"]
-                }
-                for author in self.tale['authors']
-            ]
         }
 
     def create_context(self):

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -17,7 +17,7 @@ from girder.exceptions import AccessException
 # Whenever the Tale object schema is modified (e.g. fields are added or
 # removed) increase `_currentTaleFormat` to retroactively apply those
 # changes to existing Tales.
-_currentTaleFormat = 7
+_currentTaleFormat = 6
 
 
 class Tale(AccessControlledModel):
@@ -63,12 +63,6 @@ class Tale(AccessControlledModel):
         if tale.get('config') is None:
             tale['config'] = {}
 
-        if not isinstance(tale['authors'], list):
-            # Set the authors to the Tale creator
-            tale_creator = self.model('user').load(tale['creatorId'], force=True)
-            tale['authors'] = [{'firstName': tale_creator['firstName'],
-                                'lastName': tale_creator['lastName'],
-                                'orcid': ''}]
         return tale
 
     def list(self, user=None, data=None, image=None, limit=0, offset=0,

--- a/server/schema/tale.py
+++ b/server/schema/tale.py
@@ -88,12 +88,11 @@ taleModel = {
             "description": "The last time when the tale was modified."
         },
         "authors": {
-            "type": "array",
-            "items": {
-                'type': 'object',
-                'description': "A JSON structure representing a Tale author."
-            },
-            "description": "A list of authors that are associated with the Tale"
+            "type": "string",
+            "description": (
+                "BEWARE: it's a string for now, but in the future it should "
+                "be a map of Author/User entities"
+            )
         },
         "category": {
             "type": "string",
@@ -123,18 +122,7 @@ taleModel = {
         "_accessLevel": 2,
         "_id": "5c4887409759c200017b2310",
         "_modelType": "tale",
-        "authors": [
-            {
-                "firstName": "Kacper",
-                "lastName": "Kowalik",
-                "orcid": "https://www.orcid.org/0000-0003-1709-3744"
-            },
-            {
-                "firstName": "Tommy",
-                "lastName": "Thelen",
-                "orcid": "https://www.orcid.org/0000-0003-1709-3754"
-            }
-        ],
+        "authors": "Kacper Kowalik",
         "category": "science",
         "config": {},
         "created": "2019-01-23T15:24:48.217000+00:00",


### PR DESCRIPTION
Reverts whole-tale/girder_wholetale#273.

Original PR should not have been merged until https://github.com/whole-tale/dashboard/pull/445 was merged too. It breaks Tale object handling on the UI side (every PUT/POST tale fails).