### PR TITLE
Use Coordinating Node to Register Data

### DIFF
--- a/server/lib/dataone/provider.py
+++ b/server/lib/dataone/provider.py
@@ -113,14 +113,12 @@ class DataOneImportProvider(ImportProvider):
         yield ImportItem(ImportItem.END_FOLDER)
         logger.debug('Finished registering dataset')
 
-    def _addResolutionUrls(self, list, base_url):
+    def _addResolutionUrls(self, docs, base_url):
         """
-        The download url is different between DataONE production and DataONE dev.
-        Check which place we're registering from and set the url section.
+        Combines the base coordinating node URL with the resolve endpoint and identifier
+        :param docs: List of metadata/data objects
+        :param base_url: The coordinating node base URL (including the version)
+        :return: None
         """
-        if base_url == DataONELocations.prod_cn:
-            url_insert = 'resolve'
-        else:
-            url_insert = 'object'
-        for d in list:
-            d['url'] = "{}/{}/{}".format(base_url, url_insert, d['identifier'])
+        for d in docs:
+            d['url'] = "{}/{}/{}".format(base_url, 'resolve', d['identifier'])


### PR DESCRIPTION
The coordinating-member node relations can be confusing at times. When we register data from DataONE, it's common to have the member node or the coordinating node along with the dataset identifier.

When we have the member node, we use its `object/` endpoint to access the bytes of the file. When using the coordinating node, we would use the `resolve/` endpoint to get the bytes of the file (I think resolve will redirect you to the proper member node).

The code that was doing the above runs into issues when we use any coordinating node that isn't production by tacking the `object/` endpoint on it.

Instead of worrying about whether we're getting a member node or a coordinating node, I've switched the Analyze in Whole Tale feature on the DataONE side to always send the coordinating node, regardless if it's production or development. This gives more robust data registration (we're more likely to get the bytes), gets rid of this confusing bit of logic, and standardizes the use of coordinating nodes over member nodes during registration.

Note that data submitted to the member node needs to get harvested by the coordinating node, which can take time. A common problem that people have with DataONE is trying to use the coordinating node before it harvested the new content. This means if you publish a Tale, it might take a few minutes for the coordinating node to pick up the changes.


#### DEV NCEAS Test
1. Deploy this along with the latest dashboard
2. Visit [here](https://girder.local.wholetale.org/api/v1/integration/dataone?uri=https://dev.nceas.ucsb.edu/view/doi:10.5072/FK20C5248N&title=Fire%20influences%20on%20forest%20recovery%20and%20associated%20climate%20feedbacks%20in%20Siberian%20Larch%20Forests%2C%20Russia&api=https://cn-stage-2.test.dataone.org/cn/v2)
3. Create the Tale
4. Navigate to external data
5. Download the dataset
6. Open one of the files and confirm that the URL inside resolves to bytes

#### DEV ADC Test
1. Visit [here](https://dashboard.local.wholetale.org/browse?uri=https%3A%2F%2Ftest.arcticdata.io%2Fview%2Furn%3Auuid%3A33153550-0cbc-11ea-aa11-11ea070d596a&name=Daily+Toolik+Naturalist+Journal+-+Birds&api=https%3A%2F%2Fcn-stage.test.dataone.org%2Fcn%2Fv2)
2. Do steps 3-6 from above (or try to access the file in the IDE)

#### Production DataONE Test
1. Visit [here](https://girder.local.wholetale.org/api/v1/integration/dataone?uri=urn:uuid:4ac97c2d-d3af-4430-96d4-0873b98e8aa8&title=A%20global%20database%20of%20long-term%20changes%20in%20insect%20assemblages&api=https://cn.dataone.org/cn/v2)
2. Do steps 3-6 from above (or try to access the file in the IDE)


Fixes #386 