### PR TITLE
Remove template and buildpack arguments, move environment.json

### DIFF
--- a/server/lib/exporters/bag.py
+++ b/server/lib/exporters/bag.py
@@ -23,7 +23,8 @@ run_tpl = r"""#!/bin/sh
 # Use repo2docker to build the image from the workspace
 docker run  \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -v `pwd`/data/workspace:/WholeTale/workspace \
+  -v "`pwd`/data/workspace:/WholeTale/workspace" \
+  -v "`pwd`/metadata/environment.json:/WholeTale/workspace/.wholetale/environment.json" \
   --privileged=true \
   -e DOCKER_HOST=unix:///var/run/docker.sock \
   {repo2docker} \
@@ -35,7 +36,7 @@ docker run  \
     /WholeTale/workspace
 
 docker run --rm \
-    -v `pwd`:/bag \
+    -v "`pwd`:/bag" \
     -ti jfloff/alpine-python:2.7-slim \
       -p bdbag -- bdbag --resolve-fetch all /bag
 
@@ -45,8 +46,8 @@ echo "========================================================================"
 
 # Run the built image
 docker run -p {port}:{port} \
-  -v `pwd`/data/data:/WholeTale/data \
-  -v `pwd`/data/workspace:/WholeTale/workspace \
+  -v "`pwd`/data/data:/WholeTale/data" \
+  -v "`pwd`/data/workspace:/WholeTale/workspace" \
   wholetale/tale_{taleId} {command}
 
 """
@@ -170,7 +171,7 @@ class BagTaleExporter(TaleExporter):
                     sort_keys=True,
                     allow_nan=False,
                 ),
-                'data/workspace/.wholetale/environment.json',
+                'metadata/environment.json',
             ),
             (lambda: json.dumps(self.manifest, indent=4), 'metadata/manifest.json'),
         ):

--- a/server/lib/exporters/bag.py
+++ b/server/lib/exporters/bag.py
@@ -29,8 +29,6 @@ docker run  \
   {repo2docker} \
   jupyter-repo2docker \
     --target-repo-dir=/WholeTale/workspace \
-    --template={template} \
-    --buildpack-name={buildpack} \
     --user-id=1000 --user-name={user} \
     --no-clean --no-run --debug \
     --image-name wholetale/tale_{taleId} \
@@ -58,7 +56,10 @@ readme_tpl = """# Tale: "{title}" in BDBag Format
 
 {description}
 
-# How to run?
+# Running locally
+
+If you have Docker installed, you can run this Tale locally using the
+following command:
 
 ```
 sh ./run-local.sh
@@ -77,8 +78,6 @@ class BagTaleExporter(TaleExporter):
         )
         urlPath = container_config['urlPath'].format(token=token)
         run_file = run_tpl.format(
-            template=container_config['template'],
-            buildpack=container_config['buildpack'],
             repo2docker=container_config.get('repo2docker_version', REPO2DOCKER_VERSION),
             user=container_config['user'],
             port=container_config['port'],
@@ -171,7 +170,7 @@ class BagTaleExporter(TaleExporter):
                     sort_keys=True,
                     allow_nan=False,
                 ),
-                'metadata/environment.json',
+                'data/workspace/.wholetale/environment.json',
             ),
             (lambda: json.dumps(self.manifest, indent=4), 'metadata/manifest.json'),
         ):


### PR DESCRIPTION
Fixes #309 

This PR:
* Removes the `template` and `buildpack` arguments from the repo2docker command template
* Mount `metadata/environment.json` to `data/workspace/.wholetale/environment.json` at runtime
* Quote volume paths to allow for spaces in paths

To Test:
* Export a Tale
* Run it locally and see that it works...
