### PR TITLE
Set Default Category for Tale Imports

### DIFF
--- a/plugin_tests/import_test.py
+++ b/plugin_tests/import_test.py
@@ -135,6 +135,7 @@ class TaleTestCase(base.TestCase):
             self.assertEqual(str(job_call['args'][1]['_id']), tale['_id'])
             self.assertEqual(job_call['kwargs'], {'spawn': False})
             self.assertEqual(job_call['headers']['girder_job_title'], 'Import Tale')
+            self.assertEqual(tale['category'], 'science')
 
     def testTaleImportBinder(self):
         def before_record_cb(request):

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -329,6 +329,7 @@ class Tale(Resource):
                 image,
                 [],
                 creator=user,
+                category="science",
                 save=True,
                 public=False,
                 status=TaleStatus.PREPARING,


### PR DESCRIPTION
Sets the default category to 'science' for tales that are created from datasets.

To Test:
1. Make sure you have less than 2 instances running
2. Visit https://girder.local.wholetale.org/api/v1/integration/dataone?uri=https%3A%2F%2Fsearch.dataone.org%2Fview%2Fdoi%3A10.18739%2FA2VQ2S94D&title=Fire influences on forest recovery and associated climate feedbacks in Siberian Larch Forests%2C Russia&environment=RStudio
3. Create and launch the Tale
4. Check the metadata tab for 'science'

Fixes https://github.com/whole-tale/girder_wholetale/issues/362