### PR TITLE
Don't add ../data to README.md path

### DIFF
--- a/server/lib/exporters/bag.py
+++ b/server/lib/exporters/bag.py
@@ -122,7 +122,7 @@ class BagTaleExporter(TaleExporter):
         for i in range(len(self.manifest['aggregates'])):
             uri = self.manifest['aggregates'][i]['uri']
             # Don't touch any of the extra files
-            if len([key for key in extra_files.keys() if key in uri]):
+            if len([key for key in extra_files.keys() if '../' + key in uri]):
                 continue
             if uri.startswith('../'):
                 self.manifest['aggregates'][i]['uri'] = uri.replace('..', '../data')

--- a/server/lib/exporters/bag.py
+++ b/server/lib/exporters/bag.py
@@ -118,9 +118,12 @@ class BagTaleExporter(TaleExporter):
             payload = self.stream_string(content)
             yield from self.dump_and_checksum(payload, path)
 
-        # In Bag there's an aditional 'data' folder where everything lives
+        # In Bag there's an additional 'data' folder where everything lives
         for i in range(len(self.manifest['aggregates'])):
             uri = self.manifest['aggregates'][i]['uri']
+            # Don't touch any of the extra files
+            if len([key for key in extra_files.keys() if key in uri]):
+                continue
             if uri.startswith('../'):
                 self.manifest['aggregates'][i]['uri'] = uri.replace('..', '../data')
             if 'bundledAs' in self.manifest['aggregates'][i]:


### PR DESCRIPTION
Fixes issue #341 

I couldn't think of a better way than list comprehension, which doesn't scale nicely as the number of additional files increases.

Output after this change:
```
    "aggregates": [
        {
            "uri": "../data/workspace/AirTempHistoric.ipynb.txt"
        },
        {
            "uri": "../data/workspace/fetch.txt"
        },
        {
            "schema:license": "CC-BY-4.0",
            "uri": "../data/LICENSE"
        },
        {
            "@type": "schema:HowTo",
            "uri": "../README.md"
        }
    ],
```

### To Test
1. Check this branch out
2. Export a Tale to a bag
3. Check that the manifest correctly locates the top level README.md


### To Do
- [x] Make check more restrictive