### PR TITLE
Allow to import an external dataset as a Tale

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -12,6 +12,7 @@ add_python_test(tale
   EXTERNAL_DATA
   plugins/wholetale/5c92fbd472a9910001fbff72.zip
   plugins/wholetale/tale_import_zip.txt
+  plugins/wholetale/tale_import_binder.txt
 )
 add_python_test(instance PLUGIN wholetale)
 add_python_test(constants PLUGIN wholetale)

--- a/plugin.cmake
+++ b/plugin.cmake
@@ -9,10 +9,13 @@ add_python_test(harvester
 add_python_test(image PLUGIN wholetale)
 add_python_test(tale
   PLUGIN wholetale
+)
+add_python_test(import
+  PLUGIN wholetale
   EXTERNAL_DATA
   plugins/wholetale/5c92fbd472a9910001fbff72.zip
-  plugins/wholetale/tale_import_zip.txt
   plugins/wholetale/tale_import_binder.txt
+  plugins/wholetale/tale_import_zip.txt
 )
 add_python_test(instance PLUGIN wholetale)
 add_python_test(constants PLUGIN wholetale)
@@ -38,7 +41,11 @@ add_python_test(dataverse
   plugins/wholetale/dataverse_lookup.txt
   plugins/wholetale/dataverse_listFiles.json
 )
-add_python_test(integration PLUGIN wholetale)
+add_python_test(integration
+  PLUGIN wholetale
+  EXTERNAL_DATA
+  plugins/wholetale/dataverse_integration.txt
+)
 add_python_test(repository
   PLUGIN wholetale
 )

--- a/plugin_tests/data/dataverse_integration.txt
+++ b/plugin_tests/data/dataverse_integration.txt
@@ -1,0 +1,52 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [dataverse.harvard.edu]
+      User-Agent: [Python-urllib/3.6]
+    method: GET
+    uri: https://dataverse.harvard.edu/api/search?q=entityId:3020113
+  response:
+    body: {string: '{"status":"OK","data":{"q":"entityId:3020113","total_count":1,"start":0,"spelling_alternatives":{},"items":[{"name":"data_study2.tab","type":"file","url":"https://dataverse.harvard.edu/api/access/datafile/3020113","file_id":"3020113","published_at":"2017-07-05T13:25:21Z","file_type":"Tab-Delimited","file_content_type":"text/tab-separated-values","size_in_bytes":97247,"md5":"223e50347f3443a70a0209eaa9b3f9bc","checksum":{"type":"MD5","value":"223e50347f3443a70a0209eaa9b3f9bc"},"unf":"UNF:6:oav9YMfSTA7HCJW0daUKGw==","file_persistent_id":"doi:10.7910/DVN/R3GZZW/YTPHP6","dataset_name":"Replication
+        Data for: The Economic Consequences of Partisanship in a Polarized Era","dataset_id":"3011019","dataset_persistent_id":"doi:10.7910/DVN/R3GZZW","dataset_citation":"McConnell,
+        Christopher; Margalit, Yotam; Malhotra, Neil; Levendusky, Matthew, 2017, \"Replication
+        Data for: The Economic Consequences of Partisanship in a Polarized Era\",
+        https://doi.org/10.7910/DVN/R3GZZW, Harvard Dataverse, V1, UNF:6:f4jgHeelNfPN7J+6Gkp2UA==
+        [fileUNF]"}],"count_in_response":1}}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Cache-control: [no-cache="set-cookie"]
+      Connection: [Close]
+      Content-Length: ['1062']
+      Content-Type: [application/json]
+      Date: ['Mon, 17 Jun 2019 20:23:11 GMT']
+      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
+      Set-Cookie: [AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3FE010BDBAE7AE7E438B31BFA0246B9F2DBD3EC37C4E69D8B958E3FBF8CF814030B5CB9749AB70FE33A8BB5BB36A149CB;PATH=/;MAX-AGE=28800]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [dataverse.harvard.edu]
+      User-Agent: [Python-urllib/3.6]
+    method: GET
+    uri: https://dataverse.harvard.edu/api/search?q=entityId:3020113
+  response:
+    body: {string: '{"status":"OK","data":{"q":"entityId:3020113","total_count":1,"start":0,"spelling_alternatives":{},"items":[{"name":"data_study2.tab","type":"file","url":"https://dataverse.harvard.edu/api/access/datafile/3020113","file_id":"3020113","published_at":"2017-07-05T13:25:21Z","file_type":"Tab-Delimited","file_content_type":"text/tab-separated-values","size_in_bytes":97247,"md5":"223e50347f3443a70a0209eaa9b3f9bc","checksum":{"type":"MD5","value":"223e50347f3443a70a0209eaa9b3f9bc"},"unf":"UNF:6:oav9YMfSTA7HCJW0daUKGw==","file_persistent_id":"doi:10.7910/DVN/R3GZZW/YTPHP6","dataset_name":"Replication
+        Data for: The Economic Consequences of Partisanship in a Polarized Era","dataset_id":"3011019","dataset_persistent_id":"doi:10.7910/DVN/R3GZZW","dataset_citation":"McConnell,
+        Christopher; Margalit, Yotam; Malhotra, Neil; Levendusky, Matthew, 2017, \"Replication
+        Data for: The Economic Consequences of Partisanship in a Polarized Era\",
+        https://doi.org/10.7910/DVN/R3GZZW, Harvard Dataverse, V1, UNF:6:f4jgHeelNfPN7J+6Gkp2UA==
+        [fileUNF]"}],"count_in_response":1}}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Cache-control: [no-cache="set-cookie"]
+      Connection: [Close]
+      Content-Length: ['1062']
+      Content-Type: [application/json]
+      Date: ['Mon, 17 Jun 2019 20:23:12 GMT']
+      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
+      Set-Cookie: [AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3CF6A1B0A2CD5F2F144400DE0E06A10F0DBD3EC37C4E69D8B958E3FBF8CF81403222DF6AABE0F6509EF79AB1D548B7265;PATH=/;MAX-AGE=28800]
+    status: {code: 200, message: OK}
+version: 1

--- a/plugin_tests/data/tale_import_binder.txt
+++ b/plugin_tests/data/tale_import_binder.txt
@@ -14,7 +14,7 @@ interactions:
       Connection: [close]
       Content-Length: ['85']
       Content-Type: [application/json]
-      Date: ['Thu, 13 Jun 2019 20:56:22 GMT']
+      Date: ['Fri, 14 Jun 2019 15:50:41 GMT']
       Server: [Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips]
     status: {code: 200, message: OK}
 - request:
@@ -42,9 +42,9 @@ interactions:
       Connection: [close]
       Content-Length: ['6513']
       Content-Type: [application/json]
-      Date: ['Thu, 13 Jun 2019 20:56:22 GMT']
+      Date: ['Fri, 14 Jun 2019 15:50:41 GMT']
       Server: [Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [JSESSIONID=2a0908021493a2c45b6f11541717; Path=/; Secure; HttpOnly]
+      Set-Cookie: [JSESSIONID=6af0f729295ad30cd30065a955d8; Path=/; Secure; HttpOnly]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -71,78 +71,8 @@ interactions:
       Connection: [close]
       Content-Length: ['6513']
       Content-Type: [application/json]
-      Date: ['Thu, 13 Jun 2019 20:56:23 GMT']
+      Date: ['Fri, 14 Jun 2019 15:50:41 GMT']
       Server: [Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [JSESSIONID=2a09141cfdba1b0be2e816945fb7; Path=/; Secure; HttpOnly]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Girder-Token: [affEVYUIP4r1nFx0qjGzG7o18zfXk3kEhR1mfmzFRjKP1QOXOvlfr1E9ekJ5QW0O]
-      User-Agent: [python-requests/2.21.0]
-    method: GET
-    uri: http://localhost:20200/api/v1/dm/session/5d02b8775de525773cc09876?loadObjects=true
-  response:
-    body: {string: '{"_accessLevel": 2, "_id": "5d02b8775de525773cc09876", "_modelType":
-        "session", "dataSet": [{"itemId": "5d02b8775de525773cc09866", "mountPath":
-        "/apt.txt", "obj": {"_id": "5d02b8775de525773cc09866", "baseParentId": "5d02b8765de525773cc09862",
-        "baseParentType": "collection", "created": "2019-06-13T20:56:23.187000+00:00",
-        "creatorId": "5d02b8765de525773cc09856", "description": "", "folderId": "5d02b8775de525773cc09865",
-        "lowerName": "apt.txt", "meta": {"identifier": "10.5072/FK2/NYNHAM", "provider":
-        "Dataverse"}, "name": "apt.txt", "size": 5, "updated": "2019-06-13T20:56:23.191000+00:00"},
-        "type": "item"}, {"itemId": "5d02b8775de525773cc09868", "mountPath": "/index.ipynb",
-        "obj": {"_id": "5d02b8775de525773cc09868", "baseParentId": "5d02b8765de525773cc09862",
-        "baseParentType": "collection", "created": "2019-06-13T20:56:23.208000+00:00",
-        "creatorId": "5d02b8765de525773cc09856", "description": "", "folderId": "5d02b8775de525773cc09865",
-        "lowerName": "index.ipynb", "meta": {"identifier": "10.5072/FK2/NYNHAM", "provider":
-        "Dataverse"}, "name": "index.ipynb", "size": 20183, "updated": "2019-06-13T20:56:23.212000+00:00"},
-        "type": "item"}, {"itemId": "5d02b8775de525773cc0986a", "mountPath": "/install.R",
-        "obj": {"_id": "5d02b8775de525773cc0986a", "baseParentId": "5d02b8765de525773cc09862",
-        "baseParentType": "collection", "created": "2019-06-13T20:56:23.226000+00:00",
-        "creatorId": "5d02b8765de525773cc09856", "description": "", "folderId": "5d02b8775de525773cc09865",
-        "lowerName": "install.r", "meta": {"identifier": "10.5072/FK2/NYNHAM", "provider":
-        "Dataverse"}, "name": "install.R", "size": 110, "updated": "2019-06-13T20:56:23.228000+00:00"},
-        "type": "item"}, {"itemId": "5d02b8775de525773cc0986c", "mountPath": "/irclog.tsv",
-        "obj": {"_id": "5d02b8775de525773cc0986c", "baseParentId": "5d02b8765de525773cc09862",
-        "baseParentType": "collection", "created": "2019-06-13T20:56:23.236000+00:00",
-        "creatorId": "5d02b8765de525773cc09856", "description": "", "folderId": "5d02b8775de525773cc09865",
-        "lowerName": "irclog.tsv", "meta": {"identifier": "10.5072/FK2/NYNHAM", "provider":
-        "Dataverse"}, "name": "irclog.tsv", "size": 9694487, "updated": "2019-06-13T20:56:23.238000+00:00"},
-        "type": "item"}, {"itemId": "5d02b8775de525773cc0986e", "mountPath": "/README.md",
-        "obj": {"_id": "5d02b8775de525773cc0986e", "baseParentId": "5d02b8765de525773cc09862",
-        "baseParentType": "collection", "created": "2019-06-13T20:56:23.246000+00:00",
-        "creatorId": "5d02b8765de525773cc09856", "description": "", "folderId": "5d02b8775de525773cc09865",
-        "lowerName": "readme.md", "meta": {"identifier": "10.5072/FK2/NYNHAM", "provider":
-        "Dataverse"}, "name": "README.md", "size": 430, "updated": "2019-06-13T20:56:23.248000+00:00"},
-        "type": "item"}, {"itemId": "5d02b8775de525773cc09870", "mountPath": "/runtime.txt",
-        "obj": {"_id": "5d02b8775de525773cc09870", "baseParentId": "5d02b8765de525773cc09862",
-        "baseParentType": "collection", "created": "2019-06-13T20:56:23.256000+00:00",
-        "creatorId": "5d02b8765de525773cc09856", "description": "", "folderId": "5d02b8775de525773cc09865",
-        "lowerName": "runtime.txt", "meta": {"identifier": "10.5072/FK2/NYNHAM", "provider":
-        "Dataverse"}, "name": "runtime.txt", "size": 13, "updated": "2019-06-13T20:56:23.258000+00:00"},
-        "type": "item"}, {"itemId": "5d02b8775de525773cc09872", "mountPath": "/superuser_graph.ipynb",
-        "obj": {"_id": "5d02b8775de525773cc09872", "baseParentId": "5d02b8765de525773cc09862",
-        "baseParentType": "collection", "created": "2019-06-13T20:56:23.267000+00:00",
-        "creatorId": "5d02b8765de525773cc09856", "description": "", "folderId": "5d02b8775de525773cc09865",
-        "lowerName": "superuser_graph.ipynb", "meta": {"identifier": "10.5072/FK2/NYNHAM",
-        "provider": "Dataverse"}, "name": "superuser_graph.ipynb", "size": 39258,
-        "updated": "2019-06-13T20:56:23.269000+00:00"}, "type": "item"}, {"itemId":
-        "5d02b8775de525773cc09874", "mountPath": "/superuser_graph-monthly.ipynb",
-        "obj": {"_id": "5d02b8775de525773cc09874", "baseParentId": "5d02b8765de525773cc09862",
-        "baseParentType": "collection", "created": "2019-06-13T20:56:23.278000+00:00",
-        "creatorId": "5d02b8765de525773cc09856", "description": "", "folderId": "5d02b8775de525773cc09865",
-        "lowerName": "superuser_graph-monthly.ipynb", "meta": {"identifier": "10.5072/FK2/NYNHAM",
-        "provider": "Dataverse"}, "name": "superuser_graph-monthly.ipynb", "size":
-        36087, "updated": "2019-06-13T20:56:23.279000+00:00"}, "type": "item"}], "ownerId":
-        "5d02b8765de525773cc09856", "seq": 0, "taleId": null}'}
-    headers:
-      Allow: ['DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT']
-      Content-Length: ['4493']
-      Content-Type: [application/json]
-      Date: ['Thu, 13 Jun 2019 20:56:23 GMT']
-      Server: [Girder 2.5.0]
+      Set-Cookie: [JSESSIONID=6af103017379ae687467904cfb89; Path=/; Secure; HttpOnly]
     status: {code: 200, message: OK}
 version: 1

--- a/plugin_tests/data/tale_import_binder.txt
+++ b/plugin_tests/data/tale_import_binder.txt
@@ -1,0 +1,148 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [dev2.dataverse.org]
+      User-Agent: [Python-urllib/3.6]
+    method: GET
+    uri: https://dev2.dataverse.org/api/info/version
+  response:
+    body: {string: '{"status":"OK","data":{"version":"4.14","build":"cannot-create-a-dataverse-3961134"}}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Connection: [close]
+      Content-Length: ['85']
+      Content-Type: [application/json]
+      Date: ['Thu, 13 Jun 2019 20:56:22 GMT']
+      Server: [Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [dev2.dataverse.org]
+      User-Agent: [Python-urllib/3.6]
+    method: GET
+    uri: https://dev2.dataverse.org/api/datasets/:persistentId?persistentId=doi:10.5072/FK2/NYNHAM
+  response:
+    body: {string: '{"status":"OK","data":{"id":18,"identifier":"FK2/NYNHAM","persistentUrl":"https://doi.org/10.5072/FK2/NYNHAM","protocol":"doi","authority":"10.5072","publisher":"Root","publicationDate":"2019-06-11","storageIdentifier":"file://10.5072/FK2/NYNHAM","latestVersion":{"id":5,"storageIdentifier":"file://10.5072/FK2/NYNHAM","versionNumber":1,"versionMinorNumber":1,"versionState":"RELEASED","productionDate":"Production
+        Date","lastUpdateTime":"2019-06-13T20:01:46Z","releaseTime":"2019-06-13T20:01:46Z","createTime":"2019-06-13T19:59:10Z","license":"NONE","fileAccessRequest":false,"metadataBlocks":{"citation":{"displayName":"Citation
+        Metadata","fields":[{"typeName":"title","multiple":false,"typeClass":"primitive","value":"Dataverse
+        IRC Metrics"},{"typeName":"author","multiple":true,"typeClass":"compound","value":[{"authorName":{"typeName":"authorName","multiple":false,"typeClass":"primitive","value":"Durbin,
+        Philip"},"authorAffiliation":{"typeName":"authorAffiliation","multiple":false,"typeClass":"primitive","value":"Harvard
+        University"},"authorIdentifierScheme":{"typeName":"authorIdentifierScheme","multiple":false,"typeClass":"controlledVocabulary","value":"ORCID"},"authorIdentifier":{"typeName":"authorIdentifier","multiple":false,"typeClass":"primitive","value":"0000-0002-9528-9470"}}]},{"typeName":"datasetContact","multiple":true,"typeClass":"compound","value":[{"datasetContactName":{"typeName":"datasetContactName","multiple":false,"typeClass":"primitive","value":"Durbin,
+        Philip"},"datasetContactAffiliation":{"typeName":"datasetContactAffiliation","multiple":false,"typeClass":"primitive","value":"Harvard
+        University"},"datasetContactEmail":{"typeName":"datasetContactEmail","multiple":false,"typeClass":"primitive","value":"philip_durbin@harvard.edu"}}]},{"typeName":"dsDescription","multiple":true,"typeClass":"compound","value":[{"dsDescriptionValue":{"typeName":"dsDescriptionValue","multiple":false,"typeClass":"primitive","value":"See
+        <a href=\"https://github.com/pdurbin/dataverse-irc-metrics\">https://github.com/pdurbin/dataverse-irc-metrics</a>."}}]},{"typeName":"subject","multiple":true,"typeClass":"controlledVocabulary","value":["Social
+        Sciences"]},{"typeName":"depositor","multiple":false,"typeClass":"primitive","value":"Durbin,
+        Philip"},{"typeName":"dateOfDeposit","multiple":false,"typeClass":"primitive","value":"2019-06-11"}]}},"files":[{"label":"apt.txt","restricted":false,"directoryLabel":"dataverse-irc-metrics-8f0b5b505de7730ebd9d57439952542a66a6bae0","version":2,"datasetVersionId":5,"categories":["Config"],"dataFile":{"id":28,"persistentId":"","pidURL":"","filename":"apt.txt","contentType":"text/plain","filesize":5,"storageIdentifier":"16b47a77833-0d15a8c6c14f","rootDataFileId":-1,"md5":"37055243218efa7c8adb2346f2386f7a","checksum":{"type":"MD5","value":"37055243218efa7c8adb2346f2386f7a"},"creationDate":"2019-06-11"}},{"label":"index.ipynb","restricted":false,"directoryLabel":"dataverse-irc-metrics-8f0b5b505de7730ebd9d57439952542a66a6bae0","version":1,"datasetVersionId":5,"categories":["Code"],"dataFile":{"id":30,"persistentId":"","pidURL":"","filename":"index.ipynb","contentType":"application/x-ipynb+json","filesize":20183,"storageIdentifier":"16b47a778c3-ad1b9509edeb","rootDataFileId":-1,"md5":"50ca9eeaa8c53c25567b9c8789fb0a82","checksum":{"type":"MD5","value":"50ca9eeaa8c53c25567b9c8789fb0a82"},"creationDate":"2019-06-11"}},{"label":"install.R","restricted":false,"directoryLabel":"dataverse-irc-metrics-8f0b5b505de7730ebd9d57439952542a66a6bae0","version":1,"datasetVersionId":5,"categories":["Code"],"dataFile":{"id":31,"persistentId":"","pidURL":"","filename":"install.R","contentType":"type/x-r-syntax","filesize":110,"storageIdentifier":"16b47a778ce-a8a9457ad7db","rootDataFileId":-1,"md5":"f7ed6200bcf1e18c14043c92d7ee1dee","checksum":{"type":"MD5","value":"f7ed6200bcf1e18c14043c92d7ee1dee"},"creationDate":"2019-06-11"}},{"label":"irclog.tsv","restricted":false,"directoryLabel":"dataverse-irc-metrics-8f0b5b505de7730ebd9d57439952542a66a6bae0/data","version":2,"datasetVersionId":5,"categories":["Data"],"dataFile":{"id":29,"persistentId":"","pidURL":"","filename":"irclog.tsv","contentType":"text/tsv","filesize":9694487,"storageIdentifier":"16b47a7788a-303e78082102","rootDataFileId":-1,"md5":"aed0e229f872dbb66aa1e4e6550bcbbb","checksum":{"type":"MD5","value":"aed0e229f872dbb66aa1e4e6550bcbbb"},"creationDate":"2019-06-11"}},{"label":"README.md","restricted":false,"directoryLabel":"dataverse-irc-metrics-8f0b5b505de7730ebd9d57439952542a66a6bae0","version":2,"datasetVersionId":5,"categories":["Documentation"],"dataFile":{"id":27,"persistentId":"","pidURL":"","filename":"README.md","contentType":"text/markdown","filesize":430,"storageIdentifier":"16b47a7781d-d4d481ae9509","rootDataFileId":-1,"md5":"5120a762443f13fccfcd29e9fffb0b77","checksum":{"type":"MD5","value":"5120a762443f13fccfcd29e9fffb0b77"},"creationDate":"2019-06-11"}},{"label":"runtime.txt","restricted":false,"directoryLabel":"dataverse-irc-metrics-8f0b5b505de7730ebd9d57439952542a66a6bae0","version":2,"datasetVersionId":5,"categories":["Config"],"dataFile":{"id":32,"persistentId":"","pidURL":"","filename":"runtime.txt","contentType":"text/plain","filesize":13,"storageIdentifier":"16b47a778d6-9daf3c49a3f1","rootDataFileId":-1,"md5":"376951af4316f01f81578c82f243aab7","checksum":{"type":"MD5","value":"376951af4316f01f81578c82f243aab7"},"creationDate":"2019-06-11"}},{"label":"superuser_graph.ipynb","restricted":false,"directoryLabel":"dataverse-irc-metrics-8f0b5b505de7730ebd9d57439952542a66a6bae0","version":1,"datasetVersionId":5,"categories":["Code"],"dataFile":{"id":34,"persistentId":"","pidURL":"","filename":"superuser_graph.ipynb","contentType":"application/x-ipynb+json","filesize":39258,"storageIdentifier":"16b47a778f4-57c48842a04f","rootDataFileId":-1,"md5":"b56361b57210966d9947ac75105dfc74","checksum":{"type":"MD5","value":"b56361b57210966d9947ac75105dfc74"},"creationDate":"2019-06-11"}},{"label":"superuser_graph-monthly.ipynb","restricted":false,"directoryLabel":"dataverse-irc-metrics-8f0b5b505de7730ebd9d57439952542a66a6bae0","version":1,"datasetVersionId":5,"categories":["Code"],"dataFile":{"id":33,"persistentId":"","pidURL":"","filename":"superuser_graph-monthly.ipynb","contentType":"application/x-ipynb+json","filesize":36087,"storageIdentifier":"16b47a778de-5c9102662203","rootDataFileId":-1,"md5":"eeb3449182e758c50f2b0cdac84430c8","checksum":{"type":"MD5","value":"eeb3449182e758c50f2b0cdac84430c8"},"creationDate":"2019-06-11"}}]}}}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Connection: [close]
+      Content-Length: ['6513']
+      Content-Type: [application/json]
+      Date: ['Thu, 13 Jun 2019 20:56:22 GMT']
+      Server: [Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips]
+      Set-Cookie: [JSESSIONID=2a0908021493a2c45b6f11541717; Path=/; Secure; HttpOnly]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [dev2.dataverse.org]
+      User-Agent: [Python-urllib/3.6]
+    method: GET
+    uri: https://dev2.dataverse.org/api/datasets/:persistentId?persistentId=doi:10.5072/FK2/NYNHAM
+  response:
+    body: {string: '{"status":"OK","data":{"id":18,"identifier":"FK2/NYNHAM","persistentUrl":"https://doi.org/10.5072/FK2/NYNHAM","protocol":"doi","authority":"10.5072","publisher":"Root","publicationDate":"2019-06-11","storageIdentifier":"file://10.5072/FK2/NYNHAM","latestVersion":{"id":5,"storageIdentifier":"file://10.5072/FK2/NYNHAM","versionNumber":1,"versionMinorNumber":1,"versionState":"RELEASED","productionDate":"Production
+        Date","lastUpdateTime":"2019-06-13T20:01:46Z","releaseTime":"2019-06-13T20:01:46Z","createTime":"2019-06-13T19:59:10Z","license":"NONE","fileAccessRequest":false,"metadataBlocks":{"citation":{"displayName":"Citation
+        Metadata","fields":[{"typeName":"title","multiple":false,"typeClass":"primitive","value":"Dataverse
+        IRC Metrics"},{"typeName":"author","multiple":true,"typeClass":"compound","value":[{"authorName":{"typeName":"authorName","multiple":false,"typeClass":"primitive","value":"Durbin,
+        Philip"},"authorAffiliation":{"typeName":"authorAffiliation","multiple":false,"typeClass":"primitive","value":"Harvard
+        University"},"authorIdentifierScheme":{"typeName":"authorIdentifierScheme","multiple":false,"typeClass":"controlledVocabulary","value":"ORCID"},"authorIdentifier":{"typeName":"authorIdentifier","multiple":false,"typeClass":"primitive","value":"0000-0002-9528-9470"}}]},{"typeName":"datasetContact","multiple":true,"typeClass":"compound","value":[{"datasetContactName":{"typeName":"datasetContactName","multiple":false,"typeClass":"primitive","value":"Durbin,
+        Philip"},"datasetContactAffiliation":{"typeName":"datasetContactAffiliation","multiple":false,"typeClass":"primitive","value":"Harvard
+        University"},"datasetContactEmail":{"typeName":"datasetContactEmail","multiple":false,"typeClass":"primitive","value":"philip_durbin@harvard.edu"}}]},{"typeName":"dsDescription","multiple":true,"typeClass":"compound","value":[{"dsDescriptionValue":{"typeName":"dsDescriptionValue","multiple":false,"typeClass":"primitive","value":"See
+        <a href=\"https://github.com/pdurbin/dataverse-irc-metrics\">https://github.com/pdurbin/dataverse-irc-metrics</a>."}}]},{"typeName":"subject","multiple":true,"typeClass":"controlledVocabulary","value":["Social
+        Sciences"]},{"typeName":"depositor","multiple":false,"typeClass":"primitive","value":"Durbin,
+        Philip"},{"typeName":"dateOfDeposit","multiple":false,"typeClass":"primitive","value":"2019-06-11"}]}},"files":[{"label":"apt.txt","restricted":false,"directoryLabel":"dataverse-irc-metrics-8f0b5b505de7730ebd9d57439952542a66a6bae0","version":2,"datasetVersionId":5,"categories":["Config"],"dataFile":{"id":28,"persistentId":"","pidURL":"","filename":"apt.txt","contentType":"text/plain","filesize":5,"storageIdentifier":"16b47a77833-0d15a8c6c14f","rootDataFileId":-1,"md5":"37055243218efa7c8adb2346f2386f7a","checksum":{"type":"MD5","value":"37055243218efa7c8adb2346f2386f7a"},"creationDate":"2019-06-11"}},{"label":"index.ipynb","restricted":false,"directoryLabel":"dataverse-irc-metrics-8f0b5b505de7730ebd9d57439952542a66a6bae0","version":1,"datasetVersionId":5,"categories":["Code"],"dataFile":{"id":30,"persistentId":"","pidURL":"","filename":"index.ipynb","contentType":"application/x-ipynb+json","filesize":20183,"storageIdentifier":"16b47a778c3-ad1b9509edeb","rootDataFileId":-1,"md5":"50ca9eeaa8c53c25567b9c8789fb0a82","checksum":{"type":"MD5","value":"50ca9eeaa8c53c25567b9c8789fb0a82"},"creationDate":"2019-06-11"}},{"label":"install.R","restricted":false,"directoryLabel":"dataverse-irc-metrics-8f0b5b505de7730ebd9d57439952542a66a6bae0","version":1,"datasetVersionId":5,"categories":["Code"],"dataFile":{"id":31,"persistentId":"","pidURL":"","filename":"install.R","contentType":"type/x-r-syntax","filesize":110,"storageIdentifier":"16b47a778ce-a8a9457ad7db","rootDataFileId":-1,"md5":"f7ed6200bcf1e18c14043c92d7ee1dee","checksum":{"type":"MD5","value":"f7ed6200bcf1e18c14043c92d7ee1dee"},"creationDate":"2019-06-11"}},{"label":"irclog.tsv","restricted":false,"directoryLabel":"dataverse-irc-metrics-8f0b5b505de7730ebd9d57439952542a66a6bae0/data","version":2,"datasetVersionId":5,"categories":["Data"],"dataFile":{"id":29,"persistentId":"","pidURL":"","filename":"irclog.tsv","contentType":"text/tsv","filesize":9694487,"storageIdentifier":"16b47a7788a-303e78082102","rootDataFileId":-1,"md5":"aed0e229f872dbb66aa1e4e6550bcbbb","checksum":{"type":"MD5","value":"aed0e229f872dbb66aa1e4e6550bcbbb"},"creationDate":"2019-06-11"}},{"label":"README.md","restricted":false,"directoryLabel":"dataverse-irc-metrics-8f0b5b505de7730ebd9d57439952542a66a6bae0","version":2,"datasetVersionId":5,"categories":["Documentation"],"dataFile":{"id":27,"persistentId":"","pidURL":"","filename":"README.md","contentType":"text/markdown","filesize":430,"storageIdentifier":"16b47a7781d-d4d481ae9509","rootDataFileId":-1,"md5":"5120a762443f13fccfcd29e9fffb0b77","checksum":{"type":"MD5","value":"5120a762443f13fccfcd29e9fffb0b77"},"creationDate":"2019-06-11"}},{"label":"runtime.txt","restricted":false,"directoryLabel":"dataverse-irc-metrics-8f0b5b505de7730ebd9d57439952542a66a6bae0","version":2,"datasetVersionId":5,"categories":["Config"],"dataFile":{"id":32,"persistentId":"","pidURL":"","filename":"runtime.txt","contentType":"text/plain","filesize":13,"storageIdentifier":"16b47a778d6-9daf3c49a3f1","rootDataFileId":-1,"md5":"376951af4316f01f81578c82f243aab7","checksum":{"type":"MD5","value":"376951af4316f01f81578c82f243aab7"},"creationDate":"2019-06-11"}},{"label":"superuser_graph.ipynb","restricted":false,"directoryLabel":"dataverse-irc-metrics-8f0b5b505de7730ebd9d57439952542a66a6bae0","version":1,"datasetVersionId":5,"categories":["Code"],"dataFile":{"id":34,"persistentId":"","pidURL":"","filename":"superuser_graph.ipynb","contentType":"application/x-ipynb+json","filesize":39258,"storageIdentifier":"16b47a778f4-57c48842a04f","rootDataFileId":-1,"md5":"b56361b57210966d9947ac75105dfc74","checksum":{"type":"MD5","value":"b56361b57210966d9947ac75105dfc74"},"creationDate":"2019-06-11"}},{"label":"superuser_graph-monthly.ipynb","restricted":false,"directoryLabel":"dataverse-irc-metrics-8f0b5b505de7730ebd9d57439952542a66a6bae0","version":1,"datasetVersionId":5,"categories":["Code"],"dataFile":{"id":33,"persistentId":"","pidURL":"","filename":"superuser_graph-monthly.ipynb","contentType":"application/x-ipynb+json","filesize":36087,"storageIdentifier":"16b47a778de-5c9102662203","rootDataFileId":-1,"md5":"eeb3449182e758c50f2b0cdac84430c8","checksum":{"type":"MD5","value":"eeb3449182e758c50f2b0cdac84430c8"},"creationDate":"2019-06-11"}}]}}}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Connection: [close]
+      Content-Length: ['6513']
+      Content-Type: [application/json]
+      Date: ['Thu, 13 Jun 2019 20:56:23 GMT']
+      Server: [Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips]
+      Set-Cookie: [JSESSIONID=2a09141cfdba1b0be2e816945fb7; Path=/; Secure; HttpOnly]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Girder-Token: [affEVYUIP4r1nFx0qjGzG7o18zfXk3kEhR1mfmzFRjKP1QOXOvlfr1E9ekJ5QW0O]
+      User-Agent: [python-requests/2.21.0]
+    method: GET
+    uri: http://localhost:20200/api/v1/dm/session/5d02b8775de525773cc09876?loadObjects=true
+  response:
+    body: {string: '{"_accessLevel": 2, "_id": "5d02b8775de525773cc09876", "_modelType":
+        "session", "dataSet": [{"itemId": "5d02b8775de525773cc09866", "mountPath":
+        "/apt.txt", "obj": {"_id": "5d02b8775de525773cc09866", "baseParentId": "5d02b8765de525773cc09862",
+        "baseParentType": "collection", "created": "2019-06-13T20:56:23.187000+00:00",
+        "creatorId": "5d02b8765de525773cc09856", "description": "", "folderId": "5d02b8775de525773cc09865",
+        "lowerName": "apt.txt", "meta": {"identifier": "10.5072/FK2/NYNHAM", "provider":
+        "Dataverse"}, "name": "apt.txt", "size": 5, "updated": "2019-06-13T20:56:23.191000+00:00"},
+        "type": "item"}, {"itemId": "5d02b8775de525773cc09868", "mountPath": "/index.ipynb",
+        "obj": {"_id": "5d02b8775de525773cc09868", "baseParentId": "5d02b8765de525773cc09862",
+        "baseParentType": "collection", "created": "2019-06-13T20:56:23.208000+00:00",
+        "creatorId": "5d02b8765de525773cc09856", "description": "", "folderId": "5d02b8775de525773cc09865",
+        "lowerName": "index.ipynb", "meta": {"identifier": "10.5072/FK2/NYNHAM", "provider":
+        "Dataverse"}, "name": "index.ipynb", "size": 20183, "updated": "2019-06-13T20:56:23.212000+00:00"},
+        "type": "item"}, {"itemId": "5d02b8775de525773cc0986a", "mountPath": "/install.R",
+        "obj": {"_id": "5d02b8775de525773cc0986a", "baseParentId": "5d02b8765de525773cc09862",
+        "baseParentType": "collection", "created": "2019-06-13T20:56:23.226000+00:00",
+        "creatorId": "5d02b8765de525773cc09856", "description": "", "folderId": "5d02b8775de525773cc09865",
+        "lowerName": "install.r", "meta": {"identifier": "10.5072/FK2/NYNHAM", "provider":
+        "Dataverse"}, "name": "install.R", "size": 110, "updated": "2019-06-13T20:56:23.228000+00:00"},
+        "type": "item"}, {"itemId": "5d02b8775de525773cc0986c", "mountPath": "/irclog.tsv",
+        "obj": {"_id": "5d02b8775de525773cc0986c", "baseParentId": "5d02b8765de525773cc09862",
+        "baseParentType": "collection", "created": "2019-06-13T20:56:23.236000+00:00",
+        "creatorId": "5d02b8765de525773cc09856", "description": "", "folderId": "5d02b8775de525773cc09865",
+        "lowerName": "irclog.tsv", "meta": {"identifier": "10.5072/FK2/NYNHAM", "provider":
+        "Dataverse"}, "name": "irclog.tsv", "size": 9694487, "updated": "2019-06-13T20:56:23.238000+00:00"},
+        "type": "item"}, {"itemId": "5d02b8775de525773cc0986e", "mountPath": "/README.md",
+        "obj": {"_id": "5d02b8775de525773cc0986e", "baseParentId": "5d02b8765de525773cc09862",
+        "baseParentType": "collection", "created": "2019-06-13T20:56:23.246000+00:00",
+        "creatorId": "5d02b8765de525773cc09856", "description": "", "folderId": "5d02b8775de525773cc09865",
+        "lowerName": "readme.md", "meta": {"identifier": "10.5072/FK2/NYNHAM", "provider":
+        "Dataverse"}, "name": "README.md", "size": 430, "updated": "2019-06-13T20:56:23.248000+00:00"},
+        "type": "item"}, {"itemId": "5d02b8775de525773cc09870", "mountPath": "/runtime.txt",
+        "obj": {"_id": "5d02b8775de525773cc09870", "baseParentId": "5d02b8765de525773cc09862",
+        "baseParentType": "collection", "created": "2019-06-13T20:56:23.256000+00:00",
+        "creatorId": "5d02b8765de525773cc09856", "description": "", "folderId": "5d02b8775de525773cc09865",
+        "lowerName": "runtime.txt", "meta": {"identifier": "10.5072/FK2/NYNHAM", "provider":
+        "Dataverse"}, "name": "runtime.txt", "size": 13, "updated": "2019-06-13T20:56:23.258000+00:00"},
+        "type": "item"}, {"itemId": "5d02b8775de525773cc09872", "mountPath": "/superuser_graph.ipynb",
+        "obj": {"_id": "5d02b8775de525773cc09872", "baseParentId": "5d02b8765de525773cc09862",
+        "baseParentType": "collection", "created": "2019-06-13T20:56:23.267000+00:00",
+        "creatorId": "5d02b8765de525773cc09856", "description": "", "folderId": "5d02b8775de525773cc09865",
+        "lowerName": "superuser_graph.ipynb", "meta": {"identifier": "10.5072/FK2/NYNHAM",
+        "provider": "Dataverse"}, "name": "superuser_graph.ipynb", "size": 39258,
+        "updated": "2019-06-13T20:56:23.269000+00:00"}, "type": "item"}, {"itemId":
+        "5d02b8775de525773cc09874", "mountPath": "/superuser_graph-monthly.ipynb",
+        "obj": {"_id": "5d02b8775de525773cc09874", "baseParentId": "5d02b8765de525773cc09862",
+        "baseParentType": "collection", "created": "2019-06-13T20:56:23.278000+00:00",
+        "creatorId": "5d02b8765de525773cc09856", "description": "", "folderId": "5d02b8775de525773cc09865",
+        "lowerName": "superuser_graph-monthly.ipynb", "meta": {"identifier": "10.5072/FK2/NYNHAM",
+        "provider": "Dataverse"}, "name": "superuser_graph-monthly.ipynb", "size":
+        36087, "updated": "2019-06-13T20:56:23.279000+00:00"}, "type": "item"}], "ownerId":
+        "5d02b8765de525773cc09856", "seq": 0, "taleId": null}'}
+    headers:
+      Allow: ['DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT']
+      Content-Length: ['4493']
+      Content-Type: [application/json]
+      Date: ['Thu, 13 Jun 2019 20:56:23 GMT']
+      Server: [Girder 2.5.0]
+    status: {code: 200, message: OK}
+version: 1

--- a/plugin_tests/import_test.py
+++ b/plugin_tests/import_test.py
@@ -1,0 +1,280 @@
+import mock
+import os
+import json
+import time
+import vcr
+from tests import base
+from girder import config
+
+
+SCRIPTDIRS_NAME = None
+DATADIRS_NAME = None
+DATA_PATH = os.path.join(
+    os.path.dirname(os.environ['GIRDER_TEST_DATA_PREFIX']),
+    'data_src',
+    'plugins',
+    'wholetale',
+)
+
+
+JobStatus = None
+ImageStatus = None
+Tale = None
+os.environ['GIRDER_PORT'] = os.environ.get('GIRDER_TEST_PORT', '20200')
+config.loadConfig()  # Must reload config to pickup correct port
+
+
+class FakeAsyncResult(object):
+    def __init__(self, tale_id=None):
+        self.task_id = 'fake_id'
+        self.tale_id = tale_id
+
+    def get(self, timeout=None):
+        return {
+            'image_digest': 'digest123',
+            'repo2docker_version': 1,
+            'last_build': 123,
+        }
+
+
+def setUpModule():
+    base.enabledPlugins.append('wholetale')
+    base.enabledPlugins.append('wt_data_manager')
+    base.enabledPlugins.append('wt_home_dir')
+    base.startServer(mock=False)
+
+    global JobStatus, Tale, ImageStatus
+    from girder.plugins.jobs.constants import JobStatus
+    from girder.plugins.wholetale.models.tale import Tale
+    from girder.plugins.wholetale.constants import ImageStatus
+
+    global SCRIPTDIRS_NAME, DATADIRS_NAME
+    from girder.plugins.wholetale.constants import SCRIPTDIRS_NAME, DATADIRS_NAME
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class TaleTestCase(base.TestCase):
+    def setUp(self):
+        super(TaleTestCase, self).setUp()
+        users = (
+            {
+                'email': 'root@dev.null',
+                'login': 'admin',
+                'firstName': 'Root',
+                'lastName': 'van Klompf',
+                'password': 'secret',
+            },
+            {
+                'email': 'joe@dev.null',
+                'login': 'joeregular',
+                'firstName': 'Joe',
+                'lastName': 'Regular',
+                'password': 'secret',
+            },
+        )
+
+        self.authors = [
+            {
+                'firstName': 'Charles',
+                'lastName': 'Darwmin',
+                'orcid': 'https://orcid.org/000-000',
+            },
+            {
+                'firstName': 'Thomas',
+                'lastName': 'Edison',
+                'orcid': 'https://orcid.org/111-111',
+            },
+        ]
+        self.admin, self.user = [
+            self.model('user').createUser(**user) for user in users
+        ]
+
+        self.image_admin = self.model('image', 'wholetale').createImage(
+            name="test admin image", creator=self.admin, public=True
+        )
+
+        self.image = self.model('image', 'wholetale').createImage(
+            name="test my name",
+            creator=self.user,
+            public=True,
+            config=dict(
+                template='base.tpl',
+                buildpack='SomeBuildPack',
+                user='someUser',
+                port=8888,
+                urlPath='',
+            ),
+        )
+
+    @mock.patch('gwvolman.tasks.import_tale')
+    def testTaleImport(self, it):
+        with mock.patch(
+            'girder_worker.task.celery.Task.apply_async', spec=True
+        ) as mock_apply_async:
+            # mock_apply_async.return_value = 1
+            mock_apply_async().job.return_value = json.dumps({'job': 1, 'blah': 2})
+            resp = self.request(
+                path='/tale/import',
+                method='POST',
+                user=self.user,
+                params={
+                    'url': 'http://blah.com/',
+                    'spawn': False,
+                    'imageId': self.image['_id'],
+                    'asTale': False,
+                },
+            )
+            self.assertStatusOk(resp)
+            job_call = mock_apply_async.call_args_list[-1][-1]
+            self.assertEqual(
+                job_call['args'],
+                ({'dataId': ['http://blah.com/']}, {'imageId': str(self.image['_id'])}),
+            )
+            self.assertEqual(job_call['kwargs'], {'spawn': False})
+            self.assertEqual(job_call['headers']['girder_job_title'], 'Import Tale')
+
+    def testTaleImportBinder(self):
+        def before_record_cb(request):
+            if request.host == "localhost":
+                return None
+            return request
+
+        my_vcr = vcr.VCR(before_record_request=before_record_cb)
+        with my_vcr.use_cassette(os.path.join(DATA_PATH, 'tale_import_binder.txt')):
+            image = self.model('image', 'wholetale').createImage(
+                name="Jupyter Classic",
+                creator=self.user,
+                public=True,
+                config=dict(
+                    template='base.tpl',
+                    buildpack='PythonBuildPack',
+                    user='someUser',
+                    port=8888,
+                    urlPath='',
+                ),
+            )
+
+            from girder.plugins.wholetale.constants import (
+                PluginSettings,
+                InstanceStatus,
+            )
+
+            resp = self.request(
+                '/system/setting',
+                user=self.admin,
+                method='PUT',
+                params={
+                    'list': json.dumps(
+                        [
+                            {
+                                'key': PluginSettings.DATAVERSE_URL,
+                                'value': 'https://dev2.dataverse.org',
+                            }
+                        ]
+                    )
+                },
+            )
+            self.assertStatusOk(resp)
+
+            class fakeInstance(object):
+                _id = '123456789'
+
+                def createInstance(self, tale, user, token, spawn=False):
+                    return {'_id': self._id, 'status': InstanceStatus.LAUNCHING}
+
+                def load(self, instance_id, user=None):
+                    assert instance_id == self._id
+                    return {'_id': self._id, 'status': InstanceStatus.RUNNING}
+
+            with mock.patch(
+                'girder.plugins.wholetale.models.instance.Instance', fakeInstance
+            ):
+                resp = self.request(
+                    path='/tale/import',
+                    method='POST',
+                    user=self.user,
+                    params={
+                        'url': (
+                            'https://dev2.dataverse.org/dataset.xhtml?'
+                            'persistentId=doi:10.5072/FK2/NYNHAM'
+                        ),
+                        'spawn': True,
+                        'imageId': self.image['_id'],
+                        'asTale': True,
+                    },
+                )
+
+                self.assertStatusOk(resp)
+                job = resp.json
+
+                from girder.plugins.jobs.models.job import Job
+
+                self.assertEqual(job['type'], 'wholetale.import_binder')
+                for i in range(300):
+                    if job['status'] in {JobStatus.SUCCESS, JobStatus.ERROR}:
+                        break
+                    time.sleep(0.1)
+                    job = Job().load(job['_id'], force=True)
+                self.assertEqual(job['status'], JobStatus.SUCCESS)
+
+            self.assertTrue(
+                self.model('tale', 'wholetale').findOne(
+                    {'title': 'A Tale for "Dataverse IRC Metrics"'}
+                )
+                is not None
+            )
+            self.model('image', 'wholetale').remove(image)
+
+    @vcr.use_cassette(os.path.join(DATA_PATH, 'tale_import_zip.txt'))
+    def testTaleImportZip(self):
+        image = self.model('image', 'wholetale').createImage(
+            name="Jupyter Classic",
+            creator=self.user,
+            public=True,
+            config=dict(
+                template='base.tpl',
+                buildpack='PythonBuildPack',
+                user='someUser',
+                port=8888,
+                urlPath='',
+            ),
+        )
+        with mock.patch('fs.copy.copy_fs') as mock_copy:
+            with open(
+                os.path.join(DATA_PATH, '5c92fbd472a9910001fbff72.zip'), 'rb'
+            ) as fp:
+                resp = self.request(
+                    path='/tale/import',
+                    method='POST',
+                    user=self.user,
+                    type='application/zip',
+                    body=fp.read(),
+                )
+
+            self.assertStatusOk(resp)
+            job = resp.json
+
+            from girder.plugins.jobs.models.job import Job
+
+            self.assertEqual(job['type'], 'wholetale.import_tale')
+            for i in range(300):
+                if job['status'] in {JobStatus.SUCCESS, JobStatus.ERROR}:
+                    break
+                time.sleep(0.1)
+                job = Job().load(job['_id'], force=True)
+            self.assertEqual(job['status'], JobStatus.SUCCESS)
+        mock_copy.assert_called_once()
+        # TODO: make it more extensive...
+        self.assertTrue(
+            self.model('tale', 'wholetale').findOne({'title': 'Water Tale'}) is not None
+        )
+        self.model('image', 'wholetale').remove(image)
+
+    def tearDown(self):
+        self.model('user').remove(self.user)
+        self.model('user').remove(self.admin)
+        self.model('image', 'wholetale').remove(self.image)
+        super(TaleTestCase, self).tearDown()

--- a/plugin_tests/integration_test.py
+++ b/plugin_tests/integration_test.py
@@ -1,7 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import os
+import vcr
 from tests import base
 from urllib.parse import urlparse, parse_qs
+
+DATA_PATH = os.path.join(
+    os.path.dirname(os.environ['GIRDER_TEST_DATA_PREFIX']),
+    'data_src',
+    'plugins',
+    'wholetale',
+)
 
 
 def setUpModule():
@@ -14,42 +23,85 @@ def tearDownModule():
 
 
 class IntegrationTestCase(base.TestCase):
-
+    @vcr.use_cassette(os.path.join(DATA_PATH, 'dataverse_integration.txt'))
     def testDataverseIntegration(self):
         resp = self.request(
-            '/integration/dataverse', method='GET',
-            params={'fileId': 'blah', 'siteUrl': 'https://dataverse.someplace'})
+            '/integration/dataverse',
+            method='GET',
+            params={'fileId': 'blah', 'siteUrl': 'https://dataverse.someplace'},
+        )
         self.assertStatus(resp, 400)
-        self.assertEqual(resp.json, {
-            'message': 'Invalid fileId (should be integer)',
-            'type': 'rest'
-        })
+        self.assertEqual(
+            resp.json, {'message': 'Invalid fileId (should be integer)', 'type': 'rest'}
+        )
 
         resp = self.request(
-            '/integration/dataverse', method='GET',
-            params={'fileId': '1234', 'siteUrl': 'definitely not a URL'})
+            '/integration/dataverse',
+            method='GET',
+            params={'fileId': '1234', 'siteUrl': 'definitely not a URL'},
+        )
         self.assertStatus(resp, 400)
-        self.assertEqual(resp.json, {
-            'message': 'Not a valid URL: siteUrl',
-            'type': 'rest'
-        })
+        self.assertEqual(
+            resp.json, {'message': 'Not a valid URL: siteUrl', 'type': 'rest'}
+        )
 
         resp = self.request(
-            '/integration/dataverse', method='GET',
-            params={'fileId': '1234', 'siteUrl': 'https://dataverse.someplace'})
+            '/integration/dataverse',
+            method='GET',
+            params={
+                'fileId': '3020113',
+                'siteUrl': 'https://dataverse.harvard.edu',
+                'fullDataset': False,
+            },
+        )
         self.assertStatus(resp, 303)
         self.assertEqual(
-            resp.headers['Location'],
-            'https://dashboard.wholetale.org/compose?uri='
-            'https%3A%2F%2Fdataverse.someplace%2Fapi%2Faccess%2Fdatafile%2F1234'
+            parse_qs(urlparse(resp.headers['Location']).query),
+            {
+                'uri': ['https://dataverse.harvard.edu/api/access/datafile/3020113'],
+                'name': [
+                    'Replication Data for: '
+                    'The Economic Consequences of Partisanship in a Polarized Era'
+                ],
+                'asTale': ['True'],
+            },
+        )
+
+        resp = self.request(
+            '/integration/dataverse',
+            method='GET',
+            params={
+                'fileId': '3020113',
+                'siteUrl': 'https://dataverse.harvard.edu',
+                'fullDataset': True,
+            },
+        )
+        self.assertStatus(resp, 303)
+        self.assertEqual(
+            parse_qs(urlparse(resp.headers['Location']).query),
+            {
+                'uri': [
+                    'https://dataverse.harvard.edu/dataset.xhtml'
+                    '?persistentId=doi:10.7910/DVN/R3GZZW'
+                ],
+                'name': [
+                    'Replication Data for: '
+                    'The Economic Consequences of Partisanship in a Polarized Era'
+                ],
+                'asTale': ['True'],
+            },
         )
 
     def testDataoneIntegration(self):
         resp = self.request(
-            '/integration/dataone', method='GET',
-            params={'uri': 'urn:uuid:12345.6789',
-                    'title': 'dataset title',
-                    'environment': 'rstudio'})
+            '/integration/dataone',
+            method='GET',
+            params={
+                'uri': 'urn:uuid:12345.6789',
+                'title': 'dataset title',
+                'environment': 'rstudio',
+            },
+        )
         self.assertStatus(resp, 303)
         query = parse_qs(urlparse(resp.headers['Location']).query)
         self.assertEqual(query['name'][0], 'dataset title')

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -10,7 +10,6 @@ import re
 import time
 import urllib.request
 import tempfile
-import vcr
 import zipfile
 import shutil
 from tests import base
@@ -517,118 +516,6 @@ class TaleTestCase(base.TestCase):
         self.assertEqual(tale['licenseSPDX'], WholeTaleLicense.default_spdx())
         self.assertTrue(isinstance(tale['authors'], list))
         self.model('tale', 'wholetale').remove(tale)
-
-    @mock.patch('gwvolman.tasks.import_tale')
-    def testTaleImport(self, it):
-        with mock.patch('girder_worker.task.celery.Task.apply_async', spec=True) \
-                as mock_apply_async:
-            # mock_apply_async.return_value = 1
-            mock_apply_async().job.return_value = json.dumps({'job': 1, 'blah': 2})
-            resp = self.request(
-                path='/tale/import', method='POST', user=self.user,
-                params={'url': 'http://blah.com/', 'spawn': False,
-                        'imageId': self.image['_id'], 'asTale': False}
-            )
-            self.assertStatusOk(resp)
-            job_call = mock_apply_async.call_args_list[-1][-1]
-            self.assertEqual(
-                job_call['args'],
-                ({'dataId': ['http://blah.com/']}, {'imageId': str(self.image['_id'])})
-            )
-            self.assertEqual(job_call['kwargs'], {'spawn': False})
-            self.assertEqual(job_call['headers']['girder_job_title'], 'Import Tale')
-
-    def testTaleImportBinder(self):
-
-        def before_record_cb(request):
-            if request.host == "localhost":
-                return None
-            return request
-
-        my_vcr = vcr.VCR(
-            before_record_request=before_record_cb,
-        )
-        with my_vcr.use_cassette(os.path.join(DATA_PATH, 'tale_import_binder.txt')):
-            image = self.model('image', 'wholetale').createImage(
-                name="Jupyter Classic", creator=self.user, public=True,
-                config=dict(template='base.tpl', buildpack='PythonBuildPack',
-                            user='someUser', port=8888, urlPath=''))
-
-            from girder.plugins.wholetale.constants import PluginSettings
-            resp = self.request(
-                '/system/setting', user=self.admin, method='PUT',
-                params={'list': json.dumps([
-                    {
-                        'key': PluginSettings.DATAVERSE_URL,
-                        'value': 'https://dev2.dataverse.org'
-                    }
-                ])}
-            )
-            self.assertStatusOk(resp)
-
-            with mock.patch('fs.copy.copy_fs') as mock_copy:
-                resp = self.request(
-                    path='/tale/import', method='POST', user=self.user,
-                    params={
-                        'url': (
-                            'https://dev2.dataverse.org/dataset.xhtml?'
-                            'persistentId=doi:10.5072/FK2/NYNHAM'
-                        ),
-                        'spawn': False, 'imageId': self.image['_id'], 'asTale': True
-                    }
-                )
-
-                self.assertStatusOk(resp)
-                job = resp.json
-
-                from girder.plugins.jobs.models.job import Job
-                self.assertEqual(job['type'], 'wholetale.import_binder')
-                for i in range(300):
-                    if job['status'] in {JobStatus.SUCCESS, JobStatus.ERROR}:
-                        break
-                    time.sleep(0.1)
-                    job = Job().load(job['_id'], force=True)
-                self.assertEqual(job['status'], JobStatus.SUCCESS)
-            mock_copy.assert_called_once()
-            # TODO: make it more extensive...
-            self.assertTrue(
-                self.model('tale', 'wholetale').findOne(
-                    {'title': 'A Tale for "Dataverse IRC Metrics"'}
-                ) is not None
-            )
-            self.model('image', 'wholetale').remove(image)
-
-    @vcr.use_cassette(os.path.join(DATA_PATH, 'tale_import_zip.txt'))
-    def testTaleImportZip(self):
-        image = self.model('image', 'wholetale').createImage(
-            name="Jupyter Classic", creator=self.user, public=True,
-            config=dict(template='base.tpl', buildpack='PythonBuildPack',
-                        user='someUser', port=8888, urlPath=''))
-        with mock.patch('fs.copy.copy_fs') as mock_copy:
-            with open(os.path.join(DATA_PATH, '5c92fbd472a9910001fbff72.zip'), 'rb') as fp:
-                resp = self.request(
-                    path='/tale/import', method='POST', user=self.user,
-                    type='application/zip',
-                    body=fp.read(),
-                )
-
-            self.assertStatusOk(resp)
-            job = resp.json
-
-            from girder.plugins.jobs.models.job import Job
-            self.assertEqual(job['type'], 'wholetale.import_tale')
-            for i in range(300):
-                if job['status'] in {JobStatus.SUCCESS, JobStatus.ERROR}:
-                    break
-                time.sleep(0.1)
-                job = Job().load(job['_id'], force=True)
-            self.assertEqual(job['status'], JobStatus.SUCCESS)
-        mock_copy.assert_called_once()
-        # TODO: make it more extensive...
-        self.assertTrue(
-            self.model('tale', 'wholetale').findOne({'title': 'Water Tale'}) is not None
-        )
-        self.model('image', 'wholetale').remove(image)
 
     def testTaleUpdate(self):
         from server.lib.license import WholeTaleLicense

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -538,56 +538,65 @@ class TaleTestCase(base.TestCase):
             self.assertEqual(job_call['kwargs'], {'spawn': False})
             self.assertEqual(job_call['headers']['girder_job_title'], 'Import Tale')
 
-    @vcr.use_cassette(os.path.join(DATA_PATH, 'tale_import_binder.txt'))
     def testTaleImportBinder(self):
-        image = self.model('image', 'wholetale').createImage(
-            name="Jupyter Classic", creator=self.user, public=True,
-            config=dict(template='base.tpl', buildpack='PythonBuildPack',
-                        user='someUser', port=8888, urlPath=''))
 
-        from girder.plugins.wholetale.constants import PluginSettings
-        resp = self.request(
-            '/system/setting', user=self.admin, method='PUT',
-            params={'list': json.dumps([
-                {
-                    'key': PluginSettings.DATAVERSE_URL,
-                    'value': 'https://dev2.dataverse.org'
-                }
-            ])}
+        def before_record_cb(request):
+            if request.host == "localhost":
+                return None
+            return request
+
+        my_vcr = vcr.VCR(
+            before_record_request=before_record_cb,
         )
-        self.assertStatusOk(resp)
+        with my_vcr.use_cassette(os.path.join(DATA_PATH, 'tale_import_binder.txt')):
+            image = self.model('image', 'wholetale').createImage(
+                name="Jupyter Classic", creator=self.user, public=True,
+                config=dict(template='base.tpl', buildpack='PythonBuildPack',
+                            user='someUser', port=8888, urlPath=''))
 
-        with mock.patch('fs.copy.copy_fs') as mock_copy:
+            from girder.plugins.wholetale.constants import PluginSettings
             resp = self.request(
-                path='/tale/import', method='POST', user=self.user,
-                params={
-                    'url': (
-                        'https://dev2.dataverse.org/dataset.xhtml?'
-                        'persistentId=doi:10.5072/FK2/NYNHAM'
-                    ),
-                    'spawn': False, 'imageId': self.image['_id'], 'asTale': True
-                }
+                '/system/setting', user=self.admin, method='PUT',
+                params={'list': json.dumps([
+                    {
+                        'key': PluginSettings.DATAVERSE_URL,
+                        'value': 'https://dev2.dataverse.org'
+                    }
+                ])}
             )
-
             self.assertStatusOk(resp)
-            job = resp.json
 
-            from girder.plugins.jobs.models.job import Job
-            self.assertEqual(job['type'], 'wholetale.import_binder')
-            for i in range(300):
-                if job['status'] in {JobStatus.SUCCESS, JobStatus.ERROR}:
-                    break
-                time.sleep(0.1)
-                job = Job().load(job['_id'], force=True)
-            self.assertEqual(job['status'], JobStatus.SUCCESS)
-        mock_copy.assert_called_once()
-        # TODO: make it more extensive...
-        self.assertTrue(
-            self.model('tale', 'wholetale').findOne(
-                {'title': 'A Tale for "Dataverse IRC Metrics"'}
-            ) is not None
-        )
-        self.model('image', 'wholetale').remove(image)
+            with mock.patch('fs.copy.copy_fs') as mock_copy:
+                resp = self.request(
+                    path='/tale/import', method='POST', user=self.user,
+                    params={
+                        'url': (
+                            'https://dev2.dataverse.org/dataset.xhtml?'
+                            'persistentId=doi:10.5072/FK2/NYNHAM'
+                        ),
+                        'spawn': False, 'imageId': self.image['_id'], 'asTale': True
+                    }
+                )
+
+                self.assertStatusOk(resp)
+                job = resp.json
+
+                from girder.plugins.jobs.models.job import Job
+                self.assertEqual(job['type'], 'wholetale.import_binder')
+                for i in range(300):
+                    if job['status'] in {JobStatus.SUCCESS, JobStatus.ERROR}:
+                        break
+                    time.sleep(0.1)
+                    job = Job().load(job['_id'], force=True)
+                self.assertEqual(job['status'], JobStatus.SUCCESS)
+            mock_copy.assert_called_once()
+            # TODO: make it more extensive...
+            self.assertTrue(
+                self.model('tale', 'wholetale').findOne(
+                    {'title': 'A Tale for "Dataverse IRC Metrics"'}
+                ) is not None
+            )
+            self.model('image', 'wholetale').remove(image)
 
     @vcr.use_cassette(os.path.join(DATA_PATH, 'tale_import_zip.txt'))
     def testTaleImportZip(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ kombu==4.2.2post1
 idna==2.7  # pin for requests
 requests==2.20.1  # https://github.com/requests/requests/issues/4890
 redis==2.10.6
+git+https://github.com/whole-tale/girderfs@master#egg=girderfs
 git+https://github.com/whole-tale/gwvolman@master#egg=gwvolman
 dataone.common==3.2.0
 dataone.libclient==3.2.0

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -338,6 +338,9 @@ def getJobResult(self, job):
         else:
             self.ensureTokenScopes('jobs.job_' + str(job['_id']))
 
+    if 'result' in job:
+        return job['result']
+
     celeryTaskId = job.get('celeryTaskId')
     if celeryTaskId is None:
         logger.warn(

--- a/server/lib/dataverse/integration.py
+++ b/server/lib/dataverse/integration.py
@@ -15,16 +15,36 @@ from .provider import DataverseImportProvider
 @access.public
 @autoDescribeRoute(
     Description('Convert external tools request and bounce it to the dashboard.')
-    .param('fileId', 'The Dataverse database ID of a file the external tool has '
-           'been launched on.', required=True)
-    .param('siteUrl', 'The URL of the Dataverse installation that hosts the file '
-           'with the fileId above', required=True)
-    .param('apiToken', 'The Dataverse API token of the user launching the external'
-           ' tool, if available.', required=False)
+    .param(
+        'fileId',
+        'The Dataverse database ID of a file the external tool has '
+        'been launched on.',
+        required=True,
+    )
+    .param(
+        'siteUrl',
+        'The URL of the Dataverse installation that hosts the file '
+        'with the fileId above',
+        required=True,
+    )
+    .param(
+        'apiToken',
+        'The Dataverse API token of the user launching the external'
+        ' tool, if available.',
+        required=False,
+    )
+    .param(
+        'fullDataset',
+        'If True, imports the full dataset that '
+        'contains the file defined by fileId.',
+        dataType='boolean',
+        default=True,
+        required=False,
+    )
     .notes('apiToken is currently ignored.')
 )
 @boundHandler()
-def dataverseExternalTools(self, fileId, siteUrl, apiToken):
+def dataverseExternalTools(self, fileId, siteUrl, apiToken, fullDataset):
     if not validators.url(siteUrl):
         raise RestException('Not a valid URL: siteUrl')
     try:
@@ -38,8 +58,13 @@ def dataverseExternalTools(self, fileId, siteUrl, apiToken):
     )
     query = {'uri': url}
     try:
-        title, _, _ = DataverseImportProvider._parse_access_url(urlparse(url))
+        title, _, doi = DataverseImportProvider._parse_access_url(urlparse(url))
         query['name'] = title
+        if fullDataset:
+            url = "{scheme}://{netloc}/dataset.xhtml?persistentId=doi:{doi}".format(
+                scheme=site.scheme, netloc=site.netloc, doi=doi
+            )
+            query['uri'] = url
     except (HTTPError, URLError):
         # This doesn't bode well, but let's fail later when tale import happens
         pass
@@ -47,9 +72,7 @@ def dataverseExternalTools(self, fileId, siteUrl, apiToken):
     # TODO: Make base url a plugin setting, defaulting to dashboard.<domain>
     dashboard_url = os.environ.get('DASHBOARD_URL', 'https://dashboard.wholetale.org')
     location = urlunparse(
-        urlparse(dashboard_url)._replace(
-            path='/compose',
-            query=urlencode(query))
+        urlparse(dashboard_url)._replace(path='/compose', query=urlencode(query))
     )
     setResponseHeader('Location', location)
     cherrypy.response.status = 303

--- a/server/lib/dataverse/integration.py
+++ b/server/lib/dataverse/integration.py
@@ -65,6 +65,7 @@ def dataverseExternalTools(self, fileId, siteUrl, apiToken, fullDataset):
                 scheme=site.scheme, netloc=site.netloc, doi=doi
             )
             query['uri'] = url
+        query['asTale'] = True
     except (HTTPError, URLError):
         # This doesn't bode well, but let's fail later when tale import happens
         pass

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -293,7 +293,7 @@ class Tale(Resource):
                     async=True,
                     module="girder.plugins.wholetale.tasks.import_binder",
                     args=(taleKwargs, lookupKwargs),
-                    kwargs={"user": user},
+                    kwargs={"user": user, "spawn": spawn},
                 )
                 Job().scheduleJob(job)
                 return job

--- a/server/tasks/import_binder.py
+++ b/server/tasks/import_binder.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import stat
+import sys
+import textwrap
+import traceback
+from webdavfs.webdavfs import WebDAVFS
+from fs.base import FS
+from fs.copy import copy_fs
+from fs.enums import ResourceType
+from fs.errors import FileExpected
+from fs.error_tools import convert_os_errors
+from fs.info import Info
+from fs.mode import Mode
+from fs.path import basename
+from fs.permissions import Permissions
+from girderfs.core import WtDmsGirderFS
+from girder_client import GirderClient
+from girder.constants import AccessType
+from girder.models.folder import Folder
+from girder.models.token import Token
+from girder.utility import config
+from girder.plugins.jobs.constants import JobStatus
+from girder.plugins.jobs.models.job import Job
+
+from ..constants import CATALOG_NAME
+from ..lib import pids_to_entities, register_dataMap
+from ..lib.dataone import DataONELocations  # TODO: get rid of it
+from ..models.image import Image
+from ..models.tale import Tale
+from ..utils import getOrCreateRootFolder
+
+
+def run(job):
+    jobModel = Job()
+    jobModel.updateJob(job, status=JobStatus.RUNNING)
+
+    progressTotal = 4
+
+    tale_kwargs, lookup_kwargs = job["args"]
+    user = job["kwargs"]["user"]
+    # spawn = job["kwargs"]["spawn"]
+
+    try:
+        # 1. Register data using url
+        jobModel.updateJob(
+            job,
+            status=JobStatus.RUNNING,
+            progressTotal=progressTotal,
+            progressCurrent=1,
+            progressMessage="Registering external data",
+        )
+        dataIds = lookup_kwargs.pop('dataId')
+        base_url = lookup_kwargs.get('base_url', DataONELocations.prod_cn)
+        dataMap = pids_to_entities(
+            dataIds, user=user, base_url=base_url, lookup=True
+        )  # DataONE shouldn't be here
+        imported_data = register_dataMap(
+            dataMap,
+            getOrCreateRootFolder(CATALOG_NAME),
+            'folder',
+            user=user,
+            base_url=base_url,
+        )
+
+        # Warning: We assume it's coming from a provider that creates a root folder for ds,
+        # i.e. it's not HTTP/HTTPS resource, which makes sense at the time when I'm writing this
+        # since we support only D1 and DV
+        data_folder = Folder().load(imported_data[0], user=user)
+        # Create a dataset with the content of root ds folder, so that it looks nicely and it's easy
+        # to copy to workspace later on
+        data_set = [
+            {'itemId': folder['_id'], 'mountPath': '/' + folder['name']}
+            for folder in Folder().childFolders(
+                parentType='folder', parent=data_folder, user=user
+            )
+        ]
+        data_set += [
+            {'itemId': item['_id'], 'mountPath': '/' + item['name']}
+            for item in Folder().childItems(data_folder)
+        ]
+
+        # 2. Create a session
+        # TODO: yay circular dependencies! IMHO we really should merge wholetale and wt_data_manager
+        # plugins...
+        from girder.plugins.wt_data_manager.models.session import Session
+
+        # Session is created so that we can easily copy files to workspace, without worrying about
+        # how to handler transfers. DMS will do that for us <3
+        session = Session().createSession(user, dataSet=data_set)
+
+        # 3. Create a Tale
+        jobModel.updateJob(
+            job,
+            status=JobStatus.RUNNING,
+            log="Creating a Tale object",
+            progressTotal=progressTotal,
+            progressCurrent=2,
+            progressMessage="Creating a Tale object",
+        )
+
+        # Figure out a good Tale title default based on the name of imported dataset
+        if "title" not in tale_kwargs:
+            long_name = data_folder['name']
+            long_name = long_name.replace('-', ' ').replace('_', ' ')
+            shortened_name = textwrap.shorten(text=long_name, width=30)
+            tale_kwargs["title"] = "A Tale for \"{}\"".format(shortened_name)
+
+        image_id = tale_kwargs.pop('imageId')
+        image = Image().load(image_id, user=user, level=AccessType.READ, exc=True)
+        if "icon" not in tale_kwargs:
+            tale_kwargs["icon"] = image.get(
+                "icon",
+                (
+                    "https://raw.githubusercontent.com/"
+                    "whole-tale/dashboard/master/public/"
+                    "images/whole_tale_logo.png"
+                ),
+            )
+
+        tale = Tale().createTale(
+            image,
+            [],  # empty dataset
+            creator=user,
+            save=True,
+            public=False,
+            **tale_kwargs
+        )
+
+        # 4. Copy data to the workspace using WebDAVFS
+        jobModel.updateJob(
+            job,
+            status=JobStatus.RUNNING,
+            log="Copying files to workspace",
+            progressTotal=progressTotal,
+            progressCurrent=3,
+            progressMessage="Copying files to workspace",
+        )
+        token = Token().createToken(user=user, days=0.5)
+        girder_root = "http://localhost:{}".format(
+            config.getConfig()['server.socket_port']
+        )
+        with WebDAVFS(
+            girder_root,
+            login=user["login"],
+            password="token:{_id}".format(**token),
+            root="/tales/{_id}".format(**tale),
+        ) as destination_fs, DMSFS(
+            str(session['_id']), girder_root + '/api/v1', str(token['_id'])
+        ) as source_fs:
+            copy_fs(source_fs, destination_fs)
+
+        Session().deleteSession(user, session)
+        Token().remove(token)
+
+        jobModel.updateJob(
+            job,
+            status=JobStatus.SUCCESS,
+            log="Tale created",
+            progressTotal=progressTotal,
+            progressCurrent=4,
+            progressMessage="Tale created",
+        )
+
+        # TODO: use spawn?
+    except Exception:
+        t, val, tb = sys.exc_info()
+        log = "%s: %s\n%s" % (t.__name__, repr(val), traceback.extract_tb(tb))
+        jobModel.updateJob(job, status=JobStatus.ERROR, log=log)
+        raise
+
+
+class DMSFS(FS):
+    """Wrapper for WtDmsGirderFS using pyfilesystem.
+
+    This allows to access WtDMS in a pythonic way, without actually mounting it anywhere.
+    """
+
+    STAT_TO_RESOURCE_TYPE = {
+        stat.S_IFDIR: ResourceType.directory,
+        stat.S_IFCHR: ResourceType.character,
+        stat.S_IFBLK: ResourceType.block_special_file,
+        stat.S_IFREG: ResourceType.file,
+        stat.S_IFIFO: ResourceType.fifo,
+        stat.S_IFLNK: ResourceType.symlink,
+        stat.S_IFSOCK: ResourceType.socket,
+    }
+
+    def __init__(self, session_id, api_url, token):
+        super().__init__()
+        self.session_id = session_id
+        gc = GirderClient(apiUrl=api_url)
+        gc.token = token
+        self._fs = WtDmsGirderFS(session_id, gc)
+
+    def __repr__(self):
+        return "{}({})".format(self.__class__.__name__, self.session_id)
+
+    # Required methods
+    def getinfo(self, path, namespaces=None):
+        self.check()
+        namespaces = namespaces or ()
+        _path = self.validatepath(path)
+        _stat = self._fs.getinfo(_path)
+
+        info = {
+            "basic": {"name": basename(_path), "is_dir": stat.S_ISDIR(_stat['st_mode'])}
+        }
+
+        if "details" in namespaces:
+            info["details"] = {
+                "_write": ["accessed", "modified"],
+                "accessed": _stat["st_atime"],
+                "modified": _stat["st_mtime"],
+                "size": _stat["st_size"],
+                "type": int(
+                    self.STAT_TO_RESOURCE_TYPE.get(
+                        stat.S_IFMT(_stat["st_mode"]), ResourceType.unknown
+                    )
+                ),
+            }
+        if "stat" in namespaces:
+            info["stat"] = _stat
+
+        if "access" in namespaces:
+            info["access"] = {
+                "permissions": Permissions(mode=_stat["st_mode"]).dump(),
+                "uid": 1000,  # TODO: fix
+                "gid": 100,  # TODO: fix
+            }
+
+        return Info(info)
+
+    def listdir(self, path):
+        return self._fs.listdir(path)
+
+    def openbin(self, path, mode="r", buffering=-1, **options):
+        _mode = Mode(mode)
+        _mode.validate_bin()
+        self.check()
+        _path = self.validatepath(path)
+        if _path == "/":
+            raise FileExpected(path)
+        with convert_os_errors("openbin", path):
+            # TODO: I'm not sure if it's not leaving descriptors open...
+            fd = self._fs.open(_path, os.O_RDONLY)
+            fdict = self._fs.openFiles[path]
+            self._fs._ensure_region_available(path, fdict, fd, 0, fdict['obj']['size'])
+            return open(fdict['path'], 'r+b')
+
+    def makedir(self, path, permissions=None, recreate=False):
+        pass
+
+    def remove(self, path):
+        pass
+
+    def removedir(self, path):
+        pass
+
+    def setinfo(self, path, info):
+        pass

--- a/server/tasks/import_binder.py
+++ b/server/tasks/import_binder.py
@@ -123,6 +123,12 @@ def run(job):
                     "images/whole_tale_logo.png"
                 ),
             )
+        if "illustration" not in tale_kwargs:
+            tale_kwargs["illustration"] = (
+                'https://raw.githubusercontent.com/'
+                'whole-tale/dashboard/master/public/'
+                'images/demo-graph2.jpg'
+            )
 
         tale = Tale().createTale(
             image,

--- a/server/tasks/import_binder.py
+++ b/server/tasks/import_binder.py
@@ -72,7 +72,7 @@ def run(job):
         # Warning: We assume it's coming from a provider that creates a root folder for ds,
         # i.e. it's not HTTP/HTTPS resource, which makes sense at the time when I'm writing this
         # since we support only D1 and DV
-        data_folder = Folder().load(imported_data[0], user=user)
+        data_folder = Folder().load(imported_data[0], user=user, level=AccessType.READ)
         # Create a dataset with the content of root ds folder, so that it looks nicely and it's easy
         # to copy to workspace later on
         data_set = [

--- a/server/tasks/import_binder.py
+++ b/server/tasks/import_binder.py
@@ -163,7 +163,6 @@ def run(job):
             copy_fs(source_fs, destination_fs)
 
         Session().deleteSession(user, session)
-
         if spawn:
             jobModel.updateJob(
                 job,


### PR DESCRIPTION
### Rationale
Default "Analyze in WT" workflow imports incoming dataset as an immutable, readonly data. In some scenarios (e.g. a Binder compatible collection of files published to Dataverse whole-tale/whole-tale#66) this behavior is undesirable. Data should be copied to the Workspace instead to allow user to modify the environment and/or the code.

### Approach
1. Add a parameter `asTale` to `POST /tale/import` to indicate whether the dataset defined by `url` parameter should be imported as involatile data or copied to the workspace.
2. Importing as Tale is implemented as follows:
   1. Register the dataset defined by the `url` in the Catalog
   2. Create a `Session` with the content of registered folder from 1.
   3. Create an empty `Tale`.
   4. Copy data from WtDms (defined by the Session from step 2.) to the workspace (created in step 3.)

### How to test?

Make sure you pull `wholetale/girder` before testing this. I added new dependency: https://github.com/whole-tale/girder/commit/2ad286c4fe186fbff3fc63b85c0e67d0fc2e8480

1. (optionally): Verify that
  ```
  curl -IL "https://girder.local.wholetale.org/api/v1/integration/dataverse?fileId=30&siteUrl=https://dev2.dataverse.org"
  ```
  returns uri to entire dataset instead of a single file. Compare with the output of:
  ```
  curl -IL "https://girder.local.wholetale.org/api/v1/integration/dataverse?fileId=30&siteUrl=https://dev2.dataverse.org&fullDataset=false"
  ```
  which is a previous default behaviour.
1. Add "https://dev2.dataverse.org" to `Extra Dataverse Hosts` (Girder UI > Admin console > Plugins > Wholetale [link](https://girder.local.wholetale.org/#plugins/wholetale/config)).
1. Navigate to https://dev2.dataverse.org/file.xhtml?fileId=30&version=1.0, select "Explore > girder.local Whole Tale".
1. Confirm that Input data contains: `Data Source: https://dev2.dataverse.org/dataset.xhtml?persistentId=doi:10.5072/FK2/NYNHAM`
2. Choose image, and hit "Launch New Tale". **NOTE:** I'm not actually spawning a Tale right now, so after job finishes, the dashboard returns to the default state of compose
3. Navigate to Browse.
4. Confirm that "Dataverse IRC Metrics" Tale is there and run it.
5. Confirm that workspace contains a bunch of files. 

### TODO:
1. Actually launch Tale in step 2.
1. Add tests
1. This particular example requires latest repo2docker_wholetale, that I haven't fully tested yet. To enable it, you need add new custom image with `buildpack=="RBuildPack"`