### PR TITLE
Use repo2docker version from gwvolman constants

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ kombu==4.2.2post1
 idna==2.7  # pin for requests
 requests==2.20.1  # https://github.com/requests/requests/issues/4890
 redis==2.10.6
-git+https://github.com/whole-tale/gwvolman@repo2docker-wholetale#egg=gwvolman
+git+https://github.com/whole-tale/gwvolman@master#egg=gwvolman
 dataone.common==3.2.0
 dataone.libclient==3.2.0
 dataone.cli==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ kombu==4.2.2post1
 idna==2.7  # pin for requests
 requests==2.20.1  # https://github.com/requests/requests/issues/4890
 redis==2.10.6
-git+https://github.com/whole-tale/gwvolman@master#egg=gwvolman
+git+https://github.com/whole-tale/gwvolman@repo2docker-wholetale#egg=gwvolman
 dataone.common==3.2.0
 dataone.libclient==3.2.0
 dataone.cli==3.2.0

--- a/server/lib/exporters/bag.py
+++ b/server/lib/exporters/bag.py
@@ -4,6 +4,7 @@ import json
 from girder.models.folder import Folder
 from girder.utility import JsonEncoder
 from . import TaleExporter
+from gwvolman.constants import REPO2DOCKER_VERSION
 
 
 bag_profile = (
@@ -78,7 +79,7 @@ class BagTaleExporter(TaleExporter):
         run_file = run_tpl.format(
             template=container_config['template'],
             buildpack=container_config['buildpack'],
-            repo2docker=container_config.get('repo2docker_version', 'wholetale/repo2docker:latest'),
+            repo2docker=container_config.get('repo2docker_version', REPO2DOCKER_VERSION),
             user=container_config['user'],
             port=container_config['port'],
             taleId=self.tale['_id'],


### PR DESCRIPTION
This PR changes the export process to use the repo2docker version as configured in gwvolman. Depends on  https://github.com/whole-tale/gwvolman/pull/77