### PR TITLE
Update redirect URL

### DIFF
--- a/server/lib/dataone/integration.py
+++ b/server/lib/dataone/integration.py
@@ -38,7 +38,7 @@ def dataoneDataImport(self, uri, title, environment, api, apiToken):
     dashboard_url = os.environ.get('DASHBOARD_URL', 'https://dashboard.wholetale.org')
     location = urlunparse(
         urlparse(dashboard_url)._replace(
-            path='/compose',
+            path='/browse',
             query=urlencode(query))
     )
     setResponseHeader('Location', location)


### PR DESCRIPTION
Redirect users to browse instead of compose.

If you want to test this, then check the branch out visit
https://girder.local.wholetale.org/api/v1/integration/dataone?uri=doi%3A10.5063%2FF1639N12&title=Test%20Tile&environment=RStudio

Check to see that you end up on the browse page instead of compose.

Linked to #334