### PR TITLE
Add production flag to publishing. Fixes #302

### DIFF
--- a/plugin_tests/publish_test.py
+++ b/plugin_tests/publish_test.py
@@ -76,7 +76,7 @@ class PublishTestCase(base.TestCase):
                     'taleId': str(self.tale['_id']),
                     'remoteMemberNode': remoteMemberNode,
                     'authToken': authToken,
-                    'coordinating_node': D1_ENV_DICT['dev']
+                    'coordinatingNode': D1_ENV_DICT['dev']['base_url']
                 },
             )
             self.assertStatusOk(resp)
@@ -90,7 +90,7 @@ class PublishTestCase(base.TestCase):
                         'dataone_node': remoteMemberNode,
                         'tale': str(self.tale['_id']),
                         'user_id': str(self.user['_id']),
-                        'coordinating_node': D1_ENV_DICT['dev']
+                        'coordinating_node': D1_ENV_DICT['dev']['base_url']
                     }
                 ),
             )

--- a/plugin_tests/publish_test.py
+++ b/plugin_tests/publish_test.py
@@ -75,6 +75,7 @@ class PublishTestCase(base.TestCase):
                     'taleId': str(self.tale['_id']),
                     'remoteMemberNode': remoteMemberNode,
                     'authToken': authToken,
+                    'isProduction': False
                 },
             )
             self.assertStatusOk(resp)
@@ -88,6 +89,7 @@ class PublishTestCase(base.TestCase):
                         'dataone_node': remoteMemberNode,
                         'tale': str(self.tale['_id']),
                         'user_id': str(self.user['_id']),
+                        'is_production': 'False'
                     }
                 ),
             )

--- a/plugin_tests/publish_test.py
+++ b/plugin_tests/publish_test.py
@@ -2,6 +2,7 @@ from bson import ObjectId
 import mock
 from tests import base
 
+from d1_common.env import D1_ENV_DICT
 
 def setUpModule():
     base.enabledPlugins.append('wholetale')
@@ -75,7 +76,7 @@ class PublishTestCase(base.TestCase):
                     'taleId': str(self.tale['_id']),
                     'remoteMemberNode': remoteMemberNode,
                     'authToken': authToken,
-                    'isProduction': False
+                    'coordinating_node': D1_ENV_DICT['dev']
                 },
             )
             self.assertStatusOk(resp)
@@ -89,7 +90,7 @@ class PublishTestCase(base.TestCase):
                         'dataone_node': remoteMemberNode,
                         'tale': str(self.tale['_id']),
                         'user_id': str(self.user['_id']),
-                        'is_production': 'False'
+                        'coordinating_node': D1_ENV_DICT['dev']
                     }
                 ),
             )

--- a/server/rest/publish.py
+++ b/server/rest/publish.py
@@ -7,7 +7,6 @@ from girder.constants import AccessType, TokenScope
 from girder.api.rest import Resource, filtermodel
 from girder.plugins.jobs.models.job import Job
 
-
 from ..models.tale import Tale
 
 from gwvolman.tasks import publish
@@ -38,7 +37,13 @@ class Publish(Resource):
         .param(
             'remoteMemberNode',
             description='The endpoint for the Metacat instance, including the endpoint.\n'
-            'Example: \'https://dev.nceas.ucsb.edu/knb/d1/mn/v2\'',
+            'Example: \'https://dev.nceas.ucsb.edu/knb/d1/mn',
+            required=True,
+        )
+        .param(
+            'coordinatingNode',
+            description='The coordinating node that will be managing the package.'
+            'Example: https://cn.dataone.org/cn/v2 or http://cn-stage-2.test.dataone.org/cn/v2',
             required=True,
         )
         .param(
@@ -48,13 +53,9 @@ class Publish(Resource):
             'token.',
             required=True,
         )
-        .param(
-            'isProduction',
-            description='Flag set to True when publishing to a production server',
-            required=True,
-        )
+
     )
-    def dataonePublish(self, tale, remoteMemberNode, authToken, isProduction):
+    def dataonePublish(self, tale, remoteMemberNode, coordinatingNode, authToken):
         user = self.getCurrentUser()
         token = self.getCurrentToken()
 
@@ -62,7 +63,7 @@ class Publish(Resource):
             tale=str(tale['_id']),
             dataone_node=remoteMemberNode,
             dataone_auth_token=authToken,
-            is_production=isProduction,
+            coordinating_node=coordinatingNode,
             user_id=str(user['_id']),
             girder_client_token=str(token['_id'])
         )

--- a/server/rest/publish.py
+++ b/server/rest/publish.py
@@ -48,9 +48,13 @@ class Publish(Resource):
             'token.',
             required=True,
         )
+        .param(
+            'isProduction',
+            description='Flag set to True when publishing to a production server',
+            required=True,
+        )
     )
-    def dataonePublish(self, tale, remoteMemberNode, authToken):
-
+    def dataonePublish(self, tale, remoteMemberNode, authToken, isProduction):
         user = self.getCurrentUser()
         token = self.getCurrentToken()
 
@@ -58,6 +62,7 @@ class Publish(Resource):
             tale=str(tale['_id']),
             dataone_node=remoteMemberNode,
             dataone_auth_token=authToken,
+            is_production=isProduction,
             user_id=str(user['_id']),
             girder_client_token=str(token['_id'])
         )


### PR DESCRIPTION
We need to tell whether we're publishing to production or to development, so I added a flag to the dataone publishing endpoint.

Testing steps are [here]()
Linked issues is #302 