### PR TITLE
Convert registration process to a job. Fixes #306

### DIFF
--- a/server/lib/__init__.py
+++ b/server/lib/__init__.py
@@ -80,7 +80,7 @@ def pids_to_entities(pids, user=None, base_url=None, lookup=True):
     return [x.toDict() for x in results]
 
 
-def register_dataMap(dataMaps, parent, parentType, user=None, base_url=None):
+def register_dataMap(dataMaps, parent, parentType, user=None, base_url=None, progress=False):
     """
     Register a list of Data Maps into a given Girder object
 
@@ -89,9 +89,9 @@ def register_dataMap(dataMaps, parent, parentType, user=None, base_url=None):
     :param parentType: Either a 'collection' or a 'folder'
     :param user: User performing the registration
     :param base_url: DataONE's node endpoint url
+    :param progress: If True, emit 'progress' notification for each registered file.
     :return: List of ids of registered objects
     """
-    progress = True
     importedData = []
     with ProgressContext(progress, user=user, title="Registering resources") as ctx:
         for dataMap in DataMap.fromList(dataMaps):

--- a/server/tasks/register_dataset.py
+++ b/server/tasks/register_dataset.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from girder.models.user import User
+from girder.plugins.jobs.constants import JobStatus
+from girder.plugins.jobs.models.job import Job
+
+from ..lib import register_dataMap
+
+
+def run(job):
+    dataMap, parent, parentType, user = job["args"]
+    base_url = job["kwargs"].get("base_url")
+    # In case this job is a part of a more complex task, progressTotal and progressCurrent can be
+    # passed as kwargs to take that into account
+    progressTotal = job["kwargs"].get("progressTotal", 2)
+    progressCurrent = job["kwargs"].get("progressCurrent", 0)
+
+    progressCurrent += 1
+    jobModel = Job()
+    jobModel.updateJob(
+        job,
+        status=JobStatus.RUNNING,
+        progressMessage="Registering Datasets",
+        progressTotal=progressTotal,
+        progressCurrent=progressCurrent,
+    )
+
+    # Notice progress=False below: we want to prevent default Girder progress notifications from
+    # being emitted, since all we care about is the wt_notification encompassing this job. We lose a
+    # lot of granularity here.
+    # TODO: pass progress context associated with wt_notification perhaps?
+    importedData = register_dataMap(
+        dataMap, parent, parentType, user=user, base_url=base_url, progress=False
+    )
+    if importedData:
+        user_data = set(user.get("myData", []))
+        user["myData"] = list(user_data.union(set(importedData)))
+        user = User().save(user)
+
+    # For some reason updating both status and progress keywords swallows a notification. Let's do
+    # it in two steps then.
+    progressCurrent += 1
+    jobModel.updateJob(
+        job,
+        progressMessage="Datasets registered",
+        progressTotal=progressTotal,
+        progressCurrent=progressCurrent,
+    )
+    jobModel.updateJob(job, status=JobStatus.SUCCESS)


### PR DESCRIPTION
This PR converts the dataset registration process into a job, which in turn allows for nice notifications in the dashboard (fixes https://github.com/whole-tale/ngx-dashboard/issues/43).

### How to test?

1. Deploy, register LIGO Tale
1. Create a new Tale
1. Navigate to View Tale / Files / External Data
1. Click on (+) / Web (DOI or URL)
1. Enter `doi:10.5065/D6862DM8`, click Search, then Register
   - Notification should pop up
1. (optionally) Follow the AinWT flow and verify that there's no additional registration notification, only a single one encompassing the entire AinWT process.
   1. Navigate to https://girder.local.wholetale.org/api/v1/integration/dataverse?datasetPid=doi%3A10.7910%2FDVN%2F3MJ7IR&siteUrl=https%3A%2F%2Fdataverse.harvard.edu
 