### PR TITLE
Don't recreate Tales in AinWT by default if they're already imported

### DIFF
--- a/plugin_tests/zenodo_test.py
+++ b/plugin_tests/zenodo_test.py
@@ -348,6 +348,7 @@ class ZenodoHarversterTestCase(base.TestCase):
                 "record_id": ["430905"],
                 "resource_server": ["sandbox.zenodo.org"],
                 "token": ["{girderToken}"],
+                "force": ["False"],
             },
         )
 

--- a/server/lib/import_providers.py
+++ b/server/lib/import_providers.py
@@ -47,7 +47,7 @@ class ImportProvider:
         """Given a registered object, return a URI for it"""
         raise NotImplementedError()
 
-    def import_tale(self, dataId):
+    def import_tale(self, dataId: str, user: object, force=False) -> object:
         """Given a dataId import dataset as Tale"""
         raise NotImplementedError()
 

--- a/server/lib/integration_utils.py
+++ b/server/lib/integration_utils.py
@@ -1,0 +1,40 @@
+import cherrypy
+import os
+from urllib.parse import urlparse, urlunparse, urlencode
+from girder.plugins.oauth.rest import OAuth as OAuthResource
+
+from ..models.tale import Tale
+
+
+def autologin(args=None):
+    args = {k: v for (k, v) in args.items() if v is not None}
+    redirect = cherrypy.request.base + cherrypy.request.app.script_name
+    redirect += cherrypy.request.path_info + "?"
+    redirect += urlencode(args)
+    redirect += "&token={girderToken}"
+
+    oauth_providers = OAuthResource().listProviders(params={"redirect": redirect})
+    raise cherrypy.HTTPRedirect(oauth_providers["Globus"])  # TODO: hardcoded var
+
+
+def redirect_if_tale_exists(user, token, doi):
+    existing_tale_id = Tale().findOne(
+        query={
+            "creatorId": user["_id"],
+            "relatedIdentifiers.identifier": {"$eq": doi},
+            "relatedIdentifiers.relation": {"$in": ["IsDerivedFrom", "Cites"]},
+        },
+        fields={"_id"},
+    )
+    if existing_tale_id:
+        # TODO: Make base url a plugin setting, defaulting to dashboard.<domain>
+        dashboard_url = os.environ.get(
+            "DASHBOARD_URL", "https://dashboard.wholetale.org"
+        )
+        location = urlunparse(
+            urlparse(dashboard_url)._replace(
+                path="/run/{}".format(existing_tale_id["_id"]),
+                query="token={}".format(token["_id"]),
+            )
+        )
+        raise cherrypy.HTTPRedirect(location)

--- a/server/lib/zenodo/integration.py
+++ b/server/lib/zenodo/integration.py
@@ -20,9 +20,16 @@ from .. import IMPORT_PROVIDERS
     .param("record_id", "ID", required=False)
     .param("resource_server", "resource server", required=False)
     .param("environment", "The environment that should be selected.", required=False)
+    .param(
+        "force",
+        "If True, create a new Tale regardless of the fact it was previously imported.",
+        required=False,
+        dataType="boolean",
+        default=False,
+    )
 )
 @boundHandler()
-def zenodoDataImport(self, doi, record_id, resource_server, environment):
+def zenodoDataImport(self, doi, record_id, resource_server, environment, force):
     """Fetch and unpack a Zenodo record"""
     if not (doi or record_id):
         raise RestException("You need to provide either 'doi' or 'record_id'")
@@ -54,7 +61,7 @@ def zenodoDataImport(self, doi, record_id, resource_server, environment):
     url = "https://{}/record/{}".format(resource_server, record_id)
     provider = IMPORT_PROVIDERS.providerMap["Zenodo"]
     try:
-        tale = provider.import_tale(url, user)
+        tale = provider.import_tale(url, user, force=force)
     except GirderException as exc:
         raise RestException(
             "Failed to import Tale. Server returned: '{}'".format(exc.message)

--- a/server/lib/zenodo/provider.py
+++ b/server/lib/zenodo/provider.py
@@ -77,7 +77,10 @@ class ZenodoImportProvider(ImportProvider):
         # dataId in this case == record["links"]["record_html"]
         record = self._get_record(dataId)
         existing_tale_id = Tale().findOne(
-            query={"creatorId": user["_id"], "publishInfo.pid": {"$eq": record["doi"]}},
+            query={
+                "creatorId": user["_id"],
+                "publishInfo.pid": {"$eq": self._get_doi_from_record(record)},
+            },
             fields={"_id"},
         )
         if existing_tale_id and not force:
@@ -113,7 +116,10 @@ class ZenodoImportProvider(ImportProvider):
         ]
 
         relatedIdentifiers = [
-            {"relation": "IsDerivedFrom", "identifier": self._get_doi_from_record(record)}
+            {
+                "relation": "IsDerivedFrom",
+                "identifier": self._get_doi_from_record(record),
+            }
         ]
         return Tale().createTaleFromStream(
             stream_zipfile,

--- a/server/lib/zenodo/provider.py
+++ b/server/lib/zenodo/provider.py
@@ -73,9 +73,16 @@ class ZenodoImportProvider(ImportProvider):
     def _get_doi_from_record(record):
         return "doi:" + record["doi"]
 
-    def import_tale(self, dataId, user):
+    def import_tale(self, dataId, user, force=False):
         # dataId in this case == record["links"]["record_html"]
         record = self._get_record(dataId)
+        existing_tale_id = Tale().findOne(
+            query={"creatorId": user["_id"], "publishInfo.pid": {"$eq": record["doi"]}},
+            fields={"_id"},
+        )
+        if existing_tale_id and not force:
+            return Tale().load(existing_tale_id["_id"], user=user)
+
         if not self._is_tale(record):
             raise ValueError(
                 "{} doesn't look like a Tale.".format(record["links"]["record_html"])


### PR DESCRIPTION
In order to prevent a situation when user creates multiple copies of a Tale by either clicking AinWT integration or Zenodo import link, import routes now check if such Tale already exists using info from `related_identifiers`.

### How to test?
1. Follow those links more than once:
   1. [Zenodo](https://girder.local.wholetale.org/api/v1/integration/zenodo?doi=10.5281%2Fzenodo.3620778&resource_server=zenodo.org)
   1. [Dataverse](https://girder.local.wholetale.org/api/v1/integration/dataverse?datasetPid=doi%3A10.7910%2FDVN%2F3MJ7IR&siteUrl=https%3A%2F%2Fdataverse.harvard.edu)
   1. [DataOne](https://girder.local.wholetale.org/api/v1/integration/dataone?environment=RStudio&force=False&uri=https%3A%2F%2Fsearch.dataone.org%2Fview%2Fdoi%3A10.18739%2FA2VQ2S94D&title=Fire+influences+on+forest+recovery+and+associated+climate+feedbacks+in+Siberian+Larch+Forests%2C+Russia)
1. Make sure you end up with only 3 Tales
1. (optional) add `&force=true` to any of the links above and verify that additional Tale is created, e.g.:
   1. [Zenodo (force)](https://girder.local.wholetale.org/api/v1/integration/zenodo?doi=10.5281%2Fzenodo.3620778&force=true&resource_server=zenodo.org)

