### PR TITLE
Don't default authors to creator

### DIFF
--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -409,7 +409,7 @@ class ManifestTestCase(base.TestCase):
             title=self.tale_info['name'],
             public=self.tale_info['public'],
             description=self.tale_info['description'],
-            authors=missing_orcid)
+            authors=[missing_orcid])
 
         with self.assertRaises(ValueError):
             Manifest(tale_missing_orcid, self.user)
@@ -421,7 +421,7 @@ class ManifestTestCase(base.TestCase):
             title=self.tale_info['name'],
             public=self.tale_info['public'],
             description=self.tale_info['description'],
-            authors=missing_orcid)
+            authors=[blank_orcid])
         with self.assertRaises(ValueError):
             Manifest(tale_blank_orcid, self.user)
 

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -551,10 +551,6 @@ class TaleTestCase(base.TestCase):
         tale = self.model('tale', 'wholetale').save(tale)
         self.assertEqual(tale['licenseSPDX'], WholeTaleLicense.default_spdx())
         self.assertTrue(isinstance(tale['authors'], list))
-        single_author = tale['authors'][0]
-        self.assertEqual(single_author['firstName'], self.user['firstName'])
-        self.assertEqual(single_author['lastName'], self.user['lastName'])
-        self.assertEqual(single_author['orcid'], '')
         self.model('tale', 'wholetale').remove(tale)
 
     @mock.patch('gwvolman.tasks.import_tale')

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -64,11 +64,7 @@ class Tale(AccessControlledModel):
             tale['config'] = {}
 
         if not isinstance(tale['authors'], list):
-            # Set the authors to the Tale creator
-            tale_creator = self.model('user').load(tale['creatorId'], force=True)
-            tale['authors'] = [{'firstName': tale_creator['firstName'],
-                                'lastName': tale_creator['lastName'],
-                                'orcid': ''}]
+            tale['authors'] = []
         return tale
 
     def list(self, user=None, data=None, image=None, limit=0, offset=0,


### PR DESCRIPTION
This partially fixes problems described in (https://github.com/whole-tale/girder_wholetale/issues/297). It's better not to have an author, rather than had one with an invalid ORCID id.

NOTE: as a side-effect authors will be gone from Tale cards in the UI, by default