### PR TITLE
Allow build if workspace hasn't changed

### DIFF
--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -878,7 +878,7 @@ class TaleTestCase(base.TestCase):
             self.assertStatusOk(resp)
             job_call = mock_apply_async.call_args_list[-1][-1]
             self.assertEqual(
-                job_call['args'], (str(tale['_id']),)
+                job_call['args'], (str(tale['_id']), False)
             )
             self.assertEqual(job_call['headers']['girder_job_title'], 'Build Tale Image')
         self.assertStatusOk(resp)

--- a/server/models/instance.py
+++ b/server/models/instance.py
@@ -187,7 +187,7 @@ class Instance(AccessControlledModel):
                 'Initializing', total)
 
             buildTask = build_tale_image.signature(
-                args=[str(tale['_id'])],
+                args=[str(tale['_id']), False],
                 girder_job_other_fields={
                     'wt_notification_id': str(notification['_id'])
                 },

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -265,7 +265,7 @@ class Tale(AccessControlledModel):
 
         return doc
 
-    def buildImage(self, tale, user, token, force):
+    def buildImage(self, tale, user, token, force=False):
         """
         Build the image for the tale
         """

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -265,7 +265,7 @@ class Tale(AccessControlledModel):
 
         return doc
 
-    def buildImage(self, tale, user, token):
+    def buildImage(self, tale, user, token, force):
         """
         Build the image for the tale
         """
@@ -280,7 +280,7 @@ class Tale(AccessControlledModel):
             'Initializing', BUILD_TALE_IMAGE_STEP_TOTAL)
 
         buildTask = build_tale_image.signature(
-            args=[str(tale['_id'])],
+            args=[str(tale['_id']), force],
             girder_job_other_fields={
                 'wt_notification_id': str(notification['_id']),
             },

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -328,14 +328,16 @@ class Tale(Resource):
         Description('Build the image for the Tale')
         .modelParam('id', model='tale', plugin='wholetale', level=AccessType.WRITE,
                     description='The ID of the Tale.')
+        .param('force', 'If true, force build regardless of workspace changes',
+               default=False, required=False, dataType='boolean')
         .errorResponse('ID was invalid.')
         .errorResponse('Admin access was denied for the tale.', 403)
     )
-    def buildImage(self, tale, params):
+    def buildImage(self, tale, force):
         token = self.getCurrentToken()
         user = self.getCurrentUser()
 
-        return self._model.buildImage(tale, user, token)
+        return self._model.buildImage(tale, user, token, force)
 
     def updateBuildStatus(self, event):
         """

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -337,7 +337,7 @@ class Tale(Resource):
         token = self.getCurrentToken()
         user = self.getCurrentUser()
 
-        return self._model.buildImage(tale, user, token, force)
+        return self._model.buildImage(tale, user, token, force=force)
 
     def updateBuildStatus(self, event):
         """


### PR DESCRIPTION
Primarily during testing, I often want to build an image even if the workspace hasn't changed (e.g., the repo2docker image has changed).  Along with https://github.com/whole-tale/gwvolman/pull/76, this PR adds the `force` parameter to the `tale/{id}/build` endpoint.

To test:
* Build a Tale image
* Do not change the workspace
* Using the swagger API, GET /tale/{id}/build?force=false
* Note that the tale doesn't build because the workspace is unchanged
* Using the swagger API, GET /tale/{id}/build?force=true
* Note that the tale image rebuilds even though the workspace is unchanged.
