### PR TITLE
Update globus provider. Fixes #338

### DIFF
--- a/server/lib/globus/globus_provider.py
+++ b/server/lib/globus/globus_provider.py
@@ -1,21 +1,23 @@
 import os
 import re
 from typing import Tuple
-from html.parser import HTMLParser
-from urllib.parse import parse_qs
-from urllib.request import OpenerDirector, HTTPSHandler
+from urllib.parse import urlparse
+import requests
 
 from girder.models.item import Item
 from girder.models.folder import Folder
 
 from plugins.wholetale.server.lib.file_map import FileMap
 from ..import_providers import ImportProvider
-from ..resolvers import DOIResolver
 from ..entity import Entity
 from ..data_map import DataMap
 from ..import_item import ImportItem
+from ...utils import deep_get
 
 from girder.plugins.globus_handler.clients import Clients
+
+
+TRANSFER_URL_PREFIX_REGEX = re.compile('^https://app.globus.org/file-manager')
 
 
 class GlobusImportProvider(ImportProvider):
@@ -25,11 +27,10 @@ class GlobusImportProvider(ImportProvider):
 
     @staticmethod
     def create_regex():
-        return re.compile(r'^https://publish.globus.org/jspui/handle/.*')
+        return re.compile(r'^https://petreldata.net/mdf/detail.*')
 
     def lookup(self, entity: Entity) -> DataMap:
-        doc = self._getDocument(entity.getValue())
-        (endpoint, path, doi, title) = self._extractMeta(doc)
+        endpoint, path, doi, title = self._extractMeta(entity.getValue())
         self.clients.getUserTransferClient(entity.getUser())
         # Don't compute size here. The recursive traversal of typical directory structures
         # in a datase takes ages and we want the lookup method to quickly identify whether
@@ -38,21 +39,33 @@ class GlobusImportProvider(ImportProvider):
         size = -1
         return DataMap(entity.getValue(), size, doi=doi, name=title, repository=self.getName())
 
-    def _getDocument(self, url):
-        od = OpenerDirector()
-        od.add_handler(HTTPSHandler())
-        with od.open(url) as resp:
-            if resp.status == 200:
-                return resp.read().decode('utf-8')
-            elif resp.status == 404:
-                raise Exception('Document not found %s' % url)
-            else:
-                raise Exception('Error fetching document %s: %s' % (url, resp.read()))
+    def _extractMeta(self, raw_url) -> Tuple[str, str, str, str]:
+        url = urlparse(raw_url)
+        if not url.path.startswith('/mdf/detail'):
+            raise Exception("Not an MDF resource page")
 
-    def _extractMeta(self, doc) -> Tuple[str, str, str, str]:
-        dp = DocParser()
-        dp.feed(doc)
-        return dp.getMeta()
+        globus_id = url.path[11:].strip("/")  # There's no other way...
+        headers = {"Content-Type": "application/json"}
+        data = {
+            "@datatype": "GSearchRequest",
+            "q": '"{}"'.format(globus_id),
+            "advanced": False,
+        }
+
+        req = requests.post(
+            "https://search.api.globus.org/v1/index/mdf/search", json=data, headers=headers
+        )
+        req.raise_for_status()
+        globus_meta = req.json()
+        if globus_meta['count'] != 1:
+            raise Exception("Found %i results for '%s'" % (globus_meta['count'], globus_id))
+
+        globus_uri = deep_get(globus_meta, "gmeta.0.content.0.data.endpoint_path")
+        globus_url = urlparse(globus_uri)
+
+        doi = deep_get(globus_meta, "gmeta.0.content.0.dc.identifier.identifier")
+        title = deep_get(globus_meta, "gmeta.0.content.0.dc.titles.0.title")
+        return globus_url.netloc, globus_url.path, doi, title
 
     def _computeSize(self, tc, endpoint, path, user):
         sz = 0
@@ -78,8 +91,7 @@ class GlobusImportProvider(ImportProvider):
         return top
 
     def _listRecursive(self, user, pid: str, name: str, base_url: str = None, progress=None):
-        doc = self._getDocument(pid)
-        (endpoint, path, doi, title) = self._extractMeta(doc)
+        endpoint, path, doi, title = self._extractMeta(pid)
         yield ImportItem(ImportItem.FOLDER, name=title, identifier='doi:' + doi)
         tc = self.clients.getUserTransferClient(user)
         yield from self._listRecursive2(tc, endpoint, path, progress)
@@ -127,43 +139,3 @@ class GlobusImportProvider(ImportProvider):
             for path in path_to_root[3:]:
                 root_path = os.path.join(root_path, path['object']['name'])
             return os.path.join(root_path, doc['name'])
-
-
-TRANSFER_URL_PREFIX = 'https://app.globus.org/file-manager?'
-
-
-class DocParser(HTMLParser):
-    def __init__(self):
-        super().__init__()
-        self.title = None
-        self.doi = None
-        self.endpoint = None
-        self.path = None
-
-    def handle_starttag(self, tag, attrs):
-        if tag == 'meta':
-            self._handleMetaTag(dict(attrs))
-        elif tag == 'a':
-            self._handleLink(dict(attrs))
-
-    def _handleMetaTag(self, attrs):
-        if 'name' not in attrs:
-            return
-        if attrs['name'] == 'DC.title':
-            self.title = attrs['content']
-        elif attrs['name'] == 'DC.identifier':
-            self.doi = self._extractDOI(attrs['content'])
-
-    def _extractDOI(self, content):
-        return DOIResolver.extractDOI(content)
-
-    def _handleLink(self, attrs):
-        if 'href' not in attrs:
-            return
-        if attrs['href'].startswith(TRANSFER_URL_PREFIX):
-            d = parse_qs(attrs['href'][len(TRANSFER_URL_PREFIX):])
-            self.endpoint = d['origin_id'][0]
-            self.path = d['origin_path'][0]
-
-    def getMeta(self):
-        return (self.endpoint, self.path, self.doi, self.title)

--- a/server/utils.py
+++ b/server/utils.py
@@ -63,3 +63,22 @@ def init_progress(resource, user, title, message, total):
 
     return Notification().createNotification(
         type="wt_progress", data=data, user=user, expires=expires)
+
+
+def deep_get(dikt, path):
+    """Get a value located in `path` from a nested dictionary.
+
+    Use a string separated by periods as the path to access
+    values in a nested dictionary:
+
+    deep_get(data, "data.files.0") == data["data"]["files"][0]
+
+    Taken from jupyter/repo2docker
+    """
+    value = dikt
+    for component in path.split("."):
+        if component.isdigit():
+            value = value[int(component)]
+        else:
+            value = value[component]
+    return value


### PR DESCRIPTION
This PR switches Globus provider from parsing the now obsolete https://publish.globus.org/ to https://petreldata.net/mdf. ~I still hope that someday Globus' search index could be used to get all the data we need...~ Globus dataset id is derived from the resulting url and used to query Globus Search API to get all the necessary metadata.

### How to test?
1. Deploy
2. Try to register a couple MDF datasets (e.g. 10.18126/M2662X, 10.18126/M2301J, note that these are the ones I've used for testing, so I'll get bonus points if you can test using something else ;-) )
3. Confirm that dataset is recognized as provided by "Globus". Confirm it actually registers and is accessible from within a Tale.