### PR TITLE
Create Tales upfront in POST /tale{/import}

### DIFF
--- a/server/tasks/import_binder.py
+++ b/server/tasks/import_binder.py
@@ -5,7 +5,6 @@ import json
 import os
 import stat
 import sys
-import textwrap
 import time
 import traceback
 from webdavfs.webdavfs import WebDAVFS
@@ -30,9 +29,7 @@ from girder.plugins.jobs.models.job import Job
 from ..constants import CATALOG_NAME, InstanceStatus
 from ..lib import pids_to_entities, register_dataMap
 from ..lib.dataone import DataONELocations  # TODO: get rid of it
-from ..models.image import Image
 from ..models.instance import Instance
-from ..models.tale import Tale
 from ..utils import getOrCreateRootFolder
 
 
@@ -40,11 +37,12 @@ def run(job):
     jobModel = Job()
     jobModel.updateJob(job, status=JobStatus.RUNNING)
 
-    tale_kwargs, lookup_kwargs = job["args"]
+    lookup_kwargs, = job["args"]
     user = job["kwargs"]["user"]
     spawn = job["kwargs"]["spawn"]
+    tale = job["kwargs"]["tale"]
 
-    progressTotal = 4 + int(spawn)
+    progressTotal = 3 + int(spawn)
     progressCurrent = 0
 
     try:
@@ -95,51 +93,7 @@ def run(job):
         # how to handler transfers. DMS will do that for us <3
         session = Session().createSession(user, dataSet=data_set)
 
-        # 3. Create a Tale
-        jobModel.updateJob(
-            job,
-            status=JobStatus.RUNNING,
-            log="Creating a Tale object",
-            progressTotal=progressTotal,
-            progressCurrent=progressCurrent + 1,
-            progressMessage="Creating a Tale object",
-        )
-
-        # Figure out a good Tale title default based on the name of imported dataset
-        if "title" not in tale_kwargs:
-            long_name = data_folder['name']
-            long_name = long_name.replace('-', ' ').replace('_', ' ')
-            shortened_name = textwrap.shorten(text=long_name, width=30)
-            tale_kwargs["title"] = "A Tale for \"{}\"".format(shortened_name)
-
-        image_id = tale_kwargs.pop('imageId')
-        image = Image().load(image_id, user=user, level=AccessType.READ, exc=True)
-        if "icon" not in tale_kwargs:
-            tale_kwargs["icon"] = image.get(
-                "icon",
-                (
-                    "https://raw.githubusercontent.com/"
-                    "whole-tale/dashboard/master/public/"
-                    "images/whole_tale_logo.png"
-                ),
-            )
-        if "illustration" not in tale_kwargs:
-            tale_kwargs["illustration"] = (
-                'https://raw.githubusercontent.com/'
-                'whole-tale/dashboard/master/public/'
-                'images/demo-graph2.jpg'
-            )
-
-        tale = Tale().createTale(
-            image,
-            [],  # empty dataset
-            creator=user,
-            save=True,
-            public=False,
-            **tale_kwargs
-        )
-
-        # 4. Copy data to the workspace using WebDAVFS
+        # 3. Copy data to the workspace using WebDAVFS
         jobModel.updateJob(
             job,
             status=JobStatus.RUNNING,


### PR DESCRIPTION
 ## Motivation
Some of the routes used to create Tales were returning a Job instead of a Tale object due to fact creation was a long and convoluted task. This behavior breaks REST assumption and is difficult to handle by the UI. It affects:

* Analyze in WT
* Analyze in WT "binder flavor" (i.e. data is imported to workspace)
* Importing Tale from ZIP

## Implementation
All variants of `POST /tale/import` now return Tale object and do that fairly quickly, while spawning necessary long-running tasks as jobs. Note, that it means that the Tale object returned by that route is incomplete and may (or I should rather say *will*) change without any notice to the consumer.

## How to test?

1. Analyze in WT
   1. Deploy this branch and corresponding gwvolman branch (https://github.com/whole-tale/gwvolman/pull/85)
   1. Navigate to https://girder.local.wholetale.org/api/v1/integration/dataverse?fileId=3323458&siteUrl=https%3A%2F%2Fdataverse.harvard.edu
   1. Confirm that the Tale title reads as Replication Data for: "Agricultural Fires and Health at Birth"
   1. Confirm that the only item in the Selected data section matches the uri with Data Source appended
   1. Confirm that no environment is selected
   1. Confirm that the Launch New Tale button is disabled
   1. Select an environment
   1. Open Dev Console to capture outgoing REST request to `POST /tale/import` (you'll need that later)
   1. Click Launch New Tale
   1. Confirm that the progress bar appears & properly updates
   1. Confirm that once complete, you are redirected to the run page
   1. Confirm that the Tale name matches the Tale Name in the compose page
   1. Confirm that the data exists in the Tale's external data.
1. Analyze in WT (binder flavor)
   1. Using Girder Swagger page, enter data from 1.viii. in `POST  /tale/import`. Flip `asTale` to True.
   1. Follow 1.ix - 1.xii
   1. Confirm that the data exists in the Tale's workspace.
1. Importing Tale from ZIP
   1. Export Tale created in 2. as Zip (not BagIt) to `/tmp/tale.zip` on your laptop.
   1. Delete all Tales
   1.  ```
        curl -X POST --header 'Content-Type: application/zip' --header 'Accept: application/json' \
           --header 'Girder-Token: ...' --data-binary "@/tmp/tale.zip" \
           'https://girder.local.wholetale.org/api/v1/tale/import?spawn=false'
        ```
   1. Confirm that the data exists in the Tale's workspace and matches Tale from 2.