### PR TITLE
Use a dedicated token to intialize GirderClient in jobs. Fixes #311

### DIFF
--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -7,6 +7,7 @@ from girder import events
 from girder.models.model_base import AccessControlledModel
 from girder.models.item import Item
 from girder.models.folder import Folder
+from girder.models.token import Token
 from girder.constants import AccessType
 from girder.exceptions import AccessException
 from ..constants import WORKSPACE_NAME, DATADIRS_NAME, SCRIPTDIRS_NAME
@@ -265,7 +266,7 @@ class Tale(AccessControlledModel):
 
         return doc
 
-    def buildImage(self, tale, user, token, force=False):
+    def buildImage(self, tale, user, force=False):
         """
         Build the image for the tale
         """
@@ -274,6 +275,8 @@ class Tale(AccessControlledModel):
             'type': 'wt_build_image',
             'tale_id': tale['_id']
         }
+
+        token = Token().createToken(user=user, days=0.5)
 
         notification = init_progress(
             resource, user, 'Building image',
@@ -284,9 +287,7 @@ class Tale(AccessControlledModel):
             girder_job_other_fields={
                 'wt_notification_id': str(notification['_id']),
             },
-            kwargs={
-                'girder_client_token': str(token['_id'])
-            }
+            girder_client_token=str(token['_id']),
         ).apply_async()
 
         return buildTask.job

--- a/server/rest/instance.py
+++ b/server/rest/instance.py
@@ -149,9 +149,8 @@ class Instance(Resource):
 
         # Digest ensures that container runs from newest image version
         self._model.updateAndRestartInstance(
-            currentUser,
             instance,
-            self.getCurrentToken(),
+            currentUser,
             tale['imageInfo']['digest'])
         return instance
 
@@ -164,7 +163,7 @@ class Instance(Resource):
     )
     def deleteInstance(self, instance, params):
         self.model('instance', 'wholetale').deleteInstance(
-            instance, self.getCurrentToken())
+            instance, self.getCurrentUser())
 
     @access.user
     @filtermodel(model='instance', plugin='wholetale')
@@ -184,7 +183,6 @@ class Instance(Resource):
     )
     def createInstance(self, taleId, name, spawn):
         user = self.getCurrentUser()
-        token = self.getCurrentToken()
 
         taleModel = self.model('tale', 'wholetale')
         tale = taleModel.load(
@@ -204,8 +202,7 @@ class Instance(Resource):
         if len(running_instances) + 1 > int(instance_cap):
             raise RestException(instanceCapErrMsg.format(instance_cap))
 
-        return self._model.createInstance(tale, user, token, name=name,
-                                          save=True, spawn=spawn)
+        return self._model.createInstance(tale, user, name=name, save=True, spawn=spawn)
 
     def handleUpdateJob(self, event):
         job = event.info['job']

--- a/server/rest/publish.py
+++ b/server/rest/publish.py
@@ -5,6 +5,7 @@ from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.constants import AccessType, TokenScope
 from girder.api.rest import Resource, filtermodel
+from girder.models.token import Token
 from girder.plugins.jobs.models.job import Job
 
 from ..models.tale import Tale
@@ -57,7 +58,7 @@ class Publish(Resource):
     )
     def dataonePublish(self, tale, remoteMemberNode, coordinatingNode, authToken):
         user = self.getCurrentUser()
-        token = self.getCurrentToken()
+        token = Token().createToken(user=user, days=0.5)
 
         publishTask = publish.delay(
             tale=str(tale['_id']),

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -194,8 +194,11 @@ class Tale(Resource):
         user = self.getCurrentUser()
         image = imageModel().load(imageId, user=user, level=AccessType.READ,
                                   exc=True)
-        token = self.getCurrentToken()
-        Token().addScope(token, scope=REST_CREATE_JOB_TOKEN_SCOPE)
+        token = Token().createToken(
+            user=user,
+            days=0.5,
+            scope=(TokenScope.USER_AUTH, REST_CREATE_JOB_TOKEN_SCOPE)
+        )
 
         try:
             lookupKwargs['dataId'] = [url]
@@ -334,10 +337,8 @@ class Tale(Resource):
         .errorResponse('Admin access was denied for the tale.', 403)
     )
     def buildImage(self, tale, force):
-        token = self.getCurrentToken()
         user = self.getCurrentUser()
-
-        return self._model.buildImage(tale, user, token, force=force)
+        return self._model.buildImage(tale, user, force=force)
 
     def updateBuildStatus(self, event):
         """


### PR DESCRIPTION
### Problem
If there's task running (e.g. launching a Tale) when the user logs out, the user's auth token is invalidated and any GirderClient usage (e.g. writing output to job logs) leads to task failure.

### Approach
Generate dedicated user tokens to use inside jobs.

### How to Test
1. Checkout and run this branch locally
1. Login to the WholeTale Platform.
1. In a terminal window, follow logs from `celery_worker` container:
   ```
   docker logs --tail=20 -f celery_worker
   ```
1. Launch a Tale (You should see a job running in `celery_worker`)
1. While the Tale is still launching, log out of the WholeTale Platform
1. You should see job continuing to run in `celery_worker` logs
1. Once `celery_worker` logs indicate that the Tale launched (Task gwvolman.tasks.launch_container is completed) log in to dashboard and confirm Tale is running.