### PR TITLE
Include repository information in Tale's publishInfo

### DIFF
--- a/server/schema/misc.py
+++ b/server/schema/misc.py
@@ -15,12 +15,20 @@ publishInfoSchema = {
         },
         "uri": {
             "type": ["string", "null"],
-            "description": "A URI pointing to the location of the published " "Tale.",
+            "description": "A URI pointing to the location of the published Tale.",
         },
         "date": {
             "type": "string",
             "format": "date-time",
             "description": "Date Tale was published.",
+        },
+        "repository": {
+            "type": "string",
+            "description": "The repository where Tale was published.",
+        },
+        "repository_id": {
+            "type": "string",
+            "description": "The repository specific id assigned to the publication.",
         },
     },
     "required": ["pid", "uri", "date"],


### PR DESCRIPTION
As a convenience this adds `repository` and `repository_id` to *Tale's* `publishedInfo`. The former will match whatever is used as an argument to `PUT /tale/:id/publish?repository=...`, the latter will be repository specific identifier.

This will help to trace back to published Tales in cases when DOI resolution is not possible, e.g. sandbox Zenodo, Dev MetacatUI etc.