### PR TITLE
Remove readme from manifest

### DIFF
--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -401,7 +401,6 @@ class ManifestTestCase(base.TestCase):
                 "size": 1005007,
             },
             {"uri": "../LICENSE", "schema:license": "CC-BY-4.0"},
-            {"uri": "../README.md", "@type": "schema:HowTo"},
         ]
         from operator import itemgetter
 

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -48,7 +48,7 @@ class Manifest:
         self.add_tale_records()
         # Add any external datasets to the manifest
         self.add_dataset_records()
-        self.add_system_files()
+        self.add_license_record()
 
     publishers = {
         "DataONE":
@@ -387,18 +387,15 @@ class Manifest:
             bundle['filename'] = filename
         return bundle
 
-    def add_system_files(self):
+    def add_license_record(self):
         """
-        Add records for files that we inject (README, LICENSE, etc)
+        Adds a record for the License file. When exporting to a bag, this gets placed
+        in their data/ folder.
         """
-
         self.manifest['aggregates'].append({'uri': '../LICENSE',
                                             'schema:license':
                                                 self.tale.get('licenseSPDX',
                                                               WholeTaleLicense.default_spdx())})
-
-        self.manifest['aggregates'].append({'uri': '../README.md',
-                                            '@type': 'schema:HowTo'})
 
 
 def clean_workspace_path(tale_id, path):


### PR DESCRIPTION
This PR removes the README.md record from the manifest. It was inconsistent with what we do for other bag-level files (run-local.sh).


To Test:
1. Check this branch out
1. Check out the branch in [this](https://github.com/whole-tale/gwvolman/pull/104) gwvolman PR
1. Deploy
1. Export a Tale
1. Open metadata/manifest.json
1. Confirm you don't see the README
1. Confirm that you see the README.md file in the bag root
1. Publish to DataONE development
1. You should see the README file in the file list, and a blurb about it towards the bottom of the page

This shouldn't effect Zendo publishing in any way, but I went ahead and published to Zenodo sandox and things look fine.

This should obsolete https://github.com/whole-tale/girder_wholetale/pull/400