### PR TITLE
Look for view endpoint in dataone data registration

### DIFF
--- a/plugin_tests/dataone_register_test.py
+++ b/plugin_tests/dataone_register_test.py
@@ -78,6 +78,11 @@ class TestDataONERegister(base.TestCase):
         res = find_initial_pid(pid)
         self.assertEqual(res, 'abcdefg')
 
+        # Test that the regex works for full 'view' urls
+        pid = 'https://test.arcticdata.io/view/urn:uuid:7e5e9f32-c3b6-448b-9ce0-5c5901d0c6ee'
+        res = find_initial_pid(pid)
+        self.assertEqual(res, 'urn:uuid:7e5e9f32-c3b6-448b-9ce0-5c5901d0c6ee')
+
         # Test that if nothing was found, the passed in path is returned
         bad_url = 'localhost_01'
         res = find_initial_pid(bad_url)

--- a/server/lib/dataone/register.py
+++ b/server/lib/dataone/register.py
@@ -160,14 +160,16 @@ def find_nonobsolete_resmaps(pids, base_url):
 
 def find_initial_pid(path):
     """
-    Extracts the pid from an arbitrary path to a DataOne object.
+    Takes a string that *should* have a DatONE identifier in it and returns the identifier.
+    It first checks against the most popular and common DataONE deployments and then broadens
+    the search to try to match any CN or MN.
+    If an ID wasn't found, the path passed in is returned.
     Supports:
        - HTTP & HTTPS
-       - The MetacatUI landing page (#view)
-       - The D1 v2 Object URI (/object)
-       - The D1 v2 Resolve URI (/resolve)
+       - MetacatUI landing pages (#view)
+       - The coordinating node resolve endpoint (/resolve)
 
-    :param path:
+    :param path: The string the should contain an identifier
     :type path: str
     :return: The object's pid, or the original path if one wasn't found
     :rtype: str
@@ -188,6 +190,8 @@ def find_initial_pid(path):
         return path.split("resolve/", 1)[1]
     elif doi is not None:
         return 'doi:{}'.format(doi.group())
+    elif re.search(r'view', path):
+        return path.split("view/", 1)[1]
     else:
         return path
 


### PR DESCRIPTION
During data registration from DataONE, we parse the user's input to locate the identifier/doi. For example, the user can pass in `https://search-demo.dataone.org/view/urn:uuid:34d66cfa-0798-493a-b264-ebf529fb5c12`-we want to extract `urn:uuid:34d66cfa-0798-493a-b264-ebf529fb5c12`.

We hit most cases, but miss links that hit the `view` endpoint on different domains. I added a last check to see if 

To Test:
1. Try to "analyze in WT" with [this link](https://girder.local.wholetale.org/api/v1/integration/dataone?uri=https://test.arcticdata.io/view/urn:uuid:429dac8f-9153-400b-ac75-a45e4eb6085a&title=arcticdata%20R%20package%20test&api=https://cn-stage.test.dataone.org/cn/v2), coming from test.arcticdata.io
2. Note that you won't get the dataset
3. Check this branch out
4. Visit the same link
5. Note that you get the dataset

