### PR TITLE
Unified notification support

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -45,5 +45,6 @@ add_python_test(dataset
   plugins/wholetale/dataset_register.txt
 )
 add_python_test(publish PLUGIN wholetale)
+add_python_test(notification PLUGIN wholetale)
 add_python_style_test(python_static_analysis_wholetale
                       "${PROJECT_SOURCE_DIR}/plugins/wholetale/server")

--- a/plugin_tests/notification_test.py
+++ b/plugin_tests/notification_test.py
@@ -1,0 +1,142 @@
+import time
+from tests import base
+from girder.models.setting import Setting
+
+
+def setUpModule():
+    base.enabledPlugins.append('wholetale')
+    base.startServer()
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class NotificationTestCase(base.TestCase):
+
+    def setUp(self):
+        super(NotificationTestCase, self).setUp()
+        users = ({
+            'email': 'root@dev.null',
+            'login': 'admin',
+            'firstName': 'Root',
+            'lastName': 'van Klompf',
+            'password': 'secret'
+        }, {
+            'email': 'joe@dev.null',
+            'login': 'joeregular',
+            'firstName': 'Joe',
+            'lastName': 'Regular',
+            'password': 'secret'
+        })
+
+        self.authors = [
+            {
+                'firstName': 'Charles',
+                'lastName': 'Darwmin',
+                'orcid': 'https://orcid.org/000-000'
+            },
+            {
+                'firstName': 'Thomas',
+                'lastName': 'Edison',
+                'orcid': 'https://orcid.org/111-111'
+            }
+        ]
+        self.admin, self.user = [self.model('user').createUser(**user)
+                                 for user in users]
+
+    def testNotification(self):
+        from girder.plugins.jobs.models.job import Job
+        from girder.plugins.jobs.constants import JobStatus
+        from girder.models.notification import Notification, ProgressState
+        from girder.plugins.wholetale.utils import init_progress
+        from girder.plugins.worker.constants import PluginSettings as WorkerPluginSettings
+
+        # TODO: Why do we need it here?
+        Setting().set(WorkerPluginSettings.API_URL, 'http://localhost:8080/api/v1')
+
+        total = 2
+        resource = {'type': 'wt_test_build_image', 'instance_id': 'instance_id'}
+
+        notification = init_progress(
+            resource, self.user, 'Test notification', 'Creating job', total
+        )
+
+        # Job to test error path
+        job = Job().createJob(
+            title='Error test job',
+            type='test',
+            handler='my_handler',
+            user=self.user,
+            public=False,
+            args=["tale_id"],
+            kwargs={},
+            otherFields={'wt_notification_id': str(notification['_id'])},
+        )
+        job = Job().updateJob(
+            job, status=JobStatus.INACTIVE, progressTotal=2, progressCurrent=0)
+        self.assertEqual(job['status'], JobStatus.INACTIVE)
+        time.sleep(1)
+        notification = Notification().load(notification['_id'])
+        self.assertEqual(notification['data']['state'], ProgressState.QUEUED)
+        self.assertEqual(notification['data']['total'], 2)
+        self.assertEqual(notification['data']['current'], 0)
+
+        # State change to ACTIVE
+        job = Job().updateJob(job, status=JobStatus.RUNNING)
+        self.assertEqual(job['status'], JobStatus.RUNNING)
+
+        # Progress update
+        job = Job().updateJob(
+            job, status=JobStatus.RUNNING, progressCurrent=1,
+            progressMessage="Error test message")
+        time.sleep(1)
+        notification = Notification().load(notification['_id'])
+        self.assertEqual(notification['data']['state'], ProgressState.ACTIVE)
+        self.assertEqual(notification['data']['total'], 2)
+        self.assertEqual(notification['data']['current'], 1)
+        self.assertEqual(notification['data']['message'], 'Error test message')
+
+        # State change to ERROR
+        job = Job().updateJob(job, status=JobStatus.ERROR)
+        time.sleep(1)
+        notification = Notification().load(notification['_id'])
+        self.assertEqual(notification['data']['state'], ProgressState.ERROR)
+        self.assertEqual(notification['data']['total'], 2)
+        self.assertEqual(notification['data']['current'], 1)
+        self.assertEqual(notification['data']['message'], 'Error test message')
+
+        # New job to test success path
+        job = Job().createJob(
+            title='Test Job',
+            type='test',
+            handler='my_handler',
+            user=self.user,
+            public=False,
+            args=["tale_id"],
+            kwargs={},
+            otherFields={'wt_notification_id': str(notification['_id'])},
+        )
+
+        # State change to ACTIVE
+        job = Job().updateJob(job, status=JobStatus.RUNNING)
+        self.assertEqual(job['status'], JobStatus.RUNNING)
+
+        # Progress update
+        job = Job().updateJob(
+            job, status=JobStatus.RUNNING, progressCurrent=1,
+            progressMessage="Success test message")
+        time.sleep(1)
+        notification = Notification().load(notification['_id'])
+        self.assertEqual(notification['data']['state'], ProgressState.ACTIVE)
+        self.assertEqual(notification['data']['total'], 2)
+        self.assertEqual(notification['data']['current'], 1)
+        self.assertEqual(notification['data']['message'], 'Success test message')
+
+        job = Job().updateJob(job, status=JobStatus.SUCCESS)
+        time.sleep(1)
+        notification = Notification().load(notification['_id'])
+        self.assertEqual(notification['data']['state'], ProgressState.ACTIVE)
+        self.assertEqual(notification['data']['total'], 2)
+        self.assertEqual(notification['data']['current'], 1)
+        self.assertEqual(notification['data']['message'], 'Success test message')

--- a/plugin_tests/notification_test.py
+++ b/plugin_tests/notification_test.py
@@ -81,6 +81,7 @@ class NotificationTestCase(base.TestCase):
         self.assertEqual(notification['data']['state'], ProgressState.QUEUED)
         self.assertEqual(notification['data']['total'], 2)
         self.assertEqual(notification['data']['current'], 0)
+        self.assertEqual(notification['data']['resource']['jobs'][0], job['_id'])
 
         # State change to ACTIVE
         job = Job().updateJob(job, status=JobStatus.RUNNING)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ kombu==4.2.2post1
 idna==2.7  # pin for requests
 requests==2.20.1  # https://github.com/requests/requests/issues/4890
 redis==2.10.6
-git+https://github.com/whole-tale/gwvolman@v0.7rc2#egg=gwvolman
+git+https://github.com/whole-tale/gwvolman@notification-poc#egg=gwvolman
 dataone.common==3.2.0
 dataone.libclient==3.2.0
 dataone.cli==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ kombu==4.2.2post1
 idna==2.7  # pin for requests
 requests==2.20.1  # https://github.com/requests/requests/issues/4890
 redis==2.10.6
-git+https://github.com/whole-tale/gwvolman@notification-poc#egg=gwvolman
+git+https://github.com/whole-tale/gwvolman@master#egg=gwvolman
 dataone.common==3.2.0
 dataone.libclient==3.2.0
 dataone.cli==3.2.0

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -301,16 +301,26 @@ def updateNotification(event):
         # Without the sleep, some notifications don't appear in the stream
         time.sleep(1)
 
+        # Add job IDs to the resource
+        if 'jobs' not in notification['data']['resource']:
+            notification['data']['resource']['jobs'] = []
+
+        if job['_id'] not in notification['data']['resource']['jobs']:
+            notification['data']['resource']['jobs'].append(job['_id'])
+
         # If the state hasn't changed, increment. Otherwise keep previous current value.
+        # Note, if expires parameter is not provided, updateProgress resets to 1 hour
         if not state_changed:
             Notification().updateProgress(
                 notification, state=state,
+                expires=notification['expires'],
                 message=job['progress']['message'],
                 increment=1,
                 total=notification['data']['total'])
         else:
             Notification().updateProgress(
                 notification, state=state,
+                expires=notification['expires'],
                 message=job['progress']['message'],
                 current=notification['data']['current'],
                 total=notification['data']['total'])

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import six
+import time
 import validators
 
 from girder import events, logprint, logger
@@ -277,15 +278,17 @@ def validateFileLink(event):
 
 def updateNotification(event):
     """
-    Update the Whole Tale task notification for a job, if present
+    Update the Whole Tale task notification for a job, if present.
     """
 
     job = event.info['job']
-    if job['progress'] and 'notification_id' in job['kwargs']:
+    if job['progress'] and 'wt_notification_id' in job:
         state = JobStatus.toNotificationStatus(job['status'])
-        notification = Notification().load(job['kwargs']['notification_id'])
+        notification = Notification().load(job['wt_notification_id'])
 
         if notification['data']['message'] != job['progress']['message']:
+            # Without the sleep, some notifications don't appear in the stream
+            time.sleep(1)
             Notification().updateProgress(
                 notification, state=state,
                 message=job['progress']['message'],

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -274,20 +274,22 @@ def validateFileLink(event):
     doc['exts'] = [ext.lower() for ext in doc['name'].split('.')[1:]]
     event.preventDefault().addResponse(doc)
 
-def updateNotification(event):
-   """
-   Update the Whole Tale task notification for a job, if present 
-   """
 
-   job = event.info['job']
-   if job['progress'] and 'notification_id' in job['kwargs']:
-       state = JobStatus.toNotificationStatus(job['status'])
-       notification = Notification().load(job['kwargs']['notification_id'])
-       Notification().updateProgress(
-           notification, state=state,
-           message=job['progress']['message'],
-           current=job['progress']['current'],
-           total=job['progress']['total'])
+def updateNotification(event):
+    """
+    Update the Whole Tale task notification for a job, if present
+    """
+
+    job = event.info['job']
+    if job['progress'] and 'notification_id' in job['kwargs']:
+        state = JobStatus.toNotificationStatus(job['status'])
+        notification = Notification().load(job['kwargs']['notification_id'])
+        Notification().updateProgress(
+            notification, state=state,
+            message=job['progress']['message'],
+            current=job['progress']['current'],
+            total=job['progress']['total'])
+
 
 @access.user
 @autoDescribeRoute(

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -285,11 +285,12 @@ def updateNotification(event):
         state = JobStatus.toNotificationStatus(job['status'])
         notification = Notification().load(job['kwargs']['notification_id'])
 
-        Notification().updateProgress(
-            notification, state=state,
-            message=job['progress']['message'],
-            increment=1,
-            total=notification['data']['total'])
+        if notification['data']['message'] != job['progress']['message']:
+            Notification().updateProgress(
+                notification, state=state,
+                message=job['progress']['message'],
+                increment=1,
+                total=notification['data']['total'])
 
 
 @access.user

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import six
-import time
 import validators
 
 from girder import events, logprint, logger
@@ -297,9 +296,6 @@ def updateNotification(event):
         is_last = notification['data']['total'] == (notification['data']['current'])
         if state == ProgressState.SUCCESS and not is_last:
             return
-
-        # Without the sleep, some notifications don't appear in the stream
-        time.sleep(1)
 
         # Add job IDs to the resource
         if 'jobs' not in notification['data']['resource']:

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -284,11 +284,12 @@ def updateNotification(event):
     if job['progress'] and 'notification_id' in job['kwargs']:
         state = JobStatus.toNotificationStatus(job['status'])
         notification = Notification().load(job['kwargs']['notification_id'])
+
         Notification().updateProgress(
             notification, state=state,
             message=job['progress']['message'],
-            current=job['progress']['current'],
-            total=job['progress']['total'])
+            increment=1,
+            total=notification['data']['total'])
 
 
 @access.user

--- a/server/models/instance.py
+++ b/server/models/instance.py
@@ -164,15 +164,13 @@ class Instance(AccessControlledModel):
                'type': 'wt_image_build_status',
                'tale_id': tale['_id'],
                'instance_id': instance['_id'],
-               'title': tale['title'],
-               'imageInfo': tale['imageInfo']
             }
 
             total = BUILD_TALE_IMAGE_STEP_TOTAL + CREATE_VOLUME_STEP_TOTAL + \
                     LAUNCH_CONTAINER_STEP_TOTAL 
 
             notification = init_progress(resource, user,
-                'Build tale notification', 'Creating job', total)
+                'Create instance notification', 'Creating job', total)
 
             buildTask = build_tale_image.signature(
                 args=[str(tale['_id'])], 

--- a/server/models/instance.py
+++ b/server/models/instance.py
@@ -94,8 +94,8 @@ class Instance(AccessControlledModel):
         total = UPDATE_CONTAINER_STEP_TOTAL
 
         notification = init_progress(
-            resource, user, 'Update instance notification',
-            'Creating job', total)
+            resource, user, 'Updating instance',
+            'Initializing', total)
 
         instanceTask = update_container.signature(
             args=[str(instance['_id'])], queue='manager',
@@ -183,8 +183,8 @@ class Instance(AccessControlledModel):
                 LAUNCH_CONTAINER_STEP_TOTAL
 
             notification = init_progress(
-                resource, user, 'Create instance notification',
-                'Creating job', total)
+                resource, user, 'Creating instance',
+                'Initializing', total)
 
             buildTask = build_tale_image.signature(
                 args=[str(tale['_id'])],

--- a/server/models/instance.py
+++ b/server/models/instance.py
@@ -18,7 +18,7 @@ from gwvolman.tasks import \
     create_volume, launch_container, update_container, shutdown_container, \
     remove_volume, build_tale_image, \
     CREATE_VOLUME_STEP_TOTAL, BUILD_TALE_IMAGE_STEP_TOTAL, \
-    LAUNCH_CONTAINER_STEP_TOTAL
+    LAUNCH_CONTAINER_STEP_TOTAL, UPDATE_CONTAINER_STEP_TOTAL
 
 from ..constants import InstanceStatus
 from ..schema.misc import containerInfoSchema
@@ -86,11 +86,21 @@ class Instance(AccessControlledModel):
         :type image: dict
         :returns: The instance document that was edited.
         """
+        resource = {
+           'type': 'wt_create_instance',
+           'instance_id': instance['_id'],
+        }
+
+        total = UPDATE_CONTAINER_STEP_TOTAL
+
+        notification = init_progress(resource, user,
+            'Update instance notification', 'Creating job', total)
 
         instanceTask = update_container.signature(
             args=[str(instance['_id'])], queue='manager',
             kwargs={
                 'girder_client_token': str(token['_id']),
+                'notification_id': str(notification['_id']),
                 'image': digest
             }
         ).apply_async()

--- a/server/models/instance.py
+++ b/server/models/instance.py
@@ -87,8 +87,8 @@ class Instance(AccessControlledModel):
         :returns: The instance document that was edited.
         """
         resource = {
-            'type': 'wt_create_instance',
-            'instance_id': instance['_id'],
+            'type': 'wt_update_instance',
+            'instance_id': instance['_id']
         }
 
         total = UPDATE_CONTAINER_STEP_TOTAL
@@ -99,10 +99,12 @@ class Instance(AccessControlledModel):
 
         instanceTask = update_container.signature(
             args=[str(instance['_id'])], queue='manager',
+            girder_job_other_fields={
+                'wt_notification_id': str(notification['_id'])
+            },
             kwargs={
                 'girder_client_token': str(token['_id']),
-                'notification_id': str(notification['_id']),
-                'image': digest
+                'digest': digest
             }
         ).apply_async()
         instanceTask.get(timeout=TASK_TIMEOUT)
@@ -172,7 +174,7 @@ class Instance(AccessControlledModel):
             Token().addScope(token, scope=REST_CREATE_JOB_TOKEN_SCOPE)
 
             resource = {
-                'type': 'wt_image_build_status',
+                'type': 'wt_create_instance',
                 'tale_id': tale['_id'],
                 'instance_id': instance['_id'],
             }
@@ -186,23 +188,29 @@ class Instance(AccessControlledModel):
 
             buildTask = build_tale_image.signature(
                 args=[str(tale['_id'])],
+                girder_job_other_fields={
+                    'wt_notification_id': str(notification['_id'])
+                },
                 kwargs={
-                    'notification_id': str(notification['_id']),
                     'girder_client_token': str(token['_id'])
                 },
                 immutable=True
             )
             volumeTask = create_volume.signature(
                 args=[str(instance['_id'])],
+                girder_job_other_fields={
+                    'wt_notification_id': str(notification['_id'])
+                },
                 kwargs={
-                    'notification_id': str(notification['_id']),
                     'girder_client_token': str(token['_id'])
                 },
                 immutable=True
             )
             serviceTask = launch_container.signature(
+                girder_job_other_fields={
+                    'wt_notification_id': str(notification['_id'])
+                },
                 kwargs={
-                    'notification_id': str(notification['_id']),
                     'girder_client_token': str(token['_id'])
                 },
                 queue='manager'

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -276,8 +276,8 @@ class Tale(AccessControlledModel):
         }
 
         notification = init_progress(
-            resource, user, 'Build tale notification',
-            'Creating job', BUILD_TALE_IMAGE_STEP_TOTAL)
+            resource, user, 'Building image',
+            'Initializing', BUILD_TALE_IMAGE_STEP_TOTAL)
 
         buildTask = build_tale_image.signature(
             args=[str(tale['_id'])],

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -271,7 +271,7 @@ class Tale(AccessControlledModel):
         """
 
         resource = {
-            'type': 'wt_image_build_status',
+            'type': 'wt_build_image',
             'tale_id': tale['_id']
         }
 
@@ -281,9 +281,11 @@ class Tale(AccessControlledModel):
 
         buildTask = build_tale_image.signature(
             args=[str(tale['_id'])],
+            girder_job_other_fields={
+                'wt_notification_id': str(notification['_id']),
+            },
             kwargs={
-                'girder_client_token': str(token['_id']),
-                'notification_id': str(notification['_id'])
+                'girder_client_token': str(token['_id'])
             }
         ).apply_async()
 

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -13,6 +13,8 @@ from ..constants import WORKSPACE_NAME, DATADIRS_NAME, SCRIPTDIRS_NAME
 from ..utils import getOrCreateRootFolder, init_progress
 from ..lib.license import WholeTaleLicense
 
+from gwvolman.tasks import build_tale_image, BUILD_TALE_IMAGE_STEP_TOTAL
+
 
 # Whenever the Tale object schema is modified (e.g. fields are added or
 # removed) increase `_currentTaleFormat` to retroactively apply those
@@ -263,19 +265,19 @@ class Tale(AccessControlledModel):
 
         return doc
 
-
     def buildImage(self, tale, user, token):
         """
         Build the image for the tale
         """
 
         resource = {
-           'type': 'wt_image_build_status',
-           'tale_id': tale['_id']
+            'type': 'wt_image_build_status',
+            'tale_id': tale['_id']
         }
 
-        notification = init_progress(resource, user,
-            'Build tale notification', 'Creating job', BUILD_TALE_IMAGE_STEP_TOTAL)
+        notification = init_progress(
+            resource, user, 'Build tale notification',
+            'Creating job', BUILD_TALE_IMAGE_STEP_TOTAL)
 
         buildTask = build_tale_image.signature(
             args=[str(tale['_id'])],

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -265,12 +265,13 @@ class Tale(AccessControlledModel):
 
 
     def buildImage(self, tale, user, token):
+        """
+        Build the image for the tale
+        """
 
         resource = {
            'type': 'wt_image_build_status',
-           '_id': tale['_id'],
-           'title': tale['title'],
-           'imageInfo': tale['imageInfo']
+           'tale_id': tale['_id']
         }
 
         notification = init_progress(resource, user,

--- a/server/rest/instance.py
+++ b/server/rest/instance.py
@@ -142,6 +142,7 @@ class Instance(Resource):
         # Digest ensures that container runs from newest image version
         instanceModel = self.model('instance', 'wholetale')
         instanceModel.updateAndRestartInstance(
+            currentUser,
             instance,
             self.getCurrentToken(),
             tale['imageInfo']['digest'])

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -346,7 +346,6 @@ class Tale(Resource):
     def updateBuildStatus(self, event):
         """
         Event handler that updates the Tale object based on the build_tale_image task.
-        Creates notifications when image build status changes.
         """
         job = event.info['job']
         if job['title'] == 'Build Tale Image' and job.get('status') is not None:
@@ -376,20 +375,9 @@ class Tale(Resource):
                 tale['imageInfo']['jobId'] = job['_id']
                 tale['imageInfo']['status'] = ImageStatus.BUILDING
 
-            # If the status changed, save the object and send a notification
+            # If the status changed, save the object
             if 'status' in tale['imageInfo'] and tale['imageInfo']['status'] != previousStatus:
                 self.model('tale', 'wholetale').updateTale(tale)
-
-            if job['progress']:
-                notification = Notification().load(job['kwargs']['notification_id'])
-                notification['data']['resource']['imageInfo'] = tale['imageInfo']
-                Notification().save(notification)
-            #    state = JobStatus.toNotificationStatus(job['status'])
-            #    Notification().updateProgress(
-            #        notification, state=state,
-            #        message=job['progress']['message'],
-            #        current=job['progress']['current'],
-            #        total=job['progress']['total'])
 
     def updateWorkspaceModTime(self, event):
         """

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from datetime import datetime, timedelta
 import time
 from girder import events
 from girder.api import access
@@ -14,13 +13,10 @@ from girder.utility.path import getResourcePath
 from girder.utility.progress import ProgressContext
 from girder.models.token import Token
 from girder.models.folder import Folder
-from girder.models.user import User
 from girder.plugins.jobs.constants import REST_CREATE_JOB_TOKEN_SCOPE
-from gwvolman.tasks import import_tale, build_tale_image, \
-   BUILD_TALE_IMAGE_STEP_TOTAL
+from gwvolman.tasks import import_tale
 
 from girder.plugins.jobs.constants import JobStatus
-from girder.models.notification import Notification
 
 from ..schema.tale import taleModel as taleSchema
 from ..models.tale import Tale as taleModel
@@ -32,7 +28,6 @@ from ..lib.exporters.native import NativeTaleExporter
 from girder.plugins.worker import getCeleryApp
 
 from ..constants import ImageStatus
-from ..utils import init_progress
 
 
 addModel('tale', taleSchema, resources='tale')
@@ -341,7 +336,6 @@ class Tale(Resource):
         user = self.getCurrentUser()
 
         return self._model.buildImage(tale, user, token)
-
 
     def updateBuildStatus(self, event):
         """

--- a/server/utils.py
+++ b/server/utils.py
@@ -45,14 +45,14 @@ def esc(value):
 def init_progress(resource, user, title, message, total, expires=-1):
 
     data = {
-       'title': title,
-       'total': total,
-       'current': 0,
-       'state': 'active',
-       'message': message,
-       'estimateTime': False,
-       'resource': resource,
-       'resourceName': 'Custom resource'
+        'title': title,
+        'total': total,
+        'current': 0,
+        'state': 'active',
+        'message': message,
+        'estimateTime': False,
+        'resource': resource,
+        'resourceName': 'Custom resource'
     }
 
     return Notification().createNotification(

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,7 +1,11 @@
+import datetime
 import six.moves.urllib as urllib
 
 from girder.utility.model_importer import ModelImporter
 from girder.models.notification import Notification
+
+
+NOTIFICATION_EXP_DAYS = 10
 
 
 def getOrCreateRootFolder(name, description=str()):
@@ -42,7 +46,7 @@ def esc(value):
     return urllib.parse.quote_plus(value)
 
 
-def init_progress(resource, user, title, message, total, expires=-1):
+def init_progress(resource, user, title, message, total):
 
     data = {
         'title': title,
@@ -54,6 +58,8 @@ def init_progress(resource, user, title, message, total, expires=-1):
         'resource': resource,
         'resourceName': 'WT custom resource'
     }
+
+    expires = datetime.datetime.utcnow() + datetime.timedelta(days=NOTIFICATION_EXP_DAYS)
 
     return Notification().createNotification(
         type="wt_progress", data=data, user=user, expires=expires)

--- a/server/utils.py
+++ b/server/utils.py
@@ -52,8 +52,8 @@ def init_progress(resource, user, title, message, total, expires=-1):
         'message': message,
         'estimateTime': False,
         'resource': resource,
-        'resourceName': 'Custom resource'
+        'resourceName': 'WT custom resource'
     }
 
     return Notification().createNotification(
-        type="progress", data=data, user=user, expires=expires)
+        type="wt_progress", data=data, user=user, expires=expires)

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,6 +1,7 @@
 import six.moves.urllib as urllib
 
 from girder.utility.model_importer import ModelImporter
+from girder.models.notification import Notification
 
 
 def getOrCreateRootFolder(name, description=str()):
@@ -39,3 +40,20 @@ def esc(value):
     :rtype: str
     """
     return urllib.parse.quote_plus(value)
+
+
+def init_progress(resource, user, title, message, total, expires=-1):
+
+    data = {
+       'title': title,
+       'total': total,
+       'current': 0,
+       'state': 'active',
+       'message': message,
+       'estimateTime': False,
+       'resource': resource,
+       'resourceName': 'Custom resource'
+    }
+
+    return Notification().createNotification(
+        type="progress", data=data, user=user, expires=expires)


### PR DESCRIPTION
See the [Notifications design doc](https://docs.google.com/document/d/1IkvsZqxxlIBaxVLT1yb1kWtGyDuJRo8ZzT1hsqke_NE) for details.

Along with https://github.com/whole-tale/gwvolman/pull/75, this PR implements changes to how we handle task notifications and progress reporting for instance creation, restarting, and image building.
* Each logical task (which may be multi-job) creates a progress notification and passes the ID to each job via `girder_job_other_fields`. This results in the job object having a `wt_notification_id` field.
* Gwvolman (Celery) tasks use the internal `job_manager.updateProgress()` method to update per-job progress.
* A generic `updateNotification` event handler (event=jobs.job.update.after) updates a single progress notification based on the provided `wt_notification_id`. This allows us to accumulate progress across multiple jobs and control the notification payload.
* The `resource` field  (i.e., payload) for each notification contains relevant information including a `type` (e.g., wt_build_image) and identifiers of objects related to the notification (e.g., tale ID, job IDs)
* For now, progress notifications have a default expiration of 10 days.  This is intended to allow us to support the "Archived notifications" feature in the UI.

To test (assumes `deploy-dev`):
* Checkout `notification-poc` branches for deploy-dev, girder_wholetale and gwvolman
* Restart Girder and gwvolman as needed
* In deploy-dev, run `test_stream.py <valid girder token>` (which requires the sseclient package). This will listen to the notification stream from now.
* Via the UI or swagger, launch an instance.  You should see 7 notifications in the stream -- 1 for each step (each job has two updates: starting, complete) and a final success status change.
* Restart and rebuild should each have 3 notifications including the success status change.


