### PR TITLE
Only filter datasets by user.myData if req is authenticated. Fixes #353

### DIFF
--- a/server/rest/dataset.py
+++ b/server/rest/dataset.py
@@ -117,7 +117,7 @@ class Dataset(Resource):
         datasets = []
 
         filters = {}
-        if myData:
+        if myData and user:
             filters = {'_id': {'$in': user.get('myData', [])}}
 
         if identifiers:


### PR DESCRIPTION
This PR modifies `GET /dataset?myData=true` to only apply filter for authenticated requests.

### How to test?
1. Deploy.
2. Call: 
  ```
  curl -s --header 'Accept: application/json' 'https://girder.local.wholetale.org/api/v1/dataset?myData=true' | jq
  ```
3. Verify that it returns `[]` and not a traceback.