### PR TITLE
Properly identify DOI for the root of a globus ds. Fixes #312

### DIFF
--- a/server/lib/globus/globus_provider.py
+++ b/server/lib/globus/globus_provider.py
@@ -102,12 +102,16 @@ class GlobusImportProvider(ImportProvider):
                     url='globus://%s/%s%s' % (endpoint, path, entry['name']))
 
     def getDatasetUID(self, doc, user):
-        if 'folderId' in doc:
-            path_to_root = Item().parentsToRoot(doc, user=user)
-        else:
-            path_to_root = Folder().parentsToRoot(doc, user=user)
-        # Collection{WT Catalog} / Folder{WT Catalog} / Folder{Globus ds root}
-        return path_to_root[2]['object']['meta']['identifier']
+        try:
+            identifier = doc['meta']['identifier']  # if root of ds, it should have it
+        except (KeyError, TypeError):
+            if 'folderId' in doc:
+                path_to_root = Item().parentsToRoot(doc, user=user)
+            else:
+                path_to_root = Folder().parentsToRoot(doc, user=user)
+            # Collection{WT Catalog} / Folder{WT Catalog} / Folder{Globus ds root}
+            identifier = path_to_root[2]['object']['meta']['identifier']
+        return identifier
 
     def getURI(self, doc, user):
         if 'folderId' in doc:


### PR DESCRIPTION
Fixes a case when a citation was not created properly when the root of Globus dataset was added to external data

### How to test?
1. Register http://dx.doi.org/doi:10.18126/M2662X (Manage)
2. Create an empty Tale (Compose)
3. Verify that citation in Tale's metadata is empty ( Run > Metadata )
4. Add 'A Machine Learning Approach for Engineering Bulk Metallic Glass Alloys' to the Tale ( Run > Files > External Data)
5. Verify that Tale has following citation (Run > Metadata):
  ```
  Wolverton, C. (2018) “A Machine Learning Approach for Engineering Bulk Metallic Glass Alloys.” Materials Data Facility. doi: 10.18126/M2662X.
  ```