### PR TITLE
Add agave import provider

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ dataone.cli==3.2.0
 validators
 html2markdown
 fs.webdavfs
+agavepy

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -18,7 +18,7 @@ from girder.plugins.jobs.models.job import Job as JobModel
 from girder.plugins.worker import getCeleryApp
 from girder.utility import assetstore_utilities, setting_utilities
 from girder.utility.model_importer import ModelImporter
-from girder.plugins.oauth.providers.agavebase import AgaveBase #DesignSafe, CyVerse
+from girder.plugins.oauth.providers.agavebase import AgaveBase
 from girder.models.user import User
 
 from .constants import PluginSettings, SettingDefault

--- a/server/lib/__init__.py
+++ b/server/lib/__init__.py
@@ -28,7 +28,7 @@ IMPORT_PROVIDERS = ImportProviders()
 IMPORT_PROVIDERS.addProvider(DataverseImportProvider())
 IMPORT_PROVIDERS.addProvider(GlobusImportProvider())
 IMPORT_PROVIDERS.addProvider(DataOneImportProvider())
-#IMPORT_PROVIDERS.addProvider(DesignSafeImportProvider())
+IMPORT_PROVIDERS.addProvider(DesignSafeImportProvider())
 # (almost) last resort
 IMPORT_PROVIDERS.addProvider(HTTPImportProvider())
 # just throws exceptions

--- a/server/lib/__init__.py
+++ b/server/lib/__init__.py
@@ -18,6 +18,7 @@ from .null_provider import NullImportProvider
 from .dataone.provider import DataOneImportProvider
 from .dataverse.provider import DataverseImportProvider
 from .globus.globus_provider import GlobusImportProvider
+from .agave.provider import DesignSafeImportProvider
 
 
 RESOLVERS = Resolvers()
@@ -27,6 +28,7 @@ IMPORT_PROVIDERS = ImportProviders()
 IMPORT_PROVIDERS.addProvider(DataverseImportProvider())
 IMPORT_PROVIDERS.addProvider(GlobusImportProvider())
 IMPORT_PROVIDERS.addProvider(DataOneImportProvider())
+#IMPORT_PROVIDERS.addProvider(DesignSafeImportProvider())
 # (almost) last resort
 IMPORT_PROVIDERS.addProvider(HTTPImportProvider())
 # just throws exceptions

--- a/server/lib/__init__.py
+++ b/server/lib/__init__.py
@@ -18,7 +18,8 @@ from .null_provider import NullImportProvider
 from .dataone.provider import DataOneImportProvider
 from .dataverse.provider import DataverseImportProvider
 from .globus.globus_provider import GlobusImportProvider
-from .agave.provider import DesignSafeImportProvider
+from .agave.designsafe_provider import DesignSafeImportProvider
+from .agave.cyverse_provider import CyVerseImportProvider
 
 
 RESOLVERS = Resolvers()
@@ -29,6 +30,7 @@ IMPORT_PROVIDERS.addProvider(DataverseImportProvider())
 IMPORT_PROVIDERS.addProvider(GlobusImportProvider())
 IMPORT_PROVIDERS.addProvider(DataOneImportProvider())
 IMPORT_PROVIDERS.addProvider(DesignSafeImportProvider())
+IMPORT_PROVIDERS.addProvider(CyVerseImportProvider())
 # (almost) last resort
 IMPORT_PROVIDERS.addProvider(HTTPImportProvider())
 # just throws exceptions

--- a/server/lib/agave/cyverse_provider.py
+++ b/server/lib/agave/cyverse_provider.py
@@ -1,0 +1,99 @@
+import re
+import requests
+import json
+from typing import Tuple
+from agavepy.agave import Agave
+import urllib.parse
+
+from plugins.wholetale.server.lib.file_map import FileMap
+from ..import_providers import ImportProvider
+from ..resolvers import DOIResolver
+from ..entity import Entity
+from ..data_map import DataMap
+from ..import_item import ImportItem
+
+
+class CyVerseImportProvider(ImportProvider):
+    def __init__(self):
+        super().__init__('CyVerse')
+
+    @staticmethod
+    def create_regex():
+        return re.compile(r'^http://datacommons.cyverse.org/browse/iplant/home/.*')
+
+    def lookup(self, entity: Entity) -> DataMap:
+        (doi, title) = self._extractMeta(entity.getValue())
+        size = -1
+        return DataMap(entity.getValue(), size, doi=doi, name=title, repository=self.getName())
+
+    def _extractMeta(self, url) -> Tuple[str, str]:
+        path = url.split("http://datacommons.cyverse.org/browse")[1]
+        args = {"djng_url_name": "api_stat", "djng_url_kwarg_path": path}
+        encoded = urllib.parse.urlencode(args)
+        resp = self._getDocument(
+            "http://datacommons.cyverse.org/angular/reverse/?%s" % encoded)
+        projectId = resp["id"]
+        resp = self._getDocument(
+            "http://datacommons.cyverse.org/angular/reverse/?djng_url_name=api_metadata&djng_url_kwarg_item_id=%s" % projectId)
+        doi = None
+        title = None
+        for meta in resp["sorted_meta"]:
+            if meta["key"] == "DOI":
+                doi = meta["value"].lstrip()
+            if meta["key"] == "Title":
+                title = meta["value"]
+            if doi and title:
+                break
+        return doi, title
+
+    def _getDocument(self, url):
+        resp = requests.get(url)
+        if resp.status_code == 200:
+            return json.loads(resp.text)
+        elif resp.status_code == 404:
+            raise Exception('Document not found %s' % url)
+        else:
+            raise Exception('Error fetching document %s: %s' % (url, resp.content))
+
+    def listFiles(self, entity: Entity) -> FileMap:
+        stack = []
+        top = None
+        for item in self._listRecursive(entity.getUser(), entity.getValue(), None):
+            if item.type == ImportItem.FOLDER:
+                if len(stack) == 0:
+                    fm = FileMap(item.name)
+                else:
+                    fm = stack[-1].addChild(item.name)
+                stack.append(fm)
+            elif item.type == ImportItem.END_FOLDER:
+                top = stack.pop()
+            elif item.type == ImportItem.FILE:
+                stack[-1].addFile(item.name, item.size)
+        return top
+
+    def _listRecursive(self, user, pid: str, name: str, base_url: str = None, progress=None):
+        (doi, title) = self._extractMeta(pid)
+        yield ImportItem(ImportItem.FOLDER, name=title, identifier='doi:' + doi)
+        accessToken = user["agaveAccessToken"]
+        refreshToken = user["agaveRefreshToken"]
+        path = pid.split("http://datacommons.cyverse.org/browse/iplant/home", 1)[1]
+        endpoint = "data.iplantcollaborative.org"
+        ag = Agave(api_server="https://agave.iplantc.org", token=accessToken, refresh_token=refreshToken)
+        yield from self._listRecursive2(ag, endpoint, path, progress)
+        yield ImportItem(ImportItem.END_FOLDER)
+
+    def _listRecursive2(self, ag, endpoint: str, path: str, progress=None):
+        if path[-1] != '/':
+            path = path + '/'
+        if progress:
+            progress.update(increment=1, message='Listing files')
+        for entry in ag.files.list(filePath=path, systemId=endpoint):
+            if entry['type'] == 'dir' and entry['name'] != '.':
+                yield ImportItem(ImportItem.FOLDER, name=entry['name'])
+                yield from self._listRecursive2(ag, endpoint, path + entry['name'], progress)
+                yield ImportItem(ImportItem.END_FOLDER)
+            elif entry['type'] == 'file':
+                yield ImportItem(
+                    ImportItem.FILE, entry['name'], size=entry['length'],
+                    mimeType='application/octet-stream',
+                    url='https://agave.iplantc.org/files/v2/media/system/%s/%s%s' % (endpoint, path, entry['name']))

--- a/server/lib/agave/cyverse_provider.py
+++ b/server/lib/agave/cyverse_provider.py
@@ -7,7 +7,6 @@ import urllib.parse
 
 from plugins.wholetale.server.lib.file_map import FileMap
 from ..import_providers import ImportProvider
-from ..resolvers import DOIResolver
 from ..entity import Entity
 from ..data_map import DataMap
 from ..import_item import ImportItem
@@ -34,7 +33,8 @@ class CyVerseImportProvider(ImportProvider):
             "http://datacommons.cyverse.org/angular/reverse/?%s" % encoded)
         projectId = resp["id"]
         resp = self._getDocument(
-            "http://datacommons.cyverse.org/angular/reverse/?djng_url_name=api_metadata&djng_url_kwarg_item_id=%s" % projectId)
+            "http://datacommons.cyverse.org/angular/reverse/"
+            "?djng_url_name=api_metadata&djng_url_kwarg_item_id=%s" % projectId)
         doi = None
         title = None
         for meta in resp["sorted_meta"]:
@@ -78,7 +78,8 @@ class CyVerseImportProvider(ImportProvider):
         refreshToken = user["agaveRefreshToken"]
         path = pid.split("http://datacommons.cyverse.org/browse/iplant/home", 1)[1]
         endpoint = "data.iplantcollaborative.org"
-        ag = Agave(api_server="https://agave.iplantc.org", token=accessToken, refresh_token=refreshToken)
+        ag = Agave(api_server="https://agave.iplantc.org", token=accessToken,
+                   refresh_token=refreshToken)
         yield from self._listRecursive2(ag, endpoint, path, progress)
         yield ImportItem(ImportItem.END_FOLDER)
 
@@ -96,4 +97,5 @@ class CyVerseImportProvider(ImportProvider):
                 yield ImportItem(
                     ImportItem.FILE, entry['name'], size=entry['length'],
                     mimeType='application/octet-stream',
-                    url='https://agave.iplantc.org/files/v2/media/system/%s/%s%s' % (endpoint, path, entry['name']))
+                    url='https://agave.iplantc.org/files/v2/media/system/%s/%s%s' %
+                        (endpoint, path, entry['name']))

--- a/server/lib/agave/designsafe_provider.py
+++ b/server/lib/agave/designsafe_provider.py
@@ -67,7 +67,8 @@ class DesignSafeImportProvider(ImportProvider):
         url = pid.split("https://www.designsafe-ci.org/data/browser/public/", 1)[1].split("/")
         endpoint = url[0]
         path = "/" + url[1]
-        ag = Agave(api_server="https://agave.designsafe-ci.org", token=accessToken, refresh_token=refreshToken)
+        ag = Agave(api_server="https://agave.designsafe-ci.org", token=accessToken,
+                   refresh_token=refreshToken)
         yield from self._listRecursive2(ag, endpoint, path, progress)
         yield ImportItem(ImportItem.END_FOLDER)
 
@@ -85,7 +86,8 @@ class DesignSafeImportProvider(ImportProvider):
                 yield ImportItem(
                     ImportItem.FILE, entry['name'], size=entry['length'],
                     mimeType='application/octet-stream',
-                    url='https://agave.designsafe-ci.org/files/v2/media/system/%s/%s%s' % (endpoint, path, entry['name']))
+                    url='https://agave.designsafe-ci.org/files/v2/media/system/%s/%s%s'
+                        % (endpoint, path, entry['name']))
 
 
 class DocParser(HTMLParser):

--- a/server/lib/agave/provider.py
+++ b/server/lib/agave/provider.py
@@ -1,0 +1,134 @@
+import os
+import re
+from typing import Tuple
+from html.parser import HTMLParser
+from urllib.parse import parse_qs
+from urllib.request import OpenerDirector, HTTPSHandler
+
+from girder.models.item import Item
+from girder.models.folder import Folder
+
+from plugins.wholetale.server.lib.file_map import FileMap
+from ..import_providers import ImportProvider
+from ..resolvers import DOIResolver
+from ..entity import Entity
+from ..data_map import DataMap
+from ..import_item import ImportItem
+
+
+class DesignSafeImportProvider(ImportProvider):
+    def __init__(self):
+        super().__init__('DesignSafe')
+
+    @staticmethod
+    def create_regex():
+        return re.compile(r'^https://www.designsafe-ci.org/data/browser/public/.*')
+        # DS example   'https://www.designsafe-ci.org/data/browser/public/designsafe.storage.published/PRJ-1901/#details-7889180989778095640-242ac11e-0001-012'
+        # NEES example 'https://www.designsafe-ci.org/data/browser/public/nees.public/NEES-2013-1207.groups/Experiment-15'
+        # TODO: Check if NEES support is necessary??
+
+    def lookup(self, entity: Entity) -> DataMap:
+        from pudb.remote import set_trace; set_trace(term_size=(160, 40), host='0.0.0.0', port=6900)
+        doc = self._getDocument(entity.getValue())
+        (endpoint, path, doi, title) = self._extractMeta(doc)
+        self.clients.getUserTransferClient(entity.getUser())
+        size = -1
+        return DataMap(entity.getValue(), size, doi=doi, name=title, repository=self.getName())
+
+    def _getDocument(self, url):
+        od = OpenerDirector()
+        od.add_handler(HTTPSHandler())
+        with od.open(url) as resp:
+            if resp.status == 200:
+                return resp.read().decode('utf-8')
+            elif resp.status == 404:
+                raise Exception('Document not found %s' % url)
+            else:
+                raise Exception('Error fetching document %s: %s' % (url, resp.read()))
+
+    def _extractMeta(self, doc) -> Tuple[str, str, str, str]:
+        dp = DocParser()
+        dp.feed(doc)
+        return dp.getMeta()
+
+    def listFiles(self, entity: Entity) -> FileMap:
+        from pudb.remote import set_trace; set_trace(term_size=(160, 40), host='0.0.0.0', port=6900)
+        stack = []
+        top = None
+        for item in self._listRecursive(entity.getUser(), entity.getValue(), None):
+            if item.type == ImportItem.FOLDER:
+                if len(stack) == 0:
+                    fm = FileMap(item.name)
+                else:
+                    fm = stack[-1].addChild(item.name)
+                stack.append(fm)
+            elif item.type == ImportItem.END_FOLDER:
+                top = stack.pop()
+            elif item.type == ImportItem.FILE:
+                stack[-1].addFile(item.name, item.size)
+        return top
+
+    def _listRecursive(self, user, pid: str, name: str, base_url: str = None, progress=None):
+        from pudb.remote import set_trace; set_trace(term_size=(160, 40), host='0.0.0.0', port=6900)
+        doc = self._getDocument(pid)
+        (endpoint, path, doi, title) = self._extractMeta(doc)
+        yield ImportItem(ImportItem.FOLDER, name=title, identifier='doi:' + doi)
+        tc = self.clients.getUserTransferClient(user)
+        yield from self._listRecursive2(tc, endpoint, path, progress)
+        yield ImportItem(ImportItem.END_FOLDER)
+
+    def _listRecursive2(self, tc, endpoint: str, path: str, progress=None):
+        if path[-1] != '/':
+            path = path + '/'
+        if progress:
+            progress.update(increment=1, message='Listing files')
+        for entry in tc.operation_ls(endpoint, path=path):
+            if entry['type'] == 'dir':
+                yield ImportItem(ImportItem.FOLDER, name=entry['name'])
+                yield from self._listRecursive2(tc, endpoint, path + entry['name'], progress)
+                yield ImportItem(ImportItem.END_FOLDER)
+            elif entry['type'] == 'file':
+                yield ImportItem(
+                    ImportItem.FILE, entry['name'], size=entry['size'],
+                    mimeType='application/octet-stream',
+                    url='globus://%s/%s%s' % (endpoint, path, entry['name']))
+
+
+TRANSFER_URL_PREFIX = 'https://app.globus.org/file-manager?'
+
+
+class DocParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.title = None
+        self.doi = None
+        self.endpoint = None
+        self.path = None
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'meta':
+            self._handleMetaTag(dict(attrs))
+        elif tag == 'a':
+            self._handleLink(dict(attrs))
+
+    def _handleMetaTag(self, attrs):
+        if 'name' not in attrs:
+            return
+        if attrs['name'] == 'DC.title':
+            self.title = attrs['content']
+        elif attrs['name'] == 'DC.identifier':
+            self.doi = self._extractDOI(attrs['content'])
+
+    def _extractDOI(self, content):
+        return DOIResolver.extractDOI(content)
+
+    def _handleLink(self, attrs):
+        if 'href' not in attrs:
+            return
+        if attrs['href'].startswith(TRANSFER_URL_PREFIX):
+            d = parse_qs(attrs['href'][len(TRANSFER_URL_PREFIX):])
+            self.endpoint = d['origin_id'][0]
+            self.path = d['origin_path'][0]
+
+    def getMeta(self):
+        return (self.endpoint, self.path, self.doi, self.title)

--- a/server/lib/agave/provider.py
+++ b/server/lib/agave/provider.py
@@ -1,10 +1,11 @@
 import os
 import re
+import json
 from typing import Tuple
 from html.parser import HTMLParser
 from urllib.parse import parse_qs
 from urllib.request import OpenerDirector, HTTPSHandler
-
+from agavepy.agave import Agave
 from girder.models.item import Item
 from girder.models.folder import Folder
 
@@ -25,13 +26,10 @@ class DesignSafeImportProvider(ImportProvider):
         return re.compile(r'^https://www.designsafe-ci.org/data/browser/public/.*')
         # DS example   'https://www.designsafe-ci.org/data/browser/public/designsafe.storage.published/PRJ-1901/#details-7889180989778095640-242ac11e-0001-012'
         # NEES example 'https://www.designsafe-ci.org/data/browser/public/nees.public/NEES-2013-1207.groups/Experiment-15'
-        # TODO: Check if NEES support is necessary??
 
     def lookup(self, entity: Entity) -> DataMap:
-        from pudb.remote import set_trace; set_trace(term_size=(160, 40), host='0.0.0.0', port=6900)
         doc = self._getDocument(entity.getValue())
         (endpoint, path, doi, title) = self._extractMeta(doc)
-        self.clients.getUserTransferClient(entity.getUser())
         size = -1
         return DataMap(entity.getValue(), size, doi=doi, name=title, repository=self.getName())
 
@@ -52,7 +50,6 @@ class DesignSafeImportProvider(ImportProvider):
         return dp.getMeta()
 
     def listFiles(self, entity: Entity) -> FileMap:
-        from pudb.remote import set_trace; set_trace(term_size=(160, 40), host='0.0.0.0', port=6900)
         stack = []
         top = None
         for item in self._listRecursive(entity.getUser(), entity.getValue(), None):
@@ -69,32 +66,35 @@ class DesignSafeImportProvider(ImportProvider):
         return top
 
     def _listRecursive(self, user, pid: str, name: str, base_url: str = None, progress=None):
-        from pudb.remote import set_trace; set_trace(term_size=(160, 40), host='0.0.0.0', port=6900)
         doc = self._getDocument(pid)
-        (endpoint, path, doi, title) = self._extractMeta(doc)
+        (doi, title) = self._extractMeta(doc)
         yield ImportItem(ImportItem.FOLDER, name=title, identifier='doi:' + doi)
-        tc = self.clients.getUserTransferClient(user)
-        yield from self._listRecursive2(tc, endpoint, path, progress)
+        accessToken = user["agaveAccessToken"]
+        refreshToken = user["agaveRefreshToken"]
+        url = pid.split("https://www.designsafe-ci.org/data/browser/public/", 1)[1].split("/")
+        endpoint = url[0]
+        path = "/" + url[1]
+        ag = Agave(api_server="https://agave.designsafe-ci.org", token=accessToken, refresh_token=refreshToken)
+        yield from self._listRecursive2(ag, endpoint, path, progress)
         yield ImportItem(ImportItem.END_FOLDER)
 
-    def _listRecursive2(self, tc, endpoint: str, path: str, progress=None):
+    def _listRecursive2(self, ag, endpoint: str, path: str, progress=None):
+        from pudb.remote import set_trace;set_trace(term_size=(120, 40), host='0.0.0.0', port=6900)
         if path[-1] != '/':
             path = path + '/'
         if progress:
             progress.update(increment=1, message='Listing files')
-        for entry in tc.operation_ls(endpoint, path=path):
-            if entry['type'] == 'dir':
+        for entry in ag.files.list(filePath=path, systemId=endpoint):
+            if entry['type'] == 'dir' and entry['name'] != '.':
                 yield ImportItem(ImportItem.FOLDER, name=entry['name'])
-                yield from self._listRecursive2(tc, endpoint, path + entry['name'], progress)
+                yield from self._listRecursive2(ag, endpoint, path + entry['name'], progress)
+                # yield from self._listRecursive2(ag, endpoint, path + entry['name'], progress)
                 yield ImportItem(ImportItem.END_FOLDER)
             elif entry['type'] == 'file':
                 yield ImportItem(
-                    ImportItem.FILE, entry['name'], size=entry['size'],
+                    ImportItem.FILE, entry['name'], size=entry['length'],
                     mimeType='application/octet-stream',
-                    url='globus://%s/%s%s' % (endpoint, path, entry['name']))
-
-
-TRANSFER_URL_PREFIX = 'https://app.globus.org/file-manager?'
+                    url='https://agave.designsafe-ci.org/files/v2/media/system/%s/%s%s' % (endpoint, path, entry['name']))
 
 
 class DocParser(HTMLParser):
@@ -102,33 +102,21 @@ class DocParser(HTMLParser):
         super().__init__()
         self.title = None
         self.doi = None
-        self.endpoint = None
-        self.path = None
 
     def handle_starttag(self, tag, attrs):
         if tag == 'meta':
             self._handleMetaTag(dict(attrs))
-        elif tag == 'a':
-            self._handleLink(dict(attrs))
 
     def _handleMetaTag(self, attrs):
         if 'name' not in attrs:
             return
-        if attrs['name'] == 'DC.title':
+        if attrs['name'] == 'citation_title':
             self.title = attrs['content']
-        elif attrs['name'] == 'DC.identifier':
+        elif attrs['name'] == 'citation_doi':
             self.doi = self._extractDOI(attrs['content'])
 
     def _extractDOI(self, content):
         return DOIResolver.extractDOI(content)
 
-    def _handleLink(self, attrs):
-        if 'href' not in attrs:
-            return
-        if attrs['href'].startswith(TRANSFER_URL_PREFIX):
-            d = parse_qs(attrs['href'][len(TRANSFER_URL_PREFIX):])
-            self.endpoint = d['origin_id'][0]
-            self.path = d['origin_path'][0]
-
     def getMeta(self):
-        return (self.endpoint, self.path, self.doi, self.title)
+        return self.doi, self.title


### PR DESCRIPTION
**Features:**
Save Agave oauth token
lookup and listFiles implemented for DesignSafe and CyVerse

**Steps to test:**
Register Agave Client
- Log into girder as admin
- Click on Admin console
- Click on Plugins
- Click on the cog next to the OAuth2 login plugin
- Expand the Agave tenant you wish to test
- Enter client ID and client secret
- Click save

Log into Whole Tale using Agave OAuth account
- Modify src/dashboard/config/environment.js
    - Within the if (environment === 'production') block:
        - Change ENV.authProvider = 'Globus';
    - to ENV.authProvider = 'DesignSafe'; or ENV.authProvider = 'CyVerse';
- Make sure changes propagate
- On the Whole Tale dashboard, click Access Whole Tale. If the code change is live then you should see OAuth login screen for your respective tenant INSTEAD of Globus.
- Enter credentials and click Log In

Link Data Source
- Once logged into Whole Tale using an Agave OAuth account
- Click on the Manage tab
- Click on the + sign next to Data
- Enter DOI or Agave URL and click Search
- Click Register

[More info](https://github.com/eliasmarkc/wt-design-docs/blob/AgaveIntegration/development/design_notes/agave.rst)