### PR TITLE
Update the Tale's 'imageId' on PUT

### DIFF
--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -618,6 +618,13 @@ class TaleTestCase(base.TestCase):
                 "orcid": user_orcid
             }
         ]
+
+        # Create a new image that the updated Tale will use
+        image = self.model('image', 'wholetale').createImage(
+            name="New Image", creator=self.user, public=True,
+            config=dict(template='base.tpl', buildpack='SomeBuildPack2',
+                        user='someUser', port=8888, urlPath=''))
+
         # Update the Tale with new values
         resp = self.request(
             path='/tale/{}'.format(str(resp.json['_id'])),
@@ -627,7 +634,7 @@ class TaleTestCase(base.TestCase):
             body=json.dumps({
                 'authors': new_authors,
                 'folderId': '1234',
-                'imageId': '5873dcdbaec030000144d233',
+                'imageId': str(image['_id']),
                 'dataSet': [],
                 'title': title,
                 'description': description,
@@ -646,7 +653,7 @@ class TaleTestCase(base.TestCase):
 
         # Check that the updates happened
         # self.assertStatus(resp, 200)
-        self.assertEqual(resp.json['imageId'], '5873dcdbaec030000144d233')
+        self.assertEqual(resp.json['imageId'], str(image['_id']))
         self.assertEqual(resp.json['title'], title)
         self.assertEqual(resp.json['description'], description)
         self.assertEqual(resp.json['config'], config)

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -627,7 +627,7 @@ class TaleTestCase(base.TestCase):
             body=json.dumps({
                 'authors': new_authors,
                 'folderId': '1234',
-                'imageId': str(self.image['_id']),
+                'imageId': '5873dcdbaec030000144d233',
                 'dataSet': [],
                 'title': title,
                 'description': description,
@@ -646,7 +646,7 @@ class TaleTestCase(base.TestCase):
 
         # Check that the updates happened
         # self.assertStatus(resp, 200)
-        self.assertEqual(resp.json['imageId'], str(self.image['_id']))
+        self.assertEqual(resp.json['imageId'], '5873dcdbaec030000144d233')
         self.assertEqual(resp.json['title'], title)
         self.assertEqual(resp.json['description'], description)
         self.assertEqual(resp.json['config'], config)

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -34,7 +34,7 @@ class Tale(AccessControlledModel):
         self.modifiableFields = {
             'title', 'description', 'public', 'config', 'updated', 'authors',
             'category', 'icon', 'iframe', 'illustration', 'dataSet', 'licenseSPDX',
-            'workspaceModified', 'publishInfo'
+            'workspaceModified', 'publishInfo', 'imageId'
         }
         self.exposeFields(
             level=AccessType.READ,

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -129,6 +129,12 @@ class Tale(Resource):
 
         for keyword in self._model.modifiableFields:
             try:
+                if keyword == 'imageId':
+                    image = imageModel().load(
+                        tale['imageId'], user=self.getCurrentUser(),
+                        level=AccessType.READ, exc=True)
+                    taleObj['imageId'] = image['_id']
+                    continue
                 taleObj[keyword] = tale.pop(keyword)
             except KeyError:
                 pass


### PR DESCRIPTION
This PR adds the ability to change the environment of a Tale. This was done by moving the `imageId` into the Tale's modifiable fields. Because the request that is sent to girder has the new imageId encoded as JSON, we load the image before setting `tale['imageId']` which provides us with an ObjectID type rather than string. This is reflected in the unit tests where we need to create a new image rather than using a dummy string.

To Test:
1. Check this branch out
2. Launch the dashboard
3. Navigate to a Tale's metadata page
4. Change the environment
5. Save
6. Refresh the page
7. Note that the environment has been saved.