### PR TITLE
Delay Tale operations involving workspace until it's ready

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -17,6 +17,7 @@ add_python_test(import
   plugins/wholetale/tale_import_binder.txt
   plugins/wholetale/tale_import_zip.txt
 )
+add_python_test(import_failures PLUGIN wholetale)
 add_python_test(instance PLUGIN wholetale)
 add_python_test(constants PLUGIN wholetale)
 add_python_test(utils PLUGIN wholetale)

--- a/plugin_tests/import_failures_test.py
+++ b/plugin_tests/import_failures_test.py
@@ -1,0 +1,202 @@
+import mock
+import os
+import json
+import time
+from tests import base
+from girder import config
+
+
+JobStatus = None
+ImageStatus = None
+Tale = None
+DATA_PATH = os.path.join(
+    os.path.dirname(os.environ["GIRDER_TEST_DATA_PREFIX"]),
+    "data_src",
+    "plugins",
+    "wholetale",
+)
+os.environ["GIRDER_PORT"] = os.environ.get("GIRDER_TEST_PORT", "20200")
+config.loadConfig()  # Must reload config to pickup correct port
+
+
+def setUpModule():
+    base.enabledPlugins.append("wholetale")
+    base.startServer()
+
+    global JobStatus, Tale, ImageStatus, TaleStatus, Job, Image
+    from girder.plugins.jobs.constants import JobStatus
+    from girder.plugins.jobs.models.job import Job
+    from girder.plugins.wholetale.models.image import Image
+    from girder.plugins.wholetale.models.tale import Tale
+    from girder.plugins.wholetale.constants import ImageStatus, TaleStatus
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class TaskFailTestCase(base.TestCase):
+    def setUp(self):
+        super(TaskFailTestCase, self).setUp()
+        users = (
+            {
+                "email": "root@dev.null",
+                "login": "admin",
+                "firstName": "Root",
+                "lastName": "van Klompf",
+                "password": "secret",
+            },
+            {
+                "email": "joe@dev.null",
+                "login": "joeregular",
+                "firstName": "Joe",
+                "lastName": "Regular",
+                "password": "secret",
+            },
+        )
+
+        self.authors = [
+            {
+                "firstName": "Charles",
+                "lastName": "Darwmin",
+                "orcid": "https://orcid.org/000-000",
+            },
+            {
+                "firstName": "Thomas",
+                "lastName": "Edison",
+                "orcid": "https://orcid.org/111-111",
+            },
+        ]
+        self.admin, self.user = [
+            self.model("user").createUser(**user) for user in users
+        ]
+
+        self.image = Image().createImage(
+            name="test my name",
+            creator=self.user,
+            public=True,
+            config=dict(
+                template="base.tpl",
+                buildpack="SomeBuildPack",
+                user="someUser",
+                port=8888,
+                urlPath="",
+            ),
+        )
+
+    def testTaleImportBinderFail(self):
+        with mock.patch("girder.plugins.wholetale.lib.pids_to_entities") as mock_pids:
+            mock_pids.side_effect = ValueError
+            resp = self.request(
+                path="/tale/import",
+                method="POST",
+                user=self.user,
+                params={
+                    "url": "http://blah.com",
+                    "spawn": False,
+                    "imageId": self.image["_id"],
+                    "asTale": True,
+                    "taleKwargs": json.dumps({"title": "tale should fail"}),
+                },
+            )
+            self.assertStatusOk(resp)
+            tale = resp.json
+
+            job = Job().findOne({"type": "wholetale.import_binder"})
+            self.assertEqual(
+                json.loads(job["kwargs"])["tale"]["_id"]["$oid"], tale["_id"]
+            )
+
+            for i in range(300):
+                if job["status"] in {JobStatus.SUCCESS, JobStatus.ERROR}:
+                    break
+                time.sleep(0.1)
+                job = Job().load(job["_id"], force=True)
+            self.assertEqual(job["status"], JobStatus.ERROR)
+            Job().remove(job)
+        tale = Tale().load(tale["_id"], force=True)
+        self.assertEqual(tale["status"], TaleStatus.ERROR)
+        Tale().remove(tale)
+
+    def testTaleImportZipFail(self):
+        image = Image().createImage(
+            name="Jupyter Classic",
+            creator=self.user,
+            public=True,
+            config=dict(
+                template="base.tpl",
+                buildpack="PythonBuildPack",
+                user="someUser",
+                port=8888,
+                urlPath="",
+            ),
+        )
+        with mock.patch("girder.plugins.wholetale.lib.pids_to_entities") as mock_pids:
+            mock_pids.side_effect = ValueError
+            with open(
+                os.path.join(DATA_PATH, "5c92fbd472a9910001fbff72.zip"), "rb"
+            ) as fp:
+                resp = self.request(
+                    path="/tale/import",
+                    method="POST",
+                    user=self.user,
+                    type="application/zip",
+                    body=fp.read(),
+                )
+
+            self.assertStatusOk(resp)
+            tale = resp.json
+
+            job = Job().findOne({"type": "wholetale.import_tale"})
+            self.assertEqual(
+                json.loads(job["kwargs"])["tale"]["_id"]["$oid"], tale["_id"]
+            )
+            for i in range(300):
+                if job["status"] in {JobStatus.SUCCESS, JobStatus.ERROR}:
+                    break
+                time.sleep(0.1)
+                job = Job().load(job["_id"], force=True)
+            self.assertEqual(job["status"], JobStatus.ERROR)
+            Job().remove(job)
+        tale = Tale().load(tale["_id"], force=True)
+        self.assertEqual(tale["status"], TaleStatus.ERROR)
+        Tale().remove(tale)
+        Image().remove(image)
+
+    def testCopyWorkspaceFail(self):
+        tale = Tale().createTale(
+            self.image,
+            [],
+            creator=self.admin,
+            title="tale one",
+            public=True,
+            config={"memLimit": "2g"},
+        )
+
+        job = Job().createLocalJob(
+            title='Copy "{title}" workspace'.format(**tale),
+            user=self.user,
+            type="wholetale.copy_workspace",
+            public=False,
+            async=True,
+            module="girder.plugins.wholetale.tasks.copy_workspace",
+            args=(tale["workspaceId"], "non_existing"),
+            kwargs={"user": self.user, "tale": tale},
+        )
+        Job().scheduleJob(job)
+        for i in range(300):
+            if job["status"] in {JobStatus.SUCCESS, JobStatus.ERROR}:
+                break
+            time.sleep(0.1)
+            job = Job().load(job["_id"], force=True)
+        self.assertEqual(job["status"], JobStatus.ERROR)
+        Job().remove(job)
+        tale = Tale().load(tale["_id"], force=True)
+        self.assertEqual(tale["status"], TaleStatus.ERROR)
+        Tale().remove(tale)
+
+    def tearDown(self):
+        self.model("user").remove(self.user)
+        self.model("user").remove(self.admin)
+        self.model("image", "wholetale").remove(self.image)
+        super(TaskFailTestCase, self).tearDown()

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -969,8 +969,7 @@ class TaleWithWorkspaceTestCase(base.TestCase):
         self.assertEqual(new_tale['copyOfTale'], str(tale['_id']))
         self.assertEqual(new_tale['imageId'], str(tale['imageId']))
         self.assertEqual(new_tale['creatorId'], str(self.user['_id']))
-        # TODO: Delay job execution somehow
-        # self.assertEqual(new_tale['status'], TaleStatus.PREPARING)
+        self.assertEqual(new_tale['status'], TaleStatus.PREPARING)
 
         copied_file_path = re.sub(workspace['name'], new_tale['_id'], fullPath)
         job = Job().findOne({'type': 'wholetale.copy_workspace'})
@@ -980,6 +979,12 @@ class TaleWithWorkspaceTestCase(base.TestCase):
                 break
             time.sleep(0.1)
         self.assertTrue(os.path.isfile(copied_file_path))
+        resp = self.request(
+            path='/tale/{_id}'.format(**new_tale), method='GET',
+            user=self.user
+        )
+        self.assertStatusOk(resp)
+        new_tale = resp.json
         self.assertEqual(new_tale['status'], TaleStatus.READY)
 
         Tale().remove(new_tale)

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -36,16 +36,15 @@ class Tale(AccessControlledModel):
         self.modifiableFields = {
             'title', 'description', 'public', 'config', 'updated', 'authors',
             'category', 'icon', 'iframe', 'illustration', 'dataSet', 'licenseSPDX',
-            'workspaceModified', 'publishInfo', 'imageId'
+            'workspaceModified', 'publishInfo', 'imageId', 'status'
         }
         self.exposeFields(
             level=AccessType.READ,
             fields=({'_id', 'folderId', 'imageId', 'creatorId', 'created',
                      'format', 'dataSet', 'narrative', 'narrativeId', 'licenseSPDX',
                      'imageInfo', 'publishInfo', 'workspaceId',
-                     'workspaceModified', 'dataSetCitation', 'copyOfTale',
-                     'status'} | self.modifiableFields))
-        events.bind('jobs.job.update.after', 'wholetale', self.updateTaleStatus)
+                     'workspaceModified', 'dataSetCitation',
+                     'copyOfTale'} | self.modifiableFields))
 
     def validate(self, tale):
         if 'status' not in tale:

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -10,7 +10,6 @@ from girder.models.folder import Folder
 from girder.models.token import Token
 from girder.constants import AccessType
 from girder.exceptions import AccessException
-from girder.plugins.jobs.constants import JobStatus
 
 from ..constants import WORKSPACE_NAME, DATADIRS_NAME, SCRIPTDIRS_NAME, TaleStatus
 from ..utils import getOrCreateRootFolder, init_progress
@@ -307,16 +306,3 @@ class Tale(AccessControlledModel):
         ).apply_async()
 
         return buildTask.job
-
-    @staticmethod
-    def updateTaleStatus(event):
-        job = event.info['job']
-        if job['type'] == 'wholetale.copy_workspace' and job.get('status') is not None:
-            status = int(job['status'])
-            workspace = Folder().load(job['args'][1], force=True)
-            tale = Tale().load(workspace['meta']['taleId'], force=True)
-            if status == JobStatus.SUCCESS:
-                tale['status'] = TaleStatus.READY
-            elif status == JobStatus.ERROR:
-                tale['status'] = TaleStatus.ERROR
-            Tale().updateTale(tale)

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -118,7 +118,8 @@ class Tale(AccessControlledModel):
     def createTale(self, image, data, creator=None, save=True, title=None,
                    description=None, public=None, config=None, authors=None,
                    icon=None, category=None, illustration=None, narrative=None,
-                   licenseSPDX=WholeTaleLicense.default_spdx()):
+                   licenseSPDX=WholeTaleLicense.default_spdx(),
+                   status=TaleStatus.READY):
 
         if creator is None:
             creatorId = None
@@ -149,7 +150,8 @@ class Tale(AccessControlledModel):
             'title': title,
             'public': public,
             'updated': now,
-            'licenseSPDX': licenseSPDX
+            'licenseSPDX': licenseSPDX,
+            'status': status,
         }
         if public is not None and isinstance(public, bool):
             self.setPublic(tale, public, save=False)

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -40,7 +40,7 @@ from ..lib.exporters.native import NativeTaleExporter
 
 from girder.plugins.worker import getCeleryApp
 
-from ..constants import ImageStatus
+from ..constants import ImageStatus, TaleStatus
 
 
 addModel('tale', taleSchema, resources='tale')
@@ -269,6 +269,7 @@ class Tale(Resource):
                 authors=authors,
                 category=manifest["schema:category"],
                 licenseSPDX=licenseSPDX,
+                status=TaleStatus.PREPARING,
             )
 
             job = Job().createLocalJob(
@@ -330,6 +331,7 @@ class Tale(Resource):
                 creator=user,
                 save=True,
                 public=False,
+                status=TaleStatus.PREPARING,
                 **taleKwargs
             )
 
@@ -564,6 +566,7 @@ class Tale(Resource):
             licenseSPDX=tale.get('licenseSPDX'),
         )
         new_tale['copyOfTale'] = tale['_id']
+        new_tale["status"] = TaleStatus.PREPARING
         new_tale = self._model.save(new_tale)
         # asynchronously copy the workspace of a source Tale
         tale_workspaceId = self._model.createWorkspace(tale)['_id']
@@ -573,7 +576,7 @@ class Tale(Resource):
             type='wholetale.copy_workspace', public=False, async=True,
             module='girder.plugins.wholetale.tasks.copy_workspace',
             args=(tale_workspaceId, new_tale_workspaceId),
-            kwargs={'user': user}
+            kwargs={'user': user, 'tale': new_tale}
         )
         Job().scheduleJob(job)
         return new_tale

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -564,9 +564,9 @@ class Tale(Resource):
             category=tale.get('category', 'science'),
             narrative=tale.get('narrative'),
             licenseSPDX=tale.get('licenseSPDX'),
+            status=TaleStatus.PREPARING,
         )
         new_tale['copyOfTale'] = tale['_id']
-        new_tale["status"] = TaleStatus.PREPARING
         new_tale = self._model.save(new_tale)
         # asynchronously copy the workspace of a source Tale
         tale_workspaceId = self._model.createWorkspace(tale)['_id']

--- a/server/tasks/copy_workspace.py
+++ b/server/tasks/copy_workspace.py
@@ -8,21 +8,31 @@ from girder.models.folder import Folder
 from girder.plugins.jobs.constants import JobStatus
 from girder.plugins.jobs.models.job import Job
 
+from ..constants import TaleStatus
+from ..models.tale import Tale
+
 
 def run(job):
     jobModel = Job()
     jobModel.updateJob(job, status=JobStatus.RUNNING)
 
-    src_workspace_id, dest_workspace_id = job['args']
-    user = job['kwargs']['user']
+    src_workspace_id, dest_workspace_id = job["args"]
+    user = job["kwargs"]["user"]
+    tale = job["kwargs"]["tale"]
 
     try:
-        parent = Folder().load(src_workspace_id, user=user, exc=True, level=AccessType.READ)
+        parent = Folder().load(
+            src_workspace_id, user=user, exc=True, level=AccessType.READ
+        )
         workspace = Folder().load(dest_workspace_id, user=user, exc=True)
         Folder().copyFolderComponents(parent, workspace, user, None)
+        tale["status"] = TaleStatus.READY
+        Tale().updateTale(tale)
         jobModel.updateJob(job, status=JobStatus.SUCCESS, log="Copying finished")
     except Exception:
+        tale["status"] = TaleStatus.ERROR
+        Tale().updateTale(tale)
         t, val, tb = sys.exc_info()
-        log = '%s: %s\n%s' % (t.__name__, repr(val), traceback.extract_tb(tb))
+        log = "%s: %s\n%s" % (t.__name__, repr(val), traceback.extract_tb(tb))
         jobModel.updateJob(job, status=JobStatus.ERROR, log=log)
         raise


### PR DESCRIPTION
Importing an external dataset as a "binder" or "copy-on-launch" feature, both involve file operations on Tale workspace. Currently, it is possible to trigger image build before those operations are finished. With this PR (and a corresponding https://github.com/whole-tale/gwvolman/pull/86) we prevent that from happening by setting the Tale status to `PREPARING` when the Tale is created and switching it to `READY` only after all workspace i/o is done. (Note: before that was only implemented for "copy on launch"). Additionally, whenever Tale import fails, Tale status is set to `ERROR` to indicate that Tale is incomplete (cc @bodom0015 I'm not sure how, if at all, this will affect UI...)

## How to Test?
In short "Import as Binder" any dataset that has a modified environment. To make it easier I created https://demo.dataverse.org/dataset.xhtml?persistentId=doi%3A10.70122%2FFK2%2FHXMLBW and auxiliary script (link below)

1. Download https://gist.github.com/Xarthisius/808483fa6ba023e5ce4f6b85039767c9 and save it as `test_pr350.py`
1. On current master (both girder_wholetale and gwvolman) run `test_pr350.py`
1. Successful run looks like this: 
   ```
   $ python test_pr350.py 
   Logging in as 'admin'
   Setting up DV extra_hosts
   Getting image list
   Importing and launching a Tale from DV
   Tale Created
    TALE -> id: 5d88eda2e9a2196e72f8c33a, status: 1
   Getting instance
    INSTANCE -> id: 5d88eda2e9a2196e72f8c340, status: 0
   Waiting for instance to spawn (5s)...
   Waiting for instance to spawn (5s)...
   Waiting for instance to spawn (5s)...
   Waiting for instance to spawn (5s)...
   Waiting for instance to spawn (5s)...
   Waiting for instance to spawn (5s)...
   Waiting for instance to spawn (5s)...
   Waiting for instance to spawn (5s)...
   Instance ready at: https://tmp-etost3nmrfik.local.wholetale.org/?token=62485be446b8482fa2b00f39f76474ac
   ```
1. Note Tale status == 1 (READY)
1. Follow the url to get into running instance. Open `LOSC_Event_tutorial.ipynb`, run 2nd cell with code (the one with imports). It should fail with `ImportError missing numpy`
1. Using Girder API (user: admin), delete Instance, delete Tale
1. Checkout this PR and https://github.com/whole-tale/gwvolman/pull/86 (make sure you run `make restart_worker` to pick up the latter)
1. Re-run `test_pr350.py`
1. Successful output should look like this: 
   ```
   $ python test_pr350.py 
   Logging in as 'admin'
   Setting up DV extra_hosts
   Getting image list
   Importing and launching a Tale from DV
   Tale Created
    TALE -> id: 5d88ee45f7f2cd6b5d41223d, status: 0
   Getting instance
   Polling for instance...
    INSTANCE -> id: 5d88ee45f7f2cd6b5d412243, status: 0
   Waiting for instance to spawn (5s)...
   Waiting for instance to spawn (5s)...
   <repeated multiple times>...
   Waiting for instance to spawn (5s)...
   Instance ready at: https://tmp-ubj073rybdki.local.wholetale.org/?token=83a7a6ef2fdf4f31a8e77c03c127f773
   ```
1. It should take significantly longer, Tale status should be 0 (PREPARING)
1. Follow the url to get into running instance. Open `LOSC_Event_tutorial.ipynb`, run 2nd cell with code (the one with imports). It should run without error.