### PR TITLE
Do not try to resolve raw http resources via Datacite. Fixes #327

### DIFF
--- a/server/lib/__init__.py
+++ b/server/lib/__init__.py
@@ -102,7 +102,7 @@ def update_citation(event):
             )
             provider_name = doc['meta']['provider']
             if provider_name.startswith('HTTP'):
-                provider_name = 'HTTP'  # TODO: handle HTTPS to make it unnecessary
+                continue
             provider = IMPORT_PROVIDERS.providerMap[provider_name]
         except (KeyError, ValidationException):
             continue


### PR DESCRIPTION
`update_citation` method was needlessly trying to resolve HTTP(S) resources via Datacite. Since each of HTTP(S) resources has a unique UUID (its url), it was generating numerous outgoing calls. That's no longer the case with this PR.

# How to test
1. Deploy locally, register LIGO Tale.
2. Run `Copy on Launch` on LIGO Tale and confirm it starts new instance almost immediately.
3. Celebrate!