### PR TITLE
Return a "friendly" repository name in GET /repository. Fixes #374

### DIFF
--- a/plugin_tests/repository_test.py
+++ b/plugin_tests/repository_test.py
@@ -6,7 +6,7 @@ from girder.models.user import User
 
 
 def setUpModule():
-    base.enabledPlugins.append('wholetale')
+    base.enabledPlugins.append("wholetale")
     base.startServer()
 
 
@@ -15,7 +15,6 @@ def tearDownModule():
 
 
 class RepositoryTestCase(base.TestCase):
-
     def setUp(self):
         super(RepositoryTestCase, self).setUp()
         users = (
@@ -40,37 +39,42 @@ class RepositoryTestCase(base.TestCase):
 
     def _lookup(self, url, path):
         return self.request(
-            path='/repository/' + path, method='GET',
-            params={'dataId': json.dumps([url])}
+            path="/repository/" + path,
+            method="GET",
+            params={"dataId": json.dumps([url])},
         )
 
     def testErrorHandling(self):
-        for path in ('lookup', 'listFiles'):
-            resp = self._lookup('https://doi.org/10.7910/DVN/blah', path)
+        for path in ("lookup", "listFiles"):
+            resp = self._lookup("https://doi.org/10.7910/DVN/blah", path)
             self.assertStatus(resp, 400)
-            self.assertEqual(resp.json, {
-                'message': 'Id "https://doi.org/10.7910/DVN/blah" was '
-                           'categorized as DOI, but its resolution failed.',
-                'type': 'rest'
-            })
+            self.assertEqual(
+                resp.json,
+                {
+                    "message": 'Id "https://doi.org/10.7910/DVN/blah" was '
+                    "categorized as DOI, but its resolution failed.",
+                    "type": "rest",
+                },
+            )
 
-            resp = self._lookup('https://wrong.url', path)
+            resp = self._lookup("https://wrong.url", path)
             self.assertStatus(resp, 400)
-            if path == 'lookup':
-                self.assertTrue(resp.json['message'].startswith(
-                    'Lookup for "https://wrong.url" failed with:'
-                ))
+            if path == "lookup":
+                self.assertTrue(
+                    resp.json["message"].startswith(
+                        'Lookup for "https://wrong.url" failed with:'
+                    )
+                )
             else:
-                self.assertTrue(resp.json['message'].startswith(
-                    'Listing files at "https://wrong.url" failed with:'
-                ))
+                self.assertTrue(
+                    resp.json["message"].startswith(
+                        'Listing files at "https://wrong.url" failed with:'
+                    )
+                )
 
     def testPublishers(self):
         # This assumes some defaults that probably should be set here instead...
-        resp = self.request(
-            path="/repository",
-            method="GET",
-        )
+        resp = self.request(path="/repository", method="GET")
         self.assertStatusOk(resp)
         self.assertEqual(resp.json, [])
 
@@ -81,17 +85,21 @@ class RepositoryTestCase(base.TestCase):
                 "access_token": "dataone_token",
                 "resource_server": "cn-stage-2.test.dataone.org",
                 "token_type": "dataone",
-            },
+            }
         ]
         self.user = User().save(self.user)
 
-        resp = self.request(
-            path="/repository",
-            method="GET",
-            user=self.user,
-        )
+        resp = self.request(path="/repository", method="GET", user=self.user)
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json, ["https://dev.nceas.ucsb.edu/knb/d1/mn"])
+        self.assertEqual(
+            resp.json,
+            [
+                {
+                    "name": "DataONE Dev",
+                    "repository": "https://dev.nceas.ucsb.edu/knb/d1/mn",
+                }
+            ],
+        )
 
         # Pretend we have authorized with DataONE and Zenodo
         self.user["otherTokens"].append(
@@ -104,13 +112,15 @@ class RepositoryTestCase(base.TestCase):
         )
         self.user = User().save(self.user)
 
-        resp = self.request(
-            path="/repository",
-            method="GET",
-            user=self.user,
-        )
+        resp = self.request(path="/repository", method="GET", user=self.user)
         self.assertStatusOk(resp)
         self.assertEqual(
             resp.json,
-            ["https://dev.nceas.ucsb.edu/knb/d1/mn", "sandbox.zenodo.org"],
+            [
+                {
+                    "name": "DataONE Dev",
+                    "repository": "https://dev.nceas.ucsb.edu/knb/d1/mn",
+                },
+                {"name": "Zenodo Sandbox", "repository": "sandbox.zenodo.org"},
+            ],
         )

--- a/server/constants.py
+++ b/server/constants.py
@@ -89,10 +89,15 @@ class SettingDefault:
         ],
         PluginSettings.ZENODO_EXTRA_HOSTS: [],
         PluginSettings.PUBLISHER_REPOS: [
-            {"repository": "sandbox.zenodo.org", "auth_provider": "zenodo"},
+            {
+                "repository": "sandbox.zenodo.org",
+                "auth_provider": "zenodo",
+                "name": "Zenodo Sandbox",
+            },
             {
                 "repository": "https://dev.nceas.ucsb.edu/knb/d1/mn",
                 "auth_provider": "dataonestage2",
+                "name": "DataONE Dev",
             },
         ],
     }

--- a/server/rest/repository.py
+++ b/server/rest/repository.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from operator import itemgetter
+
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.api.docs import addModel
@@ -105,13 +107,10 @@ class Repository(Resource):
         if not user:
             return []
 
-        publishers = {
-            entry["repository"]: entry["auth_provider"]
-            for entry in Setting().get(PluginSettings.PUBLISHER_REPOS)
-        }
-
         targets = []
-        for repository, publisher in publishers.items():
+        for entry in Setting().get(PluginSettings.PUBLISHER_REPOS):
+            repository = entry["repository"]
+            publisher = entry["auth_provider"]
             if publisher.startswith("dataone"):
                 key = "provider"  # Dataone
                 value = publisher
@@ -123,6 +122,6 @@ class Repository(Resource):
                 (_ for _ in user.get("otherTokens", []) if _.get(key) == value), None
             )
             if token:
-                targets.append(repository)
+                targets.append({"repository": repository, "name": entry["name"]})
 
-        return sorted(targets)
+        return sorted(targets, key=itemgetter("name"))

--- a/server/schema/misc.py
+++ b/server/schema/misc.py
@@ -269,7 +269,7 @@ repository_to_provider_schema = {
         "$id": "#/items",
         "type": "object",
         "title": "The Repository to Auth Provider Schema",
-        "required": ["repository", "auth_provider"],
+        "required": ["repository", "auth_provider", "name"],
         "properties": {
             "repository": {
                 "$id": "#/items/properties/repository",
@@ -285,6 +285,14 @@ repository_to_provider_schema = {
                 "title": "The name of the auth provider",
                 "default": "",
                 "examples": ["zenodo"],
+                "pattern": "^(.*)$",
+            },
+            "name": {
+                "$id": "#/items/properties/name",
+                "type": "string",
+                "title": "A human-readible name of the repository",
+                "default": "",
+                "examples": ["Zenodo Sandbox"],
                 "pattern": "^(.*)$",
             },
         },


### PR DESCRIPTION
## How to test?

1. Connect "DataONE Dev" and Zenodo (sandbox) accounts
2. Hit `GET /repository` and confirm it returns:

```
[
  {
    "name": "DataONE Dev",
    "repository": "https://dev.nceas.ucsb.edu/knb/d1/mn"
  },
  {
    "name": "Zenodo Sandbox",
    "repository": "sandbox.zenodo.org"
  }
]
```