### PR TITLE
Add tale_title to notification payload

### DIFF
--- a/server/models/instance.py
+++ b/server/models/instance.py
@@ -78,7 +78,7 @@ class Instance(AccessControlledModel):
                 limit=limit, offset=offset):
             yield r
 
-    def updateAndRestartInstance(self, instance, user, digest):
+    def updateAndRestartInstance(self, instance, user, tale):
         """
         Updates and restarts an instance.
 
@@ -88,9 +88,12 @@ class Instance(AccessControlledModel):
         """
         token = Token().createToken(user=user, days=0.5)
 
+        digest = tale['imageInfo']['digest']
+
         resource = {
             'type': 'wt_update_instance',
-            'instance_id': instance['_id']
+            'instance_id': instance['_id'],
+            'tale_title': tale['title']
         }
         total = UPDATE_CONTAINER_STEP_TOTAL
 
@@ -175,6 +178,7 @@ class Instance(AccessControlledModel):
                 'type': 'wt_create_instance',
                 'tale_id': tale['_id'],
                 'instance_id': instance['_id'],
+                'tale_title': tale['title']
             }
 
             total = BUILD_TALE_IMAGE_STEP_TOTAL + CREATE_VOLUME_STEP_TOTAL + \

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -286,7 +286,8 @@ class Tale(AccessControlledModel):
 
         resource = {
             'type': 'wt_build_image',
-            'tale_id': tale['_id']
+            'tale_id': tale['_id'],
+            'title_title': tale['title']
         }
 
         token = Token().createToken(user=user, days=0.5)

--- a/server/rest/instance.py
+++ b/server/rest/instance.py
@@ -151,7 +151,7 @@ class Instance(Resource):
         self._model.updateAndRestartInstance(
             instance,
             currentUser,
-            tale['imageInfo']['digest'])
+            tale)
         return instance
 
     @access.user


### PR DESCRIPTION
Fixes #320.

To test:

* Start a tale
* Modify the environment and rebuild the tale
* Restart the tale
* Inspect the notification stream and confirm that the `resource` field for notifications with `type`  in `wt_create_instance`, `wt_build_image`,  and `wt_update_instance` contains the `tale_title` set to the title of the current tale.