### PR TITLE
[WIP] Align Manifest with ROLite

### DIFF
--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -381,7 +381,7 @@ class ManifestTestCase(base.TestCase):
 
         reference_datasets = sorted(reference_datasets, key=itemgetter('@id'))
         for i, dataset in enumerate(
-            sorted(manifest_doc.manifest['Datasets'], key=itemgetter('@id'))
+            sorted(manifest_doc.manifest['dataset'], key=itemgetter('@id'))
         ):
             self.assertDictEqual(dataset, reference_datasets[i])
 

--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -194,21 +194,21 @@ class ManifestTestCase(base.TestCase):
         manifest_doc = Manifest(self.tale, self.user)
 
         attributes = manifest_doc.create_basic_attributes()
-        self.assertEqual(attributes['schema:identifier'], str(self.tale['_id']))
-        self.assertEqual(attributes['schema:name'], self.tale['title'])
-        self.assertEqual(attributes['schema:description'], self.tale['description'])
-        self.assertEqual(attributes['schema:category'], self.tale['category'])
-        self.assertEqual(attributes['schema:version'], self.tale['format'])
-        self.assertEqual(attributes['schema:image'], self.tale['illustration'])
+        self.assertEqual(attributes['identifier'], str(self.tale['_id']))
+        self.assertEqual(attributes['name'], self.tale['title'])
+        self.assertEqual(attributes['description'], self.tale['description'])
+        self.assertEqual(attributes['category'], self.tale['category'])
+        self.assertEqual(attributes['version'], self.tale['format'])
+        self.assertEqual(attributes['image'], self.tale['illustration'])
 
     def _testAddTaleCreator(self):
         from server.lib.manifest import Manifest
 
         manifest_doc = Manifest(self.tale, self.user)
         manifest_creator = manifest_doc.manifest['createdBy']
-        self.assertEqual(manifest_creator['schema:givenName'], self.user['firstName'])
-        self.assertEqual(manifest_creator['schema:familyName'], self.user['lastName'])
-        self.assertEqual(manifest_creator['schema:email'], self.user['email'])
+        self.assertEqual(manifest_creator['givenName'], self.user['firstName'])
+        self.assertEqual(manifest_creator['familyName'], self.user['lastName'])
+        self.assertEqual(manifest_creator['email'], self.user['email'])
         self.assertEqual(manifest_creator['@id'], self.tale['authors'])
 
     def _testCreateContext(self):
@@ -252,12 +252,12 @@ class ManifestTestCase(base.TestCase):
         # Test with a parent dataset
         parent_dataset = 'urn:uuid:100.99.xx'
         agg = manifest_doc.create_aggregation_record(uri, bundle, parent_dataset)
-        self.assertEqual(agg['schema:isPartOf'], parent_dataset)
+        self.assertEqual(agg['isPartOf'], parent_dataset)
 
     def _testAddTaleCreator(self):
         from server.lib.manifest import Manifest
         manifest_doc = Manifest(self.tale, self.user)
-        self.assertTrue(len(manifest_doc.manifest['schema:author']))
+        self.assertTrue(len(manifest_doc.manifest['author']))
 
     def _testGetFolderIdentifier(self):
         from server.lib.manifest import get_folder_identifier
@@ -298,7 +298,7 @@ class ManifestTestCase(base.TestCase):
             {
                 'uri': 'https://cn.dataone.org/cn/v2/resolve/urn:uuid:01a53103-8db1-46b3-967c-b42acf69ae08',
                 'bundledAs': {'folder': '../data/', 'filename': 'usco2005.xls'},
-                'schema:isPartOf': 'doi:10.5065/D6862DM8',
+                'isPartOf': 'doi:10.5065/D6862DM8',
                 'size': 6427136,
             },
             {
@@ -307,13 +307,13 @@ class ManifestTestCase(base.TestCase):
                     'folder': '../data/',
                     'filename': 'D_whites_darks_AJS.hdf',
                 },
-                'schema:isPartOf': 'doi:10.18126/M2301J',
+                'isPartOf': 'doi:10.18126/M2301J',
                 'size': 8786120536,
             },
             {
                 'uri': 'globus://82f1b5c6-6e9b-11e5-ba47-22000b92c6ec//published/publication_1106/data/Dmax',
                 'bundledAs': {'folder': '../data/Dmax/'},
-                'schema:isPartOf': 'doi:10.18126/M2662X',
+                'isPartOf': 'doi:10.18126/M2662X',
                 'size': 105050561,
             },
             {
@@ -346,7 +346,7 @@ class ManifestTestCase(base.TestCase):
                 'size': 1005007,
             },
             {'uri': '../LICENSE'},
-            {'uri': '../README.md', '@type': 'schema:HowTo'},
+            {'uri': '../README.md', '@type': 'HowTo'},
         ]
         from operator import itemgetter
 

--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -345,7 +345,7 @@ class ManifestTestCase(base.TestCase):
                 },
                 'size': 1005007,
             },
-            {'uri': '../LICENSE', 'schema:license': 'CC-BY-4.0'},
+            {'uri': '../LICENSE'},
             {'uri': '../README.md', '@type': 'schema:HowTo'},
         ]
         from operator import itemgetter

--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -195,6 +195,7 @@ class ManifestTestCase(base.TestCase):
 
         attributes = manifest_doc.create_basic_attributes()
         self.assertEqual(attributes['identifier'], str(self.tale['_id']))
+        self.assertEqual(attributes['@type'], ["DataCatalog", "ro:ResearchObject"])
         self.assertEqual(attributes['name'], self.tale['title'])
         self.assertEqual(attributes['description'], self.tale['description'])
         self.assertEqual(attributes['keywords'], self.tale['category'])

--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -197,7 +197,7 @@ class ManifestTestCase(base.TestCase):
         self.assertEqual(attributes['identifier'], str(self.tale['_id']))
         self.assertEqual(attributes['name'], self.tale['title'])
         self.assertEqual(attributes['description'], self.tale['description'])
-        self.assertEqual(attributes['category'], self.tale['category'])
+        self.assertEqual(attributes['keywords'], self.tale['category'])
         self.assertEqual(attributes['version'], self.tale['format'])
         self.assertEqual(attributes['image'], self.tale['illustration'])
 

--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -205,9 +205,11 @@ class ManifestTestCase(base.TestCase):
         from server.lib.manifest import Manifest
 
         manifest_doc = Manifest(self.tale, self.user)
-        manifest_creator = manifest_doc.manifest['createdBy']
+        manifest_creator = manifest_doc.manifest['creator']
         self.assertEqual(manifest_creator['givenName'], self.user['firstName'])
         self.assertEqual(manifest_creator['familyName'], self.user['lastName'])
+        self.assertEqual(manifest_creator['name'],
+                         self.user['firstName'] + ' ' + self.user['lastName'])
         self.assertEqual(manifest_creator['email'], self.user['email'])
         self.assertEqual(manifest_creator['@id'], self.tale['authors'])
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -4,13 +4,12 @@
 import six
 import validators
 
-from girder import events, logprint, logger
+from girder import events, logger
 from girder.api import access
 from girder.api.describe import Description, describeRoute, autoDescribeRoute
 from girder.api.rest import \
     boundHandler, loadmodel, RestException
 from girder.constants import AccessType, TokenScope, CoreEventHandler
-from girder.exceptions import GirderException
 from girder.models.model_base import ValidationException
 from girder.models.notification import Notification, ProgressState
 from girder.plugins.jobs.constants import JobStatus
@@ -362,20 +361,6 @@ def load(info):
     info['apiRoot'].instance = Instance()
     tale = Tale()
     info['apiRoot'].tale = tale
-
-    from girder.plugins.wholetale.models.tale import Tale as TaleModel
-    from girder.plugins.wholetale.models.tale import _currentTaleFormat
-    q = {
-        '$or': [
-            {'format': {'$exists': False}},
-            {'format': {'$lt': _currentTaleFormat}}
-        ]}
-    for obj in TaleModel().find(q):
-        try:
-            TaleModel().save(obj, validate=True)
-        except GirderException as exc:
-            logprint(exc)
-
     info['apiRoot'].dataset = Dataset()
     info['apiRoot'].image = Image()
     events.bind('jobs.job.update.after', 'wholetale', tale.updateBuildStatus)

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -91,12 +91,12 @@ class Manifest:
         return {
             "@id": 'https://data.wholetale.org/api/v1/tale/' + str(self.tale['_id']),
             "createdOn": str(self.tale['created']),
-            "schema:name": self.tale['title'],
-            "schema:description": self.tale.get('description', str()),
-            "schema:category": self.tale['category'],
-            "schema:identifier": str(self.tale['_id']),
-            "schema:version": self.tale['format'],
-            "schema:image": self.tale['illustration'],
+            "name": self.tale['title'],
+            "description": self.tale.get('description', str()),
+            "category": self.tale['category'],
+            "identifier": str(self.tale['_id']),
+            "version": self.tale['format'],
+            "image": self.tale['illustration'],
             "aggregates": list(),
             "Datasets": list()
         }
@@ -111,10 +111,10 @@ class Manifest:
                                         force=True)
         self.manifest['createdBy'] = {
             "@id": tale_user['email'],
-            "@type": "schema:Person",
-            "schema:givenName": tale_user.get('firstName', ''),
-            "schema:familyName": tale_user.get('lastName', ''),
-            "schema:email": tale_user.get('email', '')
+            "@type": "Person",
+            "givenName": tale_user.get('firstName', ''),
+            "familyName": tale_user.get('lastName', ''),
+            "email": tale_user.get('email', '')
         }
 
     def create_author_record(self):
@@ -123,12 +123,12 @@ class Manifest:
         :return: A dictionary listing of the authors
         """
         return {
-            'schema:author': [
+            'author': [
                 {
                     "@id": author["orcid"],
-                    "@type": "schema:Person",
-                    "schema:givenName": author["firstName"],
-                    "schema:familyName": author["lastName"]
+                    "@type": "Person",
+                    "givenName": author["firstName"],
+                    "familyName": author["lastName"]
                 }
                 for author in self.tale['authors']
             ]
@@ -143,7 +143,8 @@ class Manifest:
         return {
             "@context": [
                 "https://w3id.org/bundle/context",
-                {"schema": "http://schema.org/"},
+                "https://schema.org/",
+                {"name": "http://schema.org/name"},
                 {"Datasets": {"@type": "@id"}}
             ]
         }
@@ -192,7 +193,7 @@ class Manifest:
             aggregation['bundledAs'] = bundle
         # TODO: in case parent_dataset_id == uri do something special?
         if parent_dataset_identifier and parent_dataset_identifier != uri:
-            aggregation['schema:isPartOf'] = parent_dataset_identifier
+            aggregation['isPartOf'] = parent_dataset_identifier
         return aggregation
 
     def add_tale_records(self):
@@ -370,7 +371,7 @@ class Manifest:
         self.manifest['aggregates'].append({'uri': '../LICENSE'})
 
         self.manifest['aggregates'].append({'uri': '../README.md',
-                                            '@type': 'schema:HowTo'})
+                                            '@type': 'HowTo'})
 
 
 def clean_workspace_path(tale_id, path):

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -98,7 +98,7 @@ class Manifest:
             "version": self.tale['format'],
             "image": self.tale['illustration'],
             "aggregates": list(),
-            "Datasets": list()
+            "dataset": list()
         }
 
     def add_tale_creator(self):
@@ -145,7 +145,6 @@ class Manifest:
                 "https://w3id.org/bundle/context",
                 "https://schema.org/",
                 {"name": "http://schema.org/name"},
-                {"Datasets": {"@type": "@id"}}
             ]
         }
 
@@ -343,7 +342,7 @@ class Manifest:
         for folder_id in self.datasets:
             dataset_record = self.create_dataset_record(folder_id)
             if dataset_record:
-                self.manifest['Datasets'].append(dataset_record)
+                self.manifest['dataset'].append(dataset_record)
 
     def create_bundle(self, folder, filename):
         """

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -109,11 +109,12 @@ class Manifest:
         tale_user = self.userModel.load(self.tale['creatorId'],
                                         user=self.user,
                                         force=True)
-        self.manifest['createdBy'] = {
+        self.manifest['creator'] = {
             "@id": tale_user['email'],
             "@type": "Person",
             "givenName": tale_user.get('firstName', ''),
             "familyName": tale_user.get('lastName', ''),
+            "name": tale_user.get('firstName') + ' ' + tale_user.get('lastName'),
             "email": tale_user.get('email', '')
         }
 

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -1,6 +1,5 @@
 import os
 
-from .license import WholeTaleLicense
 from . import IMPORT_PROVIDERS
 
 from girder import logger
@@ -368,10 +367,7 @@ class Manifest:
         Add records for files that we inject (README, LICENSE, etc)
         """
 
-        self.manifest['aggregates'].append({'uri': '../LICENSE',
-                                            'schema:license':
-                                                self.tale.get('licenseSPDX',
-                                                              WholeTaleLicense.default_spdx())})
+        self.manifest['aggregates'].append({'uri': '../LICENSE'})
 
         self.manifest['aggregates'].append({'uri': '../README.md',
                                             '@type': 'schema:HowTo'})

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -93,7 +93,7 @@ class Manifest:
             "createdOn": str(self.tale['created']),
             "name": self.tale['title'],
             "description": self.tale.get('description', str()),
-            "category": self.tale['category'],
+            "keywords": self.tale['category'],
             "identifier": str(self.tale['_id']),
             "version": self.tale['format'],
             "image": self.tale['illustration'],

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -90,6 +90,7 @@ class Manifest:
 
         return {
             "@id": 'https://data.wholetale.org/api/v1/tale/' + str(self.tale['_id']),
+            "@type": ["DataCatalog", "ro:ResearchObject"],
             "createdOn": str(self.tale['created']),
             "name": self.tale['title'],
             "description": self.tale.get('description', str()),

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -91,7 +91,7 @@ class Manifest:
         return {
             "@id": 'https://data.wholetale.org/api/v1/tale/' + str(self.tale['_id']),
             "@type": ["DataCatalog", "ro:ResearchObject"],
-            "createdOn": str(self.tale['created']),
+            "dateCreated": str(self.tale['created']),
             "name": self.tale['title'],
             "description": self.tale.get('description', str()),
             "keywords": self.tale['category'],

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -18,11 +18,8 @@ from ..lib.license import WholeTaleLicense
 
 from gwvolman.tasks import build_tale_image, BUILD_TALE_IMAGE_STEP_TOTAL
 
-
-# Whenever the Tale object schema is modified (e.g. fields are added or
-# removed) increase `_currentTaleFormat` to retroactively apply those
-# changes to existing Tales.
-_currentTaleFormat = 7
+# Whenever changes are made the the manifest scheme, this should get bumped a version
+_currentMetadataFormat = 8
 
 
 class Tale(AccessControlledModel):
@@ -79,7 +76,7 @@ class Tale(AccessControlledModel):
         if 'copyOfTale' not in tale:
             tale['copyOfTale'] = None
 
-        tale['format'] = _currentTaleFormat
+        tale['format'] = _currentMetadataFormat
 
         if not isinstance(tale['authors'], list):
             tale['authors'] = []
@@ -139,7 +136,7 @@ class Tale(AccessControlledModel):
             'creatorId': creatorId,
             'dataSet': data or [],
             'description': description,
-            'format': _currentTaleFormat,
+            'format': _currentMetadataFormat,
             'created': now,
             'icon': icon,
             'iframe': image.get('iframe', False),


### PR DESCRIPTION
This PR addresses the issues raised [here](https://github.com/craig-willis/bdbag-water-tale/pull/1). Note that this should be merged at the same time the [gwvolman branch](https://github.com/whole-tale/gwvolman/pull/64) is merged (EML generation uses values in the manifest).

### Changes
1.Removed the `schema:license` attribute from the LICENSE aggregation (schema:license was implying the license that the LICENSE file was under)
2. Added schema.org to the context (removes `schema:` from everything)
3. Replace `Datasets` (and remove it from the context) with `dataset`
4. Use `keywords` instead of `category`
5. Replace 'createdBy' with creator & add "name"
~6. Escape the file path in the bundle~ This is has been left out
7. Set the manifest type to `["DataCatalog", "ro:ResearchObject"]`. 
8. Use `dateCreated ` instead of `createdOn`
9. Rename `Description` -> `description`

### Testing
To test this, you can manually validate that the changes above were reflected in your manifest. To do this,

1. Create a Tale
2. Add authors
3. Add an external dataset
4. Generate the manifest from the API, exporting, or publishing
5. Confirm that `description` is lower case
6. Confirm that there aren't any references to `schema` outside the context
7. Confirm that the `license` aggregate doesn't have a license assigned to it
8. Note that `createdBy` no longer exists
9. Note that `creator` exists and has a `name` property
10. Note that the folder for the dataset is escaped
11. Confirm `category` no longer exists and that `keywords` took its place
12. Confirm `dateCreated` replaced `createdDate`
13. The `@type` of the manifest is set to `["DataCatalog", "ro:ResearchObject"]`
14. Note the removal of `Datasets` and its replacement, `dataset`

You can find a manifest that was generated by this change [here](https://dev.nceas.ucsb.edu/view/doi:10.5072/FK2Q81D650)
### Things not Addressed
Right now the `@id` of the creator is still the user's email. This can be addressed when we require users to link their ORCIDs.

Escaping file paths