### PR TITLE
Add md5, mimetype, and file sizes to bag manifest

### DIFF
--- a/server/lib/exporters/__init__.py
+++ b/server/lib/exporters/__init__.py
@@ -95,3 +95,21 @@ class TaleExporter:
             yield data
         for alg in self.algs:
             self.state[alg].append((zip_path, getattr(hash_file_stream, alg)))
+
+    def append_aggergate_checksums(self):
+        """
+        Takes the md5 checksums and adds them to the files in the 'aggregates' section
+        :return: None
+        """
+        for path, chksum in self.state['md5']:
+            uri = '../' + path
+            index = next(
+                (
+                    i
+                    for (i, d) in enumerate(self.manifest['aggregates'])
+                    if d['uri'] == uri
+                ),
+                None,
+            )
+            if index is not None:
+                self.manifest['aggregates'][index]['md5'] = chksum

--- a/server/lib/exporters/__init__.py
+++ b/server/lib/exporters/__init__.py
@@ -113,3 +113,49 @@ class TaleExporter:
             )
             if index is not None:
                 self.manifest['aggregates'][index]['md5'] = chksum
+
+    def append_aggregate_filesize_mimetypes(self, prepended_path):
+        """
+        Adds the file size and mimetype to the workspace files
+        :param prepended_path: Any additions to the file URI
+        :type prepended_path: str
+        :return: None
+        """
+        for path, fobj in Folder().fileList(
+            self.workspace, user=self.user, subpath=False, data=False
+        ):
+            uri = prepended_path + path
+            index = next(
+                (
+                    i
+                    for (i, d) in enumerate(self.manifest['aggregates'])
+                    if d['uri'] == uri
+                ),
+                None,
+            )
+            if index is not None:
+                self.manifest['aggregates'][index]['mimeType'] = (
+                    fobj['mimeType'] or 'application/octet-stream'
+                )
+                self.manifest['aggregates'][index]['size'] = fobj['size']
+
+    def append_extras_filesize_mimetypes(self, extra_files):
+        """
+        Appends the mimetype and size to the extra files in the 'aggregates 'section
+        :param extra_files: Dictionary of extra file names
+        :type extra_files: dict
+        :return: None
+        """
+        for path, content in extra_files.items():
+            uri = '../' + path
+            index = next(
+                (
+                    i
+                    for (i, d) in enumerate(self.manifest['aggregates'])
+                    if d['uri'] == uri
+                ),
+                None,
+            )
+            if index is not None:
+                self.manifest['aggregates'][index]['mimeType'] = 'text/plain'
+                self.manifest['aggregates'][index]['size'] = len(content)

--- a/server/lib/exporters/bag.py
+++ b/server/lib/exporters/bag.py
@@ -131,9 +131,11 @@ class BagTaleExporter(TaleExporter):
                 self.manifest['aggregates'][i]['bundledAs']['folder'] = folder.replace(
                     '..', '../data'
                 )
-
-        fetch_file = ""
         # Update manifest with hashes
+        self.append_aggergate_checksums()
+
+        # Create the fetch file
+        fetch_file = ""
         for bundle in self.manifest['aggregates']:
             if 'bundledAs' not in bundle:
                 continue
@@ -190,5 +192,6 @@ class BagTaleExporter(TaleExporter):
             (lambda: tagmanifest['sha256'], 'tagmanifest-sha256.txt'),
         ):
             yield from self.zip_generator.addFile(payload, fname)
+
 
         yield self.zip_generator.footer()

--- a/server/lib/exporters/bag.py
+++ b/server/lib/exporters/bag.py
@@ -134,6 +134,12 @@ class BagTaleExporter(TaleExporter):
         # Update manifest with hashes
         self.append_aggergate_checksums()
 
+        # Update manifest with filesizes and mimeTypes for workspace items
+        self.append_aggregate_filesize_mimetypes('../data/workspace/')
+
+        # Update manifest with filesizes and mimeTypes for extra items
+        self.append_extras_filesize_mimetypes(extra_files)
+
         # Create the fetch file
         fetch_file = ""
         for bundle in self.manifest['aggregates']:
@@ -192,6 +198,5 @@ class BagTaleExporter(TaleExporter):
             (lambda: tagmanifest['sha256'], 'tagmanifest-sha256.txt'),
         ):
             yield from self.zip_generator.addFile(payload, fname)
-
 
         yield self.zip_generator.footer()

--- a/server/lib/exporters/native.py
+++ b/server/lib/exporters/native.py
@@ -26,18 +26,7 @@ class NativeTaleExporter(TaleExporter):
             yield from self.dump_and_checksum(payload, path)
 
         # Update manifest with hashes
-        for path, chksum in self.state['md5']:
-            uri = '../' + path
-            index = next(
-                (
-                    i
-                    for (i, d) in enumerate(self.manifest['aggregates'])
-                    if d['uri'] == uri
-                ),
-                None,
-            )
-            if index is not None:
-                self.manifest['aggregates'][index]['md5'] = chksum
+        self.append_aggergate_checksums()
 
         # Update manifest with filesizes and mimeTypes
         for path, fobj in Folder().fileList(

--- a/server/lib/exporters/native.py
+++ b/server/lib/exporters/native.py
@@ -29,38 +29,10 @@ class NativeTaleExporter(TaleExporter):
         self.append_aggergate_checksums()
 
         # Update manifest with filesizes and mimeTypes
-        for path, fobj in Folder().fileList(
-            self.workspace, user=self.user, subpath=False, data=False
-        ):
-            uri = '../workspace/' + path
-            index = next(
-                (
-                    i
-                    for (i, d) in enumerate(self.manifest['aggregates'])
-                    if d['uri'] == uri
-                ),
-                None,
-            )
-            if index is not None:
-                self.manifest['aggregates'][index]['mimeType'] = (
-                    fobj['mimeType'] or 'application/octet-stream'
-                )
-                self.manifest['aggregates'][index]['size'] = fobj['size']
+        self.append_aggregate_filesize_mimetypes('../workspace/')
 
-        # Need to handle extra files coming not from girder...
-        for path, content in extra_files.items():
-            uri = '../' + path
-            index = next(
-                (
-                    i
-                    for (i, d) in enumerate(self.manifest['aggregates'])
-                    if d['uri'] == uri
-                ),
-                None,
-            )
-            if index is not None:
-                self.manifest['aggregates'][index]['mimeType'] = 'text/plain'
-                self.manifest['aggregates'][index]['size'] = len(content)
+        # Update manifest with filesizes and mimeTypes for extra items
+        self.append_extras_filesize_mimetypes(extra_files)
 
         for data in self.zip_generator.addFile(
             lambda: json.dumps(self.manifest, indent=4), 'metadata/manifest.json'


### PR DESCRIPTION
This change mostly pulls out some methods from the zip exporter and puts it in the `TaleExporter` class so that it can be used by the bag exporter. Fixes issue #337


### Testing
1. Check this branch out
2. Add some files to the workspace
3. Export with zip and bag
4. Note that the manifest in both cases should show the mimetype, size, and md5 of each file

**Note: Don't merge this before  #342**