### PR TITLE
Add Zenodo external data provider

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -37,6 +37,13 @@ add_python_test(dataone_register
   plugins/wholetale/dataone_register_test01.json
   plugins/wholetale/DataONE_register_nested.txt
 )
+add_python_test(zenodo
+  PLUGIN wholetale
+  EXTERNAL_DATA
+  plugins/wholetale/zenodo_hierarchy.txt
+  plugins/wholetale/zenodo_manifest.txt
+  plugins/wholetale/zenodo_lookup.txt
+)
 add_python_test(dataverse
   PLUGIN wholetale
   EXTERNAL_DATA

--- a/plugin_tests/data/zenodo_hierarchy.txt
+++ b/plugin_tests/data/zenodo_hierarchy.txt
@@ -1,0 +1,41 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.zenodo.v1+json]
+      Connection: [close]
+      Host: [zenodo.org]
+      User-Agent: [Python-urllib/3.6]
+    method: GET
+    uri: https://zenodo.org/api/records/3463499
+  response:
+    body: {string: '{"conceptdoi":"10.5281/zenodo.3462714","conceptrecid":"3462714","created":"2019-09-27T15:17:47.295427+00:00","doi":"10.5281/zenodo.3463499","files":[{"bucket":"fbcb465c-c250-41da-9d9a-f28d8587c0e3","checksum":"md5:131225ba8fd81a5a2f4f50a191a1504e","key":"jbferet/biodivMapR-v1.0.1.zip","links":{"self":"https://zenodo.org/api/files/fbcb465c-c250-41da-9d9a-f28d8587c0e3/jbferet/biodivMapR-v1.0.1.zip"},"size":24692383,"type":"zip"}],"id":3463499,"links":{"badge":"https://zenodo.org/badge/doi/10.5281/zenodo.3463499.svg","bucket":"https://zenodo.org/api/files/fbcb465c-c250-41da-9d9a-f28d8587c0e3","conceptbadge":"https://zenodo.org/badge/doi/10.5281/zenodo.3462714.svg","conceptdoi":"https://doi.org/10.5281/zenodo.3462714","doi":"https://doi.org/10.5281/zenodo.3463499","html":"https://zenodo.org/record/3463499","latest":"https://zenodo.org/api/records/3463499","latest_html":"https://zenodo.org/record/3463499","self":"https://zenodo.org/api/records/3463499"},"metadata":{"access_right":"open","access_right_category":"success","creators":[{"name":"floriandeboissieu"}],"description":"biodivMapR
+        v1.0.1 (Release date: 2019-09-27)\n<p>Added NEWS.md\nUpdated README.md: transfered
+        from gitlab.irstea to github\nchanged return() into return(invisible())\nupdated
+        vignettes &amp; tutorial with latest outputs and figures from code</p>","doi":"10.5281/zenodo.3463499","license":{"id":"other-open"},"publication_date":"2019-09-27","related_identifiers":[{"identifier":"https://github.com/jbferet/biodivMapR/tree/v1.0.1","relation":"isSupplementTo","scheme":"url"},{"identifier":"10.5281/zenodo.3462714","relation":"isVersionOf","scheme":"doi"}],"relations":{"version":[{"count":2,"index":1,"is_last":true,"last_child":{"pid_type":"recid","pid_value":"3463499"},"parent":{"pid_type":"recid","pid_value":"3462714"}}]},"resource_type":{"title":"Software","type":"software"},"title":"jbferet/biodivMapR:
+        v1.0.1","version":"v1.0.1"},"owners":[77934],"revision":2,"stats":{"downloads":0.0,"unique_downloads":0.0,"unique_views":0.0,"version_downloads":0.0,"version_unique_downloads":0.0,"version_unique_views":1.0,"version_views":1.0,"version_volume":0.0,"views":0.0,"volume":0.0},"updated":"2019-09-27T15:17:52.038019+00:00"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['Content-Type, ETag, Link, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset']
+      Connection: [close]
+      Content-Length: ['2216']
+      Content-Type: [application/json]
+      Date: ['Fri, 27 Sep 2019 17:03:42 GMT']
+      ETag: ['"2"']
+      Last-Modified: ['Fri, 27 Sep 2019 15:17:52 GMT']
+      Link: ['<https://zenodo.org/api/records/3463499>; rel="self"']
+      Referrer-Policy: [strict-origin-when-cross-origin]
+      Retry-After: ['60']
+      Server: [nginx/1.12.2]
+      Strict-Transport-Security: [max-age=0]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [sameorigin]
+      X-RateLimit-Limit: ['60']
+      X-RateLimit-Remaining: ['59']
+      X-RateLimit-Reset: ['1569603883']
+      X-Request-ID: [b3e130b599f4dc70cd99fe2439808d3c]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/plugin_tests/data/zenodo_lookup.txt
+++ b/plugin_tests/data/zenodo_lookup.txt
@@ -1,0 +1,319 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [doi.org]
+      User-Agent: [Python-urllib/3.6]
+    method: HEAD
+    uri: https://doi.org/10.5281/zenodo.3459420
+  response:
+    body: {string: ''}
+    headers:
+      CF-RAY: [51ced3d1f83cc504-ORD]
+      Connection: [close]
+      Content-Length: ['151']
+      Content-Type: [text/html;charset=utf-8]
+      Date: ['Fri, 27 Sep 2019 16:24:22 GMT']
+      Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
+      Expires: ['Fri, 27 Sep 2019 16:58:30 GMT']
+      Location: ['https://zenodo.org/record/3459420']
+      Server: [cloudflare]
+      Set-Cookie: ['__cfduid=d273ce4905f3667b4b29f37f8c7d0bf8b1569601462; expires=Sat,
+          26-Sep-20 16:24:22 GMT; path=/; domain=.doi.org; HttpOnly']
+      Strict-Transport-Security: [max-age=2592000; includeSubDomains]
+      Vary: [Accept]
+    status: {code: 302, message: ''}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [zenodo.org]
+      User-Agent: [Python-urllib/3.6]
+    method: HEAD
+    uri: https://zenodo.org/record/3459420
+  response:
+    body: {string: ''}
+    headers:
+      Connection: [close]
+      Content-Length: ['72211']
+      Content-Type: [text/html; charset=utf-8]
+      Date: ['Fri, 27 Sep 2019 16:24:23 GMT']
+      Referrer-Policy: [strict-origin-when-cross-origin]
+      Retry-After: ['59']
+      Server: [nginx/1.12.2]
+      Set-Cookie: ['session=d35bd7003e4dfeaf_5d8e37b7.7GK7a4LBBy6jD_hxiGacnE7OINM;
+          Expires=Mon, 28-Oct-2019 16:24:23 GMT; Secure; HttpOnly; Path=/']
+      Strict-Transport-Security: [max-age=0]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [sameorigin]
+      X-RateLimit-Limit: ['60']
+      X-RateLimit-Remaining: ['59']
+      X-RateLimit-Reset: ['1569601523']
+      X-Request-ID: [7e4902cbf614b22c2d142661557b1849]
+      X-Session-ID: [d35bd7003e4dfeaf_5d8e37b7]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.zenodo.v1+json]
+      Connection: [close]
+      Host: [zenodo.org]
+      User-Agent: [Python-urllib/3.6]
+    method: GET
+    uri: https://zenodo.org/api/records/3459420
+  response:
+    body: {string: '{"conceptdoi":"10.5281/zenodo.1035252","conceptrecid":"1035252","created":"2019-09-24T23:01:29.515343+00:00","doi":"10.5281/zenodo.3459420","files":[{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:9e3800d4122de9233cf7884fbe57ec5e","key":"part-i-chemical-disease-path-theme-distributions.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-i-chemical-disease-path-theme-distributions.txt.gz"},"size":76685159,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:d367301c2c682ae211b117f239a2d778","key":"part-i-chemical-gene-path-theme-distributions.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-i-chemical-gene-path-theme-distributions.txt.gz"},"size":26797602,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:9609214deb310b9c77824319d0b23282","key":"part-i-gene-disease-path-theme-distributions.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-i-gene-disease-path-theme-distributions.txt.gz"},"size":71291352,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:6ac8550b601d194cde73df02fbb026c8","key":"part-i-gene-gene-path-theme-distributions.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-i-gene-gene-path-theme-distributions.txt.gz"},"size":57814698,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:ade2bbbb9624f7afdad254a66c653177","key":"part-ii-dependency-paths-chemical-disease-sorted.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-ii-dependency-paths-chemical-disease-sorted.txt.gz"},"size":1552310509,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:2e40dabec8e95575580d279a6cf75ccd","key":"part-ii-dependency-paths-chemical-disease-sorted-with-themes.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-ii-dependency-paths-chemical-disease-sorted-with-themes.txt.gz"},"size":433425857,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:84268a23cbcf0139673824dc6df06c5e","key":"part-ii-dependency-paths-chemical-gene-sorted.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-ii-dependency-paths-chemical-gene-sorted.txt.gz"},"size":920838205,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:94c3fb120d11a0bd87e3b6e3e7439ccb","key":"part-ii-dependency-paths-chemical-gene-sorted-with-themes.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-ii-dependency-paths-chemical-gene-sorted-with-themes.txt.gz"},"size":163072348,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:5109d1172531e843a0dbab3ce9dd5f00","key":"part-ii-dependency-paths-gene-disease-sorted.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-ii-dependency-paths-gene-disease-sorted.txt.gz"},"size":1203846235,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:e4d3bbbfb30204e69b1edacf2ffe97ca","key":"part-ii-dependency-paths-gene-disease-sorted-with-themes.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-ii-dependency-paths-gene-disease-sorted-with-themes.txt.gz"},"size":351234432,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:d77896d3ceabf1111a82e9d966d70a5e","key":"part-ii-dependency-paths-gene-gene-sorted.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-ii-dependency-paths-gene-gene-sorted.txt.gz"},"size":2756212307,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:3ebee254dedf271c657c9481b1d8ac49","key":"part-ii-dependency-paths-gene-gene-sorted-with-themes.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-ii-dependency-paths-gene-gene-sorted-with-themes.txt.gz"},"size":424098043,"type":"gz"}],"id":3459420,"links":{"badge":"https://zenodo.org/badge/doi/10.5281/zenodo.3459420.svg","bucket":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","conceptbadge":"https://zenodo.org/badge/doi/10.5281/zenodo.1035252.svg","conceptdoi":"https://doi.org/10.5281/zenodo.1035252","doi":"https://doi.org/10.5281/zenodo.3459420","html":"https://zenodo.org/record/3459420","latest":"https://zenodo.org/api/records/3459420","latest_html":"https://zenodo.org/record/3459420","self":"https://zenodo.org/api/records/3459420"},"metadata":{"access_right":"open","access_right_category":"success","communities":[{"id":"zenodo"}],"creators":[{"affiliation":"Icahn
+        School of Medicine at Mount Sinai","name":"Percha, Bethany"},{"affiliation":"Stanford
+        University","name":"Altman, Russ B."}],"description":"<p>This repository contains
+        labeled, weighted networks of chemical-gene, gene-gene, gene-disease, and
+        chemical-disease relationships based on single sentences in PubMed abstracts.
+        All raw dependency paths are provided in addition to the labeled relationships.</p>\n\n<p>PART
+        I: Connects dependency paths to labels, or &quot;themes&quot;. Each record
+        contains a dependency path followed by its score for each theme, and indicators
+        of whether or not the path is part of the flagship path set for each theme
+        (meaning that it was manually reviewed and determined to reflect that theme).
+        The themes themselves are listed below and are in our paper (reference below).</p>\n\n<p>PART
+        II: Connects sentences to dependency paths. It consists of sentences and associated
+        metadata, entity pairs found in the sentences, and dependency paths connecting
+        those entity pairs. Each record contains the following information:</p>\n\n<ul>\n\t<li>PubMed
+        ID</li>\n\t<li>Sentence number (0 = title)</li>\n\t<li>First entity name,
+        formatted</li>\n\t<li>First entity name, location (characters from start of
+        abstract)</li>\n\t<li>Second entity name, formatted</li>\n\t<li>Second entity
+        name, location</li>\n\t<li>First entity name, raw string</li>\n\t<li>Second
+        entity name, raw string</li>\n\t<li>First entity name, database ID(s)</li>\n\t<li>Second
+        entity name, database ID(s)</li>\n\t<li>First entity type (Chemical, Gene,
+        Disease)</li>\n\t<li>Second entity type (Chemical, Gene, Disease)</li>\n\t<li>Dependency
+        path</li>\n\t<li>Sentence, tokenized</li>\n</ul>\n\n<p>The &quot;with-themes.txt&quot;
+        files only contain dependency paths with corresponding theme assignments from
+        Part I. The plain &quot;.txt&quot; files contain all dependency paths.</p>\n\n<p>This
+        release contains the annotated network for the&nbsp;<strong>September 15,
+        2019&nbsp;version of PubTator</strong>. The version discussed in our paper,
+        below, is an older one - from April 30, 2016. If you&#39;re interested in
+        that network, it can be found in Version 1 of this repository.&nbsp;We will
+        be releasing updated networks periodically, as the PubTator community continues
+        to release new versions of named entity annotations for Medline each month
+        or so.</p>\n\n<p>------------------------------------------------------------------------------------<br>\nREFERENCES</p>\n\n<p>Percha
+        B, Altman RBA (2017) A global network of biomedical relationships derived
+        from text. <em>Bioinformatics,&nbsp;</em>34(15): 2614-2624.<br>\nPercha B,
+        Altman RBA (2015) Learning the structure of biomedical relationships from
+        unstructured text. <em>PLoS Computational Biology,</em> 11(7): e1004216.</p>\n\n<p>This
+        project depends on named entity annotations from the PubTator project:<br>\nhttps://www.ncbi.nlm.nih.gov/CBBresearch/Lu/Demo/PubTator/</p>\n\n<p>Reference:<br>\nWei
+        CH et. al., PubTator: a Web-based text mining tool for assisting Biocuration,
+        Nucleic acids research, 2013, 41 (W1): W518-W522.</p>\n\n<p>Dependency parsing
+        was provided by the Stanford CoreNLP toolkit (<strong>version 3.9.1</strong>):<br>\nhttps://stanfordnlp.github.io/CoreNLP/index.html</p>\n\n<p>Reference:<br>\nManning,
+        Christopher D., Mihai Surdeanu, John Bauer, Jenny Finkel, Steven J. Bethard,
+        and David McClosky. 2014. The Stanford CoreNLP Natural Language Processing
+        Toolkit In Proceedings of the 52nd Annual Meeting of the Association for Computational
+        Linguistics: System Demonstrations, pp. 55-60.</p>\n\n<p>------------------------------------------------------------------------------------<br>\nTHEMES</p>\n\n<p><strong>chemical-gene</strong><br>\n(A+)
+        agonism, activation<br>\n(A-) antagonism, blocking<br>\n(B) binding, ligand
+        (esp. receptors)<br>\n(E+) increases expression/production<br>\n(E-) decreases
+        expression/production<br>\n(E) affects expression/production (neutral)<br>\n(N)
+        inhibits</p>\n\n<p><strong>gene-chemical</strong><br>\n(O) transport, channels<br>\n(K)
+        metabolism, pharmacokinetics<br>\n(Z) enzyme activity</p>\n\n<p><strong>chemical-disease</strong><br>\n(T)
+        treatment/therapy (including investigatory)<br>\n(C) inhibits cell growth
+        (esp. cancers)<br>\n(Sa) side effect/adverse event<br>\n(Pr) prevents, suppresses<br>\n(Pa)
+        alleviates, reduces<br>\n(J) role in disease pathogenesis</p>\n\n<p><strong>disease-chemical</strong><br>\n(Mp)
+        biomarkers (of disease progression)</p>\n\n<p><strong>gene-disease</strong><br>\n(U)
+        causal mutations<br>\n(Ud) mutations affecting disease course<br>\n(D) drug
+        targets<br>\n(J) role in pathogenesis<br>\n(Te) possible therapeutic effect<br>\n(Y)
+        polymorphisms alter risk<br>\n(G) promotes progression</p>\n\n<p><strong>disease-gene</strong><br>\n(Md)
+        biomarkers (diagnostic)<br>\n(X) overexpression in disease<br>\n(L) improper
+        regulation linked to disease</p>\n\n<p><strong>gene-gene</strong><br>\n(B)
+        binding, ligand (esp. receptors)<br>\n(W) enhances response<br>\n(V+) activates,
+        stimulates<br>\n(E+) increases expression/production<br>\n(E) affects expression/production
+        (neutral)<br>\n(I) signaling pathway<br>\n(H) same protein or complex<br>\n(Rg)
+        regulation<br>\n(Q) production by cell population</p>\n\n<p>------------------------------------------------------------------------------------<br>\nFORMATTING
+        NOTE</p>\n\n<p>A few users have mentioned that the dependency paths in the
+        &quot;part-i&quot; files are all lowercase text, whereas those in the &quot;part-ii&quot;
+        files maintain the case of the original sentence. This complicates mapping
+        between the two sets of files.</p>\n\n<p>We kept the part-ii files in the
+        same case as the original sentence to facilitate downstream debugging - it&#39;s
+        easier to tell which words in a particular sentence are contributing to the
+        dependency path if their original case is maintained. When working with the
+        part-ii &quot;with-themes&quot; files, if you simply convert the dependency
+        path to lowercase, it is guaranteed to match to one of the paths in the corresponding
+        part-i file and you&#39;ll be able to get the theme scores.</p>\n\n<p>Apologies
+        for the additional complexity, and please reach out to us if you have any
+        questions (see correspondence information in the&nbsp;<em>Bioinformatics</em>
+        manuscript, above).</p>","doi":"10.5281/zenodo.3459420","keywords":["natural
+        language processing","Medline","text mining","relation extraction","unsupervised
+        learning"],"license":{"id":"CC-BY-4.0"},"publication_date":"2019-09-24","related_identifiers":[{"identifier":"10.5281/zenodo.1035252","relation":"isVersionOf","scheme":"doi"}],"relations":{"version":[{"count":7,"index":6,"is_last":true,"last_child":{"pid_type":"recid","pid_value":"3459420"},"parent":{"pid_type":"recid","pid_value":"1035252"}}]},"resource_type":{"title":"Dataset","type":"dataset"},"title":"A
+        global network of biomedical relationships derived from text"},"owners":[12511],"revision":2,"stats":{"downloads":45.0,"unique_downloads":18.0,"unique_views":191.0,"version_downloads":9528.0,"version_unique_downloads":1762.0,"version_unique_views":8681.0,"version_views":10706.0,"version_volume":10466130143498.0,"views":235.0,"volume":21727037561.0},"updated":"2019-09-25T07:06:04.731448+00:00"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['Content-Type, ETag, Link, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset']
+      Connection: [close]
+      Content-Length: ['12082']
+      Content-Type: [application/json]
+      Date: ['Fri, 27 Sep 2019 16:24:25 GMT']
+      ETag: ['"2"']
+      Last-Modified: ['Wed, 25 Sep 2019 07:06:04 GMT']
+      Link: ['<https://zenodo.org/api/records/3459420>; rel="self"']
+      Referrer-Policy: [strict-origin-when-cross-origin]
+      Retry-After: ['60']
+      Server: [nginx/1.12.2]
+      Strict-Transport-Security: [max-age=0]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [sameorigin]
+      X-RateLimit-Limit: ['60']
+      X-RateLimit-Remaining: ['58']
+      X-RateLimit-Reset: ['1569601526']
+      X-Request-ID: [2182c19b539c5fa436993ca804dbd099]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.zenodo.v1+json]
+      Connection: [close]
+      Host: [zenodo.org]
+      User-Agent: [Python-urllib/3.6]
+    method: GET
+    uri: https://zenodo.org/api/records/3459420
+  response:
+    body: {string: '{"conceptdoi":"10.5281/zenodo.1035252","conceptrecid":"1035252","created":"2019-09-24T23:01:29.515343+00:00","doi":"10.5281/zenodo.3459420","files":[{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:9e3800d4122de9233cf7884fbe57ec5e","key":"part-i-chemical-disease-path-theme-distributions.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-i-chemical-disease-path-theme-distributions.txt.gz"},"size":76685159,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:d367301c2c682ae211b117f239a2d778","key":"part-i-chemical-gene-path-theme-distributions.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-i-chemical-gene-path-theme-distributions.txt.gz"},"size":26797602,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:9609214deb310b9c77824319d0b23282","key":"part-i-gene-disease-path-theme-distributions.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-i-gene-disease-path-theme-distributions.txt.gz"},"size":71291352,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:6ac8550b601d194cde73df02fbb026c8","key":"part-i-gene-gene-path-theme-distributions.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-i-gene-gene-path-theme-distributions.txt.gz"},"size":57814698,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:ade2bbbb9624f7afdad254a66c653177","key":"part-ii-dependency-paths-chemical-disease-sorted.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-ii-dependency-paths-chemical-disease-sorted.txt.gz"},"size":1552310509,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:2e40dabec8e95575580d279a6cf75ccd","key":"part-ii-dependency-paths-chemical-disease-sorted-with-themes.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-ii-dependency-paths-chemical-disease-sorted-with-themes.txt.gz"},"size":433425857,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:84268a23cbcf0139673824dc6df06c5e","key":"part-ii-dependency-paths-chemical-gene-sorted.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-ii-dependency-paths-chemical-gene-sorted.txt.gz"},"size":920838205,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:94c3fb120d11a0bd87e3b6e3e7439ccb","key":"part-ii-dependency-paths-chemical-gene-sorted-with-themes.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-ii-dependency-paths-chemical-gene-sorted-with-themes.txt.gz"},"size":163072348,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:5109d1172531e843a0dbab3ce9dd5f00","key":"part-ii-dependency-paths-gene-disease-sorted.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-ii-dependency-paths-gene-disease-sorted.txt.gz"},"size":1203846235,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:e4d3bbbfb30204e69b1edacf2ffe97ca","key":"part-ii-dependency-paths-gene-disease-sorted-with-themes.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-ii-dependency-paths-gene-disease-sorted-with-themes.txt.gz"},"size":351234432,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:d77896d3ceabf1111a82e9d966d70a5e","key":"part-ii-dependency-paths-gene-gene-sorted.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-ii-dependency-paths-gene-gene-sorted.txt.gz"},"size":2756212307,"type":"gz"},{"bucket":"a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","checksum":"md5:3ebee254dedf271c657c9481b1d8ac49","key":"part-ii-dependency-paths-gene-gene-sorted-with-themes.txt.gz","links":{"self":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9/part-ii-dependency-paths-gene-gene-sorted-with-themes.txt.gz"},"size":424098043,"type":"gz"}],"id":3459420,"links":{"badge":"https://zenodo.org/badge/doi/10.5281/zenodo.3459420.svg","bucket":"https://zenodo.org/api/files/a3684bb7-35d8-45a5-aa1b-1bf4e51944c9","conceptbadge":"https://zenodo.org/badge/doi/10.5281/zenodo.1035252.svg","conceptdoi":"https://doi.org/10.5281/zenodo.1035252","doi":"https://doi.org/10.5281/zenodo.3459420","html":"https://zenodo.org/record/3459420","latest":"https://zenodo.org/api/records/3459420","latest_html":"https://zenodo.org/record/3459420","self":"https://zenodo.org/api/records/3459420"},"metadata":{"access_right":"open","access_right_category":"success","communities":[{"id":"zenodo"}],"creators":[{"affiliation":"Icahn
+        School of Medicine at Mount Sinai","name":"Percha, Bethany"},{"affiliation":"Stanford
+        University","name":"Altman, Russ B."}],"description":"<p>This repository contains
+        labeled, weighted networks of chemical-gene, gene-gene, gene-disease, and
+        chemical-disease relationships based on single sentences in PubMed abstracts.
+        All raw dependency paths are provided in addition to the labeled relationships.</p>\n\n<p>PART
+        I: Connects dependency paths to labels, or &quot;themes&quot;. Each record
+        contains a dependency path followed by its score for each theme, and indicators
+        of whether or not the path is part of the flagship path set for each theme
+        (meaning that it was manually reviewed and determined to reflect that theme).
+        The themes themselves are listed below and are in our paper (reference below).</p>\n\n<p>PART
+        II: Connects sentences to dependency paths. It consists of sentences and associated
+        metadata, entity pairs found in the sentences, and dependency paths connecting
+        those entity pairs. Each record contains the following information:</p>\n\n<ul>\n\t<li>PubMed
+        ID</li>\n\t<li>Sentence number (0 = title)</li>\n\t<li>First entity name,
+        formatted</li>\n\t<li>First entity name, location (characters from start of
+        abstract)</li>\n\t<li>Second entity name, formatted</li>\n\t<li>Second entity
+        name, location</li>\n\t<li>First entity name, raw string</li>\n\t<li>Second
+        entity name, raw string</li>\n\t<li>First entity name, database ID(s)</li>\n\t<li>Second
+        entity name, database ID(s)</li>\n\t<li>First entity type (Chemical, Gene,
+        Disease)</li>\n\t<li>Second entity type (Chemical, Gene, Disease)</li>\n\t<li>Dependency
+        path</li>\n\t<li>Sentence, tokenized</li>\n</ul>\n\n<p>The &quot;with-themes.txt&quot;
+        files only contain dependency paths with corresponding theme assignments from
+        Part I. The plain &quot;.txt&quot; files contain all dependency paths.</p>\n\n<p>This
+        release contains the annotated network for the&nbsp;<strong>September 15,
+        2019&nbsp;version of PubTator</strong>. The version discussed in our paper,
+        below, is an older one - from April 30, 2016. If you&#39;re interested in
+        that network, it can be found in Version 1 of this repository.&nbsp;We will
+        be releasing updated networks periodically, as the PubTator community continues
+        to release new versions of named entity annotations for Medline each month
+        or so.</p>\n\n<p>------------------------------------------------------------------------------------<br>\nREFERENCES</p>\n\n<p>Percha
+        B, Altman RBA (2017) A global network of biomedical relationships derived
+        from text. <em>Bioinformatics,&nbsp;</em>34(15): 2614-2624.<br>\nPercha B,
+        Altman RBA (2015) Learning the structure of biomedical relationships from
+        unstructured text. <em>PLoS Computational Biology,</em> 11(7): e1004216.</p>\n\n<p>This
+        project depends on named entity annotations from the PubTator project:<br>\nhttps://www.ncbi.nlm.nih.gov/CBBresearch/Lu/Demo/PubTator/</p>\n\n<p>Reference:<br>\nWei
+        CH et. al., PubTator: a Web-based text mining tool for assisting Biocuration,
+        Nucleic acids research, 2013, 41 (W1): W518-W522.</p>\n\n<p>Dependency parsing
+        was provided by the Stanford CoreNLP toolkit (<strong>version 3.9.1</strong>):<br>\nhttps://stanfordnlp.github.io/CoreNLP/index.html</p>\n\n<p>Reference:<br>\nManning,
+        Christopher D., Mihai Surdeanu, John Bauer, Jenny Finkel, Steven J. Bethard,
+        and David McClosky. 2014. The Stanford CoreNLP Natural Language Processing
+        Toolkit In Proceedings of the 52nd Annual Meeting of the Association for Computational
+        Linguistics: System Demonstrations, pp. 55-60.</p>\n\n<p>------------------------------------------------------------------------------------<br>\nTHEMES</p>\n\n<p><strong>chemical-gene</strong><br>\n(A+)
+        agonism, activation<br>\n(A-) antagonism, blocking<br>\n(B) binding, ligand
+        (esp. receptors)<br>\n(E+) increases expression/production<br>\n(E-) decreases
+        expression/production<br>\n(E) affects expression/production (neutral)<br>\n(N)
+        inhibits</p>\n\n<p><strong>gene-chemical</strong><br>\n(O) transport, channels<br>\n(K)
+        metabolism, pharmacokinetics<br>\n(Z) enzyme activity</p>\n\n<p><strong>chemical-disease</strong><br>\n(T)
+        treatment/therapy (including investigatory)<br>\n(C) inhibits cell growth
+        (esp. cancers)<br>\n(Sa) side effect/adverse event<br>\n(Pr) prevents, suppresses<br>\n(Pa)
+        alleviates, reduces<br>\n(J) role in disease pathogenesis</p>\n\n<p><strong>disease-chemical</strong><br>\n(Mp)
+        biomarkers (of disease progression)</p>\n\n<p><strong>gene-disease</strong><br>\n(U)
+        causal mutations<br>\n(Ud) mutations affecting disease course<br>\n(D) drug
+        targets<br>\n(J) role in pathogenesis<br>\n(Te) possible therapeutic effect<br>\n(Y)
+        polymorphisms alter risk<br>\n(G) promotes progression</p>\n\n<p><strong>disease-gene</strong><br>\n(Md)
+        biomarkers (diagnostic)<br>\n(X) overexpression in disease<br>\n(L) improper
+        regulation linked to disease</p>\n\n<p><strong>gene-gene</strong><br>\n(B)
+        binding, ligand (esp. receptors)<br>\n(W) enhances response<br>\n(V+) activates,
+        stimulates<br>\n(E+) increases expression/production<br>\n(E) affects expression/production
+        (neutral)<br>\n(I) signaling pathway<br>\n(H) same protein or complex<br>\n(Rg)
+        regulation<br>\n(Q) production by cell population</p>\n\n<p>------------------------------------------------------------------------------------<br>\nFORMATTING
+        NOTE</p>\n\n<p>A few users have mentioned that the dependency paths in the
+        &quot;part-i&quot; files are all lowercase text, whereas those in the &quot;part-ii&quot;
+        files maintain the case of the original sentence. This complicates mapping
+        between the two sets of files.</p>\n\n<p>We kept the part-ii files in the
+        same case as the original sentence to facilitate downstream debugging - it&#39;s
+        easier to tell which words in a particular sentence are contributing to the
+        dependency path if their original case is maintained. When working with the
+        part-ii &quot;with-themes&quot; files, if you simply convert the dependency
+        path to lowercase, it is guaranteed to match to one of the paths in the corresponding
+        part-i file and you&#39;ll be able to get the theme scores.</p>\n\n<p>Apologies
+        for the additional complexity, and please reach out to us if you have any
+        questions (see correspondence information in the&nbsp;<em>Bioinformatics</em>
+        manuscript, above).</p>","doi":"10.5281/zenodo.3459420","keywords":["natural
+        language processing","Medline","text mining","relation extraction","unsupervised
+        learning"],"license":{"id":"CC-BY-4.0"},"publication_date":"2019-09-24","related_identifiers":[{"identifier":"10.5281/zenodo.1035252","relation":"isVersionOf","scheme":"doi"}],"relations":{"version":[{"count":7,"index":6,"is_last":true,"last_child":{"pid_type":"recid","pid_value":"3459420"},"parent":{"pid_type":"recid","pid_value":"1035252"}}]},"resource_type":{"title":"Dataset","type":"dataset"},"title":"A
+        global network of biomedical relationships derived from text"},"owners":[12511],"revision":2,"stats":{"downloads":45.0,"unique_downloads":18.0,"unique_views":191.0,"version_downloads":9528.0,"version_unique_downloads":1762.0,"version_unique_views":8681.0,"version_views":10706.0,"version_volume":10466130143498.0,"views":235.0,"volume":21727037561.0},"updated":"2019-09-25T07:06:04.731448+00:00"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['Content-Type, ETag, Link, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset']
+      Connection: [close]
+      Content-Length: ['12082']
+      Content-Type: [application/json]
+      Date: ['Fri, 27 Sep 2019 16:24:26 GMT']
+      ETag: ['"2"']
+      Last-Modified: ['Wed, 25 Sep 2019 07:06:04 GMT']
+      Link: ['<https://zenodo.org/api/records/3459420>; rel="self"']
+      Referrer-Policy: [strict-origin-when-cross-origin]
+      Retry-After: ['60']
+      Server: [nginx/1.12.2]
+      Strict-Transport-Security: [max-age=0]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [sameorigin]
+      X-RateLimit-Limit: ['60']
+      X-RateLimit-Remaining: ['57']
+      X-RateLimit-Reset: ['1569601527']
+      X-Request-ID: [6ea39f1a9091019166ed28e782bb2677]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.zenodo.v1+json]
+      Connection: [close]
+      Host: [zenodo.org]
+      User-Agent: [Python-urllib/3.6]
+    method: GET
+    uri: https://zenodo.org/api/records/3463499
+  response:
+    body: {string: '{"conceptdoi":"10.5281/zenodo.3462714","conceptrecid":"3462714","created":"2019-09-27T15:17:47.295427+00:00","doi":"10.5281/zenodo.3463499","files":[{"bucket":"fbcb465c-c250-41da-9d9a-f28d8587c0e3","checksum":"md5:131225ba8fd81a5a2f4f50a191a1504e","key":"jbferet/biodivMapR-v1.0.1.zip","links":{"self":"https://zenodo.org/api/files/fbcb465c-c250-41da-9d9a-f28d8587c0e3/jbferet/biodivMapR-v1.0.1.zip"},"size":24692383,"type":"zip"}],"id":3463499,"links":{"badge":"https://zenodo.org/badge/doi/10.5281/zenodo.3463499.svg","bucket":"https://zenodo.org/api/files/fbcb465c-c250-41da-9d9a-f28d8587c0e3","conceptbadge":"https://zenodo.org/badge/doi/10.5281/zenodo.3462714.svg","conceptdoi":"https://doi.org/10.5281/zenodo.3462714","doi":"https://doi.org/10.5281/zenodo.3463499","html":"https://zenodo.org/record/3463499","latest":"https://zenodo.org/api/records/3463499","latest_html":"https://zenodo.org/record/3463499","self":"https://zenodo.org/api/records/3463499"},"metadata":{"access_right":"open","access_right_category":"success","creators":[{"name":"floriandeboissieu"}],"description":"biodivMapR
+        v1.0.1 (Release date: 2019-09-27)\n<p>Added NEWS.md\nUpdated README.md: transfered
+        from gitlab.irstea to github\nchanged return() into return(invisible())\nupdated
+        vignettes &amp; tutorial with latest outputs and figures from code</p>","doi":"10.5281/zenodo.3463499","license":{"id":"other-open"},"publication_date":"2019-09-27","related_identifiers":[{"identifier":"https://github.com/jbferet/biodivMapR/tree/v1.0.1","relation":"isSupplementTo","scheme":"url"},{"identifier":"10.5281/zenodo.3462714","relation":"isVersionOf","scheme":"doi"}],"relations":{"version":[{"count":2,"index":1,"is_last":true,"last_child":{"pid_type":"recid","pid_value":"3463499"},"parent":{"pid_type":"recid","pid_value":"3462714"}}]},"resource_type":{"title":"Software","type":"software"},"title":"jbferet/biodivMapR:
+        v1.0.1","version":"v1.0.1"},"owners":[77934],"revision":2,"stats":{"downloads":0.0,"unique_downloads":0.0,"unique_views":0.0,"version_downloads":0.0,"version_unique_downloads":0.0,"version_unique_views":1.0,"version_views":1.0,"version_volume":0.0,"views":0.0,"volume":0.0},"updated":"2019-09-27T15:17:52.038019+00:00"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['Content-Type, ETag, Link, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset']
+      Connection: [close]
+      Content-Length: ['2216']
+      Content-Type: [application/json]
+      Date: ['Fri, 27 Sep 2019 16:24:27 GMT']
+      ETag: ['"2"']
+      Last-Modified: ['Fri, 27 Sep 2019 15:17:52 GMT']
+      Link: ['<https://zenodo.org/api/records/3463499>; rel="self"']
+      Referrer-Policy: [strict-origin-when-cross-origin]
+      Retry-After: ['60']
+      Server: [nginx/1.12.2]
+      Strict-Transport-Security: [max-age=0]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [sameorigin]
+      X-RateLimit-Limit: ['60']
+      X-RateLimit-Remaining: ['56']
+      X-RateLimit-Reset: ['1569601528']
+      X-Request-ID: [de59d444d00ea57fdcb5b71d45c46ae2]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/plugin_tests/data/zenodo_manifest.txt
+++ b/plugin_tests/data/zenodo_manifest.txt
@@ -1,0 +1,80 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.zenodo.v1+json]
+      Connection: [close]
+      Host: [zenodo.org]
+      User-Agent: [Python-urllib/3.6]
+    method: GET
+    uri: https://zenodo.org/api/records/3463499
+  response:
+    body: {string: '{"conceptdoi":"10.5281/zenodo.3462714","conceptrecid":"3462714","created":"2019-09-27T15:17:47.295427+00:00","doi":"10.5281/zenodo.3463499","files":[{"bucket":"fbcb465c-c250-41da-9d9a-f28d8587c0e3","checksum":"md5:131225ba8fd81a5a2f4f50a191a1504e","key":"jbferet/biodivMapR-v1.0.1.zip","links":{"self":"https://zenodo.org/api/files/fbcb465c-c250-41da-9d9a-f28d8587c0e3/jbferet/biodivMapR-v1.0.1.zip"},"size":24692383,"type":"zip"}],"id":3463499,"links":{"badge":"https://zenodo.org/badge/doi/10.5281/zenodo.3463499.svg","bucket":"https://zenodo.org/api/files/fbcb465c-c250-41da-9d9a-f28d8587c0e3","conceptbadge":"https://zenodo.org/badge/doi/10.5281/zenodo.3462714.svg","conceptdoi":"https://doi.org/10.5281/zenodo.3462714","doi":"https://doi.org/10.5281/zenodo.3463499","html":"https://zenodo.org/record/3463499","latest":"https://zenodo.org/api/records/3463499","latest_html":"https://zenodo.org/record/3463499","self":"https://zenodo.org/api/records/3463499"},"metadata":{"access_right":"open","access_right_category":"success","creators":[{"name":"floriandeboissieu"}],"description":"biodivMapR
+        v1.0.1 (Release date: 2019-09-27)\n<p>Added NEWS.md\nUpdated README.md: transfered
+        from gitlab.irstea to github\nchanged return() into return(invisible())\nupdated
+        vignettes &amp; tutorial with latest outputs and figures from code</p>","doi":"10.5281/zenodo.3463499","license":{"id":"other-open"},"publication_date":"2019-09-27","related_identifiers":[{"identifier":"https://github.com/jbferet/biodivMapR/tree/v1.0.1","relation":"isSupplementTo","scheme":"url"},{"identifier":"10.5281/zenodo.3462714","relation":"isVersionOf","scheme":"doi"}],"relations":{"version":[{"count":2,"index":1,"is_last":true,"last_child":{"pid_type":"recid","pid_value":"3463499"},"parent":{"pid_type":"recid","pid_value":"3462714"}}]},"resource_type":{"title":"Software","type":"software"},"title":"jbferet/biodivMapR:
+        v1.0.1","version":"v1.0.1"},"owners":[77934],"revision":2,"stats":{"downloads":0.0,"unique_downloads":0.0,"unique_views":0.0,"version_downloads":0.0,"version_unique_downloads":0.0,"version_unique_views":1.0,"version_views":1.0,"version_volume":0.0,"views":0.0,"volume":0.0},"updated":"2019-09-27T15:17:52.038019+00:00"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['Content-Type, ETag, Link, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset']
+      Connection: [close]
+      Content-Length: ['2216']
+      Content-Type: [application/json]
+      Date: ['Fri, 27 Sep 2019 17:33:48 GMT']
+      ETag: ['"2"']
+      Last-Modified: ['Fri, 27 Sep 2019 15:17:52 GMT']
+      Link: ['<https://zenodo.org/api/records/3463499>; rel="self"']
+      Referrer-Policy: [strict-origin-when-cross-origin]
+      Retry-After: ['59']
+      Server: [nginx/1.12.2]
+      Strict-Transport-Security: [max-age=0]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [sameorigin]
+      X-RateLimit-Limit: ['60']
+      X-RateLimit-Remaining: ['57']
+      X-RateLimit-Reset: ['1569605688']
+      X-Request-ID: [49476388454579cffe96ae857d165899]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.zenodo.v1+json]
+      Connection: [close]
+      Host: [zenodo.org]
+      User-Agent: [Python-urllib/3.6]
+    method: GET
+    uri: https://zenodo.org/api/records/3463499
+  response:
+    body: {string: '{"conceptdoi":"10.5281/zenodo.3462714","conceptrecid":"3462714","created":"2019-09-27T15:17:47.295427+00:00","doi":"10.5281/zenodo.3463499","files":[{"bucket":"fbcb465c-c250-41da-9d9a-f28d8587c0e3","checksum":"md5:131225ba8fd81a5a2f4f50a191a1504e","key":"jbferet/biodivMapR-v1.0.1.zip","links":{"self":"https://zenodo.org/api/files/fbcb465c-c250-41da-9d9a-f28d8587c0e3/jbferet/biodivMapR-v1.0.1.zip"},"size":24692383,"type":"zip"}],"id":3463499,"links":{"badge":"https://zenodo.org/badge/doi/10.5281/zenodo.3463499.svg","bucket":"https://zenodo.org/api/files/fbcb465c-c250-41da-9d9a-f28d8587c0e3","conceptbadge":"https://zenodo.org/badge/doi/10.5281/zenodo.3462714.svg","conceptdoi":"https://doi.org/10.5281/zenodo.3462714","doi":"https://doi.org/10.5281/zenodo.3463499","html":"https://zenodo.org/record/3463499","latest":"https://zenodo.org/api/records/3463499","latest_html":"https://zenodo.org/record/3463499","self":"https://zenodo.org/api/records/3463499"},"metadata":{"access_right":"open","access_right_category":"success","creators":[{"name":"floriandeboissieu"}],"description":"biodivMapR
+        v1.0.1 (Release date: 2019-09-27)\n<p>Added NEWS.md\nUpdated README.md: transfered
+        from gitlab.irstea to github\nchanged return() into return(invisible())\nupdated
+        vignettes &amp; tutorial with latest outputs and figures from code</p>","doi":"10.5281/zenodo.3463499","license":{"id":"other-open"},"publication_date":"2019-09-27","related_identifiers":[{"identifier":"https://github.com/jbferet/biodivMapR/tree/v1.0.1","relation":"isSupplementTo","scheme":"url"},{"identifier":"10.5281/zenodo.3462714","relation":"isVersionOf","scheme":"doi"}],"relations":{"version":[{"count":2,"index":1,"is_last":true,"last_child":{"pid_type":"recid","pid_value":"3463499"},"parent":{"pid_type":"recid","pid_value":"3462714"}}]},"resource_type":{"title":"Software","type":"software"},"title":"jbferet/biodivMapR:
+        v1.0.1","version":"v1.0.1"},"owners":[77934],"revision":2,"stats":{"downloads":0.0,"unique_downloads":0.0,"unique_views":0.0,"version_downloads":0.0,"version_unique_downloads":0.0,"version_unique_views":1.0,"version_views":1.0,"version_volume":0.0,"views":0.0,"volume":0.0},"updated":"2019-09-27T15:17:52.038019+00:00"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Access-Control-Expose-Headers: ['Content-Type, ETag, Link, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset']
+      Connection: [close]
+      Content-Length: ['2216']
+      Content-Type: [application/json]
+      Date: ['Fri, 27 Sep 2019 17:33:49 GMT']
+      ETag: ['"2"']
+      Last-Modified: ['Fri, 27 Sep 2019 15:17:52 GMT']
+      Link: ['<https://zenodo.org/api/records/3463499>; rel="self"']
+      Referrer-Policy: [strict-origin-when-cross-origin]
+      Retry-After: ['59']
+      Server: [nginx/1.12.2]
+      Strict-Transport-Security: [max-age=0]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [sameorigin]
+      X-RateLimit-Limit: ['60']
+      X-RateLimit-Remaining: ['56']
+      X-RateLimit-Reset: ['1569605689']
+      X-Request-ID: [235c9030e58421c1e5009a77ea98e007]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/plugin_tests/dataverse_test.py
+++ b/plugin_tests/dataverse_test.py
@@ -249,7 +249,7 @@ class DataverseHarversterTestCase(base.TestCase):
         from girder.plugins.wholetale.lib.dataverse.provider import DataverseImportProvider
         self.assertEqual(
             '^https://demo.dataverse.org|https://random.d.org|https://random2.d.org.*$',
-            DataverseImportProvider().dataverse_regex.pattern
+            DataverseImportProvider().regex.pattern
         )
         resp = self.request(
             '/system/setting', user=self.admin, method='PUT',

--- a/plugin_tests/zenodo_test.py
+++ b/plugin_tests/zenodo_test.py
@@ -50,7 +50,7 @@ class ZenodoHarversterTestCase(base.TestCase):
         resolved_lookup = {
             "dataId": "https://zenodo.org/record/3459420",
             "doi": "doi:10.5281/zenodo.3459420",
-            "name": "A global network of biomedical relationships derived from text_rev2",
+            "name": "A global network of biomedical relationships derived from text_ver_7",
             "repository": "Zenodo",
             "size": 8037626747,
         }
@@ -73,7 +73,7 @@ class ZenodoHarversterTestCase(base.TestCase):
 
         resolved_listFiles = [
             {
-                "jbferet/biodivMapR: v1.0.1_rev2": {
+                "jbferet/biodivMapR: v1.0.1_ver_v1.0.1": {
                     "jbferet": {
                         "fileList": [{"biodivMapR-v1.0.1.zip": {"size": 24692383}}]
                     }
@@ -186,7 +186,7 @@ class ZenodoHarversterTestCase(base.TestCase):
         self.assertEqual(
             resp.json[0],
             {
-                "jbferet/biodivMapR: v1.0.1_rev2": {
+                "jbferet/biodivMapR: v1.0.1_ver_v1.0.1": {
                     "jbferet": {
                         "fileList": [{"biodivMapR-v1.0.1.zip": {"size": 24692383}}]
                     }

--- a/plugin_tests/zenodo_test.py
+++ b/plugin_tests/zenodo_test.py
@@ -1,0 +1,235 @@
+import json
+import os
+import vcr
+from tests import base
+from girder.models.folder import Folder
+from girder.models.user import User
+
+
+DATA_PATH = os.path.join(
+    os.path.dirname(os.environ["GIRDER_TEST_DATA_PREFIX"]),
+    "data_src",
+    "plugins",
+    "wholetale",
+)
+
+
+def setUpModule():
+    base.enabledPlugins.append("wholetale")
+    base.startServer()
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class ZenodoHarversterTestCase(base.TestCase):
+    def setUp(self):
+        users = (
+            {
+                "email": "root@dev.null",
+                "login": "admin",
+                "firstName": "Root",
+                "lastName": "van Klompf",
+                "password": "secret",
+            },
+            {
+                "email": "joe@dev.null",
+                "login": "joeregular",
+                "firstName": "Joe",
+                "lastName": "Regular",
+                "password": "secret",
+            },
+        )
+        self.admin, self.user = [
+            self.model("user").createUser(**user) for user in users
+        ]
+
+    @vcr.use_cassette(os.path.join(DATA_PATH, "zenodo_lookup.txt"))
+    def testLookup(self):
+        resolved_lookup = {
+            "dataId": "https://zenodo.org/record/3459420",
+            "doi": "doi:10.5281/zenodo.3459420",
+            "name": "A global network of biomedical relationships derived from text_rev2",
+            "repository": "Zenodo",
+            "size": 8037626747,
+        }
+
+        resp = self.request(
+            path="/repository/lookup",
+            method="GET",
+            user=self.user,
+            params={
+                "dataId": json.dumps(
+                    [
+                        "https://doi.org/10.5281/zenodo.3459420",
+                        "https://zenodo.org/record/3459420",
+                    ]
+                )
+            },
+        )
+        self.assertStatus(resp, 200)
+        self.assertEqual(resp.json, [resolved_lookup, resolved_lookup])
+
+        resolved_listFiles = [
+            {
+                "jbferet/biodivMapR: v1.0.1_rev2": {
+                    "jbferet": {
+                        "fileList": [{"biodivMapR-v1.0.1.zip": {"size": 24692383}}]
+                    }
+                }
+            }
+        ]
+
+        resp = self.request(
+            path="/repository/listFiles",
+            method="GET",
+            user=self.user,
+            params={"dataId": json.dumps(["https://zenodo.org/record/3463499"])},
+        )
+        self.assertStatus(resp, 200)
+        self.assertEqual(resp.json, resolved_listFiles)
+
+    def test_extra_hosts(self):
+        from girder.plugins.wholetale.constants import PluginSettings, SettingDefault
+
+        resp = self.request(
+            "/system/setting",
+            user=self.admin,
+            method="PUT",
+            params={
+                "key": PluginSettings.ZENODO_EXTRA_HOSTS,
+                "value": "https://sandbox.zenodo.org/record",
+            },
+        )
+        self.assertStatus(resp, 400)
+        self.assertEqual(
+            resp.json,
+            {
+                "field": "value",
+                "type": "validation",
+                "message": "Zenodo extra hosts setting must be a list.",
+            },
+        )
+
+        resp = self.request(
+            "/system/setting",
+            user=self.admin,
+            method="PUT",
+            params={
+                "key": PluginSettings.ZENODO_EXTRA_HOSTS,
+                "value": json.dumps(["not a url"]),
+            },
+        )
+        self.assertStatus(resp, 400)
+        self.assertEqual(
+            resp.json,
+            {
+                "field": "value",
+                "type": "validation",
+                "message": "Invalid URL in Zenodo extra hosts",
+            },
+        )
+
+        # defaults
+        resp = self.request(
+            "/system/setting",
+            user=self.admin,
+            method="PUT",
+            params={"key": PluginSettings.ZENODO_EXTRA_HOSTS, "value": ""},
+        )
+        self.assertStatusOk(resp)
+        resp = self.request(
+            "/system/setting",
+            user=self.admin,
+            method="GET",
+            params={"key": PluginSettings.ZENODO_EXTRA_HOSTS},
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(
+            resp.body[0].decode(),
+            str(SettingDefault.defaults[PluginSettings.ZENODO_EXTRA_HOSTS]),
+        )
+
+        resp = self.request(
+            "/system/setting",
+            user=self.admin,
+            method="PUT",
+            params={
+                "list": json.dumps(
+                    [
+                        {
+                            "key": PluginSettings.ZENODO_EXTRA_HOSTS,
+                            "value": ["https://sandbox.zenodo.org/record/"],
+                        }
+                    ]
+                )
+            },
+        )
+        self.assertStatusOk(resp)
+        from girder.plugins.wholetale.lib.zenodo.provider import ZenodoImportProvider
+
+        self.assertEqual(
+            "^http(s)?://(sandbox.zenodo.org/record/|zenodo.org/record/).*$",
+            ZenodoImportProvider().regex.pattern,
+        )
+
+    @vcr.use_cassette(os.path.join(DATA_PATH, "zenodo_hierarchy.txt"))
+    def test_dataset_with_hierarchy(self):
+        resp = self.request(
+            path="/repository/listFiles",
+            method="GET",
+            user=self.user,
+            params={"dataId": json.dumps(["https://zenodo.org/record/3463499"])},
+        )
+        self.assertStatus(resp, 200)
+        self.assertEqual(
+            resp.json[0],
+            {
+                "jbferet/biodivMapR: v1.0.1_rev2": {
+                    "jbferet": {
+                        "fileList": [{"biodivMapR-v1.0.1.zip": {"size": 24692383}}]
+                    }
+                }
+            },
+        )
+
+    @vcr.use_cassette(os.path.join(DATA_PATH, "zenodo_manifest.txt"))
+    def test_manifest_helpers(self):
+        resp = self.request(
+            path="/repository/lookup",
+            method="GET",
+            user=self.user,
+            params={"dataId": json.dumps(["https://zenodo.org/record/3463499"])},
+        )
+        self.assertStatus(resp, 200)
+        data_map = resp.json
+
+        resp = self.request(
+            path="/dataset/register",
+            method="POST",
+            params={"dataMap": json.dumps(data_map)},
+            user=self.user,
+        )
+        self.assertStatusOk(resp)
+
+        user = User().load(self.user["_id"], force=True)
+        dataset_root_folder = Folder().load(user["myData"][0], user=user)
+        child_folder = next(
+            Folder().childFolders(
+                parentType="folder", parent=dataset_root_folder, user=user
+            )
+        )
+        child_item = next((item for item in Folder().childItems(folder=child_folder)))
+
+        from girder.plugins.wholetale.lib.zenodo.provider import ZenodoImportProvider
+
+        for obj in (dataset_root_folder, child_folder, child_item):
+            self.assertEqual(
+                ZenodoImportProvider().getDatasetUID(obj, user),
+                "doi:10.5281/zenodo.3463499",
+            )
+
+    def tearDown(self):
+        self.model("user").remove(self.user)
+        self.model("user").remove(self.admin)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -81,6 +81,17 @@ def validateDataverseExtraHosts(doc):
             raise ValidationException('Invalid URL in Dataverse extra hosts', 'value')
 
 
+@setting_utilities.validator(PluginSettings.ZENODO_EXTRA_HOSTS)
+def validateZenodoExtraHosts(doc):
+    if not doc['value']:
+        doc['value'] = defaultZenodoExtraHosts()
+    if not isinstance(doc['value'], list):
+        raise ValidationException('Zenodo extra hosts setting must be a list.', 'value')
+    for url in doc['value']:
+        if not validators.url(url):
+            raise ValidationException('Invalid URL in Zenodo extra hosts', 'value')
+
+
 @setting_utilities.validator(PluginSettings.INSTANCE_CAP)
 def validateInstanceCap(doc):
     if not doc['value']:
@@ -113,6 +124,11 @@ def defaultDataverseURL():
 @setting_utilities.default(PluginSettings.DATAVERSE_EXTRA_HOSTS)
 def defaultDataverseExtraHosts():
     return SettingDefault.defaults[PluginSettings.DATAVERSE_EXTRA_HOSTS]
+
+
+@setting_utilities.default(PluginSettings.ZENODO_EXTRA_HOSTS)
+def defaultZenodoExtraHosts():
+    return SettingDefault.defaults[PluginSettings.ZENODO_EXTRA_HOSTS]
 
 
 @access.public(scope=TokenScope.DATA_READ)

--- a/server/constants.py
+++ b/server/constants.py
@@ -25,6 +25,7 @@ class PluginSettings:
     DATAVERSE_EXTRA_HOSTS = "wholetale.dataverse_extra_hosts"
     EXTERNAL_AUTH_PROVIDERS = "wholetale.external_auth_providers"
     EXTERNAL_APIKEY_GROUPS = "wholetale.external_apikey_groups"
+    ZENODO_EXTRA_HOSTS = "wholetale.zenodo_extra_hosts"
 
 
 class SettingDefault:
@@ -85,6 +86,7 @@ class SettingDefault:
                 ],
             },
         ],
+        PluginSettings.ZENODO_EXTRA_HOSTS: [],
     }
 
 

--- a/server/lib/__init__.py
+++ b/server/lib/__init__.py
@@ -18,6 +18,7 @@ from .null_provider import NullImportProvider
 from .dataone.provider import DataOneImportProvider
 from .dataverse.provider import DataverseImportProvider
 from .globus.globus_provider import GlobusImportProvider
+from .zenodo.provider import ZenodoImportProvider
 
 
 RESOLVERS = Resolvers()
@@ -25,6 +26,7 @@ RESOLVERS.add(DOIResolver())
 
 IMPORT_PROVIDERS = ImportProviders()
 IMPORT_PROVIDERS.addProvider(DataverseImportProvider())
+IMPORT_PROVIDERS.addProvider(ZenodoImportProvider())
 IMPORT_PROVIDERS.addProvider(GlobusImportProvider())
 IMPORT_PROVIDERS.addProvider(DataOneImportProvider())
 # (almost) last resort

--- a/server/lib/dataverse/provider.py
+++ b/server/lib/dataverse/provider.py
@@ -72,17 +72,9 @@ def _get_attrs_via_head(obj, url):
 
 
 class DataverseImportProvider(ImportProvider):
-    _dataverse_regex = None
-
     def __init__(self):
         super().__init__('Dataverse')
         events.bind('model.setting.save.after', 'wholetale', self.setting_changed)
-
-    @property
-    def dataverse_regex(self):
-        if not self._dataverse_regex:
-            self._dataverse_regex = self.create_dataverse_regex()
-        return self._dataverse_regex
 
     @staticmethod
     def get_base_url_setting():
@@ -92,7 +84,7 @@ class DataverseImportProvider(ImportProvider):
     def get_extra_hosts_setting():
         return Setting().get(constants.PluginSettings.DATAVERSE_EXTRA_HOSTS)
 
-    def create_dataverse_regex(self):
+    def create_regex(self):
         url = self.get_base_url_setting()
         if not url.endswith('installations-json'):
             url = urlunparse(
@@ -129,11 +121,7 @@ class DataverseImportProvider(ImportProvider):
         }
         if not hasattr(event, "info") or event.info.get('key', '') not in triggers:
             return
-        self._dataverse_regex = None
-
-    def matches(self, entity: Entity) -> bool:
-        url = entity.getValue()
-        return self.dataverse_regex.match(url) is not None
+        self._regex = None
 
     @staticmethod
     def _parse_dataset(url):

--- a/server/lib/dataverse/provider.py
+++ b/server/lib/dataverse/provider.py
@@ -99,7 +99,7 @@ class DataverseImportProvider(ImportProvider):
             else:
                 urls = [self.get_base_url_setting()]
         except Exception:
-            logger.warn('[dataverse] failed to generate regex')
+            logger.warning('[dataverse] failed to generate regex')
             urls = []
 
         urls += self.get_extra_hosts_setting()

--- a/server/lib/globus/globus_provider.py
+++ b/server/lib/globus/globus_provider.py
@@ -25,8 +25,7 @@ class GlobusImportProvider(ImportProvider):
         super().__init__('Globus')
         self.clients = Clients()
 
-    @staticmethod
-    def create_regex():
+    def create_regex(self):
         return re.compile(r'^https://petreldata.net/mdf/detail.*')
 
     def lookup(self, entity: Entity) -> DataMap:

--- a/server/lib/http_provider.py
+++ b/server/lib/http_provider.py
@@ -18,8 +18,7 @@ class HTTPImportProvider(ImportProvider):
     def __init__(self):
         super().__init__('HTTP')
 
-    @staticmethod
-    def create_regex():
+    def create_regex(self):
         return re.compile(r'^http(s)?://.*')
 
     def lookup(self, entity: Entity) -> DataMap:

--- a/server/lib/import_providers.py
+++ b/server/lib/import_providers.py
@@ -22,8 +22,7 @@ class ImportProvider:
             self._regex = self.create_regex()
         return self._regex
 
-    @staticmethod
-    def create_regex():
+    def create_regex(self):
         """Create and initialize regular expression used for matching"""
         raise NotImplementedError()
 

--- a/server/lib/import_providers.py
+++ b/server/lib/import_providers.py
@@ -76,8 +76,13 @@ class ImportProvider:
         folder = self.folderModel.createFolder(parent, item.name, description='',
                                                parentType=parentType, creator=user,
                                                reuseExisting=True)
-        folder = self.folderModel.setMetadata(folder, {'identifier': item.identifier,
-                                                       'provider': self.getName()})
+        meta = {
+            "identifier": item.identifier,
+            "provider": self.getName(),
+        }
+        if item.meta:
+            meta.update(item.meta)
+        folder = self.folderModel.setMetadata(folder, meta)
         stack.append((folder, 'folder'))
         return (folder, 'folder')
 
@@ -87,6 +92,8 @@ class ImportProvider:
         meta = {'provider': self.getName()}
         if item.identifier:
             meta['identifier'] = item.identifier
+        if item.meta:
+            meta.update(item.meta)
         gitem = self.itemModel.setMetadata(gitem, meta)
 
         # girder does not allow anything else than http and https. So we need a better

--- a/server/lib/zenodo/provider.py
+++ b/server/lib/zenodo/provider.py
@@ -65,7 +65,14 @@ class ZenodoImportProvider(ImportProvider):
 
     @staticmethod
     def _get_title_from_record(record):
-        return record["metadata"]["title"] + "_rev{}".format(record["revision"])
+        try:
+            version = record["metadata"]["version"]
+        except KeyError:
+            try:
+                version = record["metadata"]["relations"]["version"][0]["count"]
+            except (KeyError, IndexError):
+                version = record["id"]
+        return record["metadata"]["title"] + "_ver_{}".format(version)
 
     def lookup(self, entity: Entity) -> DataMap:
         record = self._get_record(entity.getValue())

--- a/server/lib/zenodo/provider.py
+++ b/server/lib/zenodo/provider.py
@@ -107,7 +107,7 @@ class ZenodoImportProvider(ImportProvider):
             temp["+files+"].append(
                 {
                     "size": file_obj["size"],
-                    "name": file_obj["key"].rsplit("/", maxsplit=1)[1],
+                    "name": file_obj["key"].rsplit("/", maxsplit=1)[-1],
                     "url": file_obj["links"]["self"],
                     "mimeType": "application/octet-stream",
                 }
@@ -134,7 +134,7 @@ class ZenodoImportProvider(ImportProvider):
                 yield from _recurse_hierarchy(hierarchy[folder])
                 yield ImportItem(ImportItem.END_FOLDER)
 
-        meta = {k: record[k] for k in ["conceptdoi", "conceptrecid"]}
+        meta = {k: record.get(k, "") for k in ["conceptdoi", "conceptrecid"]}
         meta["subProvider"] = urlparse(pid).netloc
 
         yield ImportItem(

--- a/server/lib/zenodo/provider.py
+++ b/server/lib/zenodo/provider.py
@@ -1,0 +1,140 @@
+import json
+import re
+import pathlib
+from urllib.parse import urlparse
+from urllib.request import urlopen, Request
+
+from girder.models.folder import Folder
+from girder.models.item import Item
+
+from ..import_providers import ImportProvider
+from ..data_map import DataMap
+from ..file_map import FileMap
+from ..import_item import ImportItem
+from ..entity import Entity
+
+
+class ZenodoImportProvider(ImportProvider):
+    _zenodo_regex = None
+
+    def __init__(self):
+        super().__init__("Zenodo")
+        self.url_to_api = {
+            "zenodo.org": "https://zenodo.org/api/records/",
+            "data.caltech.edu": "https://data.caltech.edu/api/record/",
+        }
+
+    @staticmethod
+    def create_regex():
+        return re.compile(
+            r"^http(s)?://(zenodo.org/record|data.caltech.edu/records)/.*$"
+        )
+
+    def getDatasetUID(self, doc: object, user: object) -> str:
+        try:
+            identifier = doc["meta"]["identifier"]  # if root of ds, it should have it
+        except (KeyError, TypeError):
+            if "folderId" in doc:
+                path_to_root = Item().parentsToRoot(doc, user=user)
+            else:
+                path_to_root = Folder().parentsToRoot(doc, user=user)
+            # Collection{WT Catalog} / Folder{WT Catalog} / Folder{Zenodo ds root}
+            identifier = path_to_root[2]["object"]["meta"]["identifier"]
+        return identifier
+
+    def _get_record(self, raw_url):
+        url = urlparse(raw_url)
+        record_id = url.path.rsplit("/", maxsplit=1)[1]
+        req = Request(
+            self.url_to_api[url.netloc] + record_id,
+            headers={"accept": "application/vnd.zenodo.v1+json"},
+        )
+        resp = urlopen(req)
+        return json.loads(resp.read().decode("utf-8"))
+
+    @staticmethod
+    def _get_doi_from_record(record):
+        return "doi:" + record["doi"]
+
+    @staticmethod
+    def _get_title_from_record(record):
+        return record["metadata"]["title"] + "_rev{}".format(record["revision"])
+
+    def lookup(self, entity: Entity) -> DataMap:
+        record = self._get_record(entity.getValue())
+        size = sum((file_obj["size"] for file_obj in record["files"]))
+        return DataMap(
+            entity.getValue(),
+            size,
+            doi=self._get_doi_from_record(record),
+            name=self._get_title_from_record(record),
+            repository=self.getName(),
+        )
+
+    def listFiles(self, entity: Entity) -> FileMap:
+        stack = []
+        top = None
+        for item in self._listRecursive(entity.getUser(), entity.getValue(), None):
+            if item.type == ImportItem.FOLDER:
+                if len(stack) == 0:
+                    fm = FileMap(item.name)
+                else:
+                    fm = stack[-1].addChild(item.name)
+                stack.append(fm)
+            elif item.type == ImportItem.END_FOLDER:
+                top = stack.pop()
+            elif item.type == ImportItem.FILE:
+                stack[-1].addFile(item.name, item.size)
+        return top
+
+    @staticmethod
+    def _files_to_hierarchy(files):
+        hierarchy = {"+files+": []}
+
+        for file_obj in files:
+            temp = hierarchy
+            for subdir in pathlib.Path(file_obj["key"]).parts[:-1]:
+                if subdir not in temp:
+                    temp[subdir] = {"+files+": []}
+                temp = temp[subdir]
+            temp["+files+"].append(
+                {
+                    "size": file_obj["size"],
+                    "name": file_obj["key"].rsplit("/", maxsplit=1)[1],
+                    "url": file_obj["links"]["self"],
+                    "mimeType": "application/octet-stream",
+                }
+            )
+        return hierarchy
+
+    def _listRecursive(
+        self, user, pid: str, name: str, base_url: str = None, progress=None
+    ):
+        record = self._get_record(pid)
+
+        def _recurse_hierarchy(hierarchy):
+            files = hierarchy.pop("+files+")
+            for obj in files:
+                yield ImportItem(
+                    ImportItem.FILE,
+                    obj["name"],
+                    size=obj["size"],
+                    mimeType=obj["mimeType"],
+                    url=obj["url"],
+                )
+            for folder in hierarchy.keys():
+                yield ImportItem(ImportItem.FOLDER, name=folder)
+                yield from _recurse_hierarchy(hierarchy[folder])
+                yield ImportItem(ImportItem.END_FOLDER)
+
+        meta = {k: record[k] for k in ["conceptdoi", "conceptrecid"]}
+        meta["subProvider"] = urlparse(pid).netloc
+
+        yield ImportItem(
+            ImportItem.FOLDER,
+            name=self._get_title_from_record(record),
+            identifier=self._get_doi_from_record(record),
+            meta=meta,
+        )
+        yield from _recurse_hierarchy(self._files_to_hierarchy(record["files"]))
+        yield ImportItem(ImportItem.END_FOLDER)


### PR DESCRIPTION
This PR allows to register resources from Zenodo.

### Implementation notes
* Datasets in Zenodo have versions (revisions). Each of them has a unique DOI you can use to register it. A collection of revisions can be referenced by a single "Concept" DOI, which AFAICT points to the latest revision by default. In order to differentiate between versions, we append `_rev{}` to root folder in the WT Catalog. ConceptDOI is stored as a metadata keyword.
* Zenodo provider supports multiple targets (e.g. "zenodo.org", "sandbox.zenodo.org") which can be configured via plugin's config page. Specific target that was used to register data, is now being stored as metadata entry in the root folder. (_subProvider_)
* The fact that the folder structure in Zenodo is just a labeling, i.e. there are no actual folders you can download, nor there's API that would emulate that, `GET /tale/{id}/manifest?expandFolders=False` on a Tale using structured dataset will fail.

### How to test?
1. Deploy and try to import a few datasets from Zenodo :) Try at least:
   * dataset with multiple files
   * dataset with folder structure
   * dataset with a single (or no) revision(s)
   * multiple versions of a dataset
   * concept DOI

I'm deliberately not providing any particular DOIs so that we don't test using the same data. Sorry!
