### PR TITLE
Validate Tale's dataSet. Fixes #372

### DIFF
--- a/plugin_tests/basic_test.py
+++ b/plugin_tests/basic_test.py
@@ -159,4 +159,4 @@ class WholeTaleTestCase(base.TestCase):
             path='/folder/{_id}/dataset'.format(**f1), user=self.user)
         self.assertStatusOk(resp)
         self.assertEqual({_['mountPoint'] for _ in resp.json},
-                         {'/i1', '/i2', '/f3/i1', '/f3/i2'})
+                         {'i1', 'i2', 'f3/i1', 'f3/i2'})

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -195,9 +195,13 @@ def listFolder(self, folder, params):
 def getDataSet(self, folder, params):
     modelFolder = self.model('folder')
 
-    def _getPath(folder, user, path='/'):
+    def _getPath(folder, user, path=''):
         dataSet = [
-            {'itemId': item['_id'], 'mountPoint': path + item['name']}
+            {
+                'itemId': item['_id'],
+                'mountPoint': path + item['name'],
+                '_modelType': 'item',
+            }
             for item in modelFolder.childItems(folder=folder)
         ]
         for childFolder in modelFolder.childFolders(

--- a/server/schema/misc.py
+++ b/server/schema/misc.py
@@ -107,7 +107,7 @@ dataSetItemSchema = {
             "description": "Either a Girder item or a Girder folder",
         },
         "itemId": {
-            "type": "string",
+            # TODO: Can't enforce type cause it may be ObjectId
             "description": "ID of a Girder item or a Girder folder",
         },
         "mountPath": {

--- a/server/schema/misc.py
+++ b/server/schema/misc.py
@@ -115,7 +115,7 @@ dataSetItemSchema = {
             "description": "An absolute path where the item/folder are mounted in the EFS",
         },
     },
-    "required": ["itemId", "mountPath"],
+    "required": ["itemId", "mountPath", "_modelType"],
 }
 
 dataSetSchema = {


### PR DESCRIPTION
Perform some sanity checks on Tale's `dataSet`

### How to test?
1. Register any dataset (e.g. 10.5065/D6862DM8), create a Tale, add "Humans and ..." folder to dataSet using Run > External Data > "+". Note your Tale's id, it will come handy in step 2.
2. Using Swagger, modify dataSet `_modelType` from folder to item. The easiest way of doing that:
`GET /tale/:id`, copy and paste to `PUT /tale/:id`, change the field manually.
3. You should get 400 error for PUT