### PR TITLE
Validate apikeys before storing them. Fixes #404

### DIFF
--- a/plugin_tests/accounts_test.py
+++ b/plugin_tests/accounts_test.py
@@ -26,6 +26,16 @@ AUTH_PROVIDERS = [
         "docs_href": "https://zenodo.org/account/settings/applications/tokens/new/",
         "targets": [],
     },
+    {
+        "name": "dataverse",
+        "logo": "",
+        "fullName": "Dataverse",
+        "tags": ["data", "publish"],
+        "url": "",
+        "type": "apikey",
+        "docs_href": "https://dataverse.org/",
+        "targets": [],
+    },
 ]
 
 DATAONE_PROVIDER = {
@@ -38,7 +48,10 @@ DATAONE_PROVIDER = {
     "state": "unauthorized",
 }
 
-APIKEY_GROUPS = [{"name": "zenodo", "targets": ["sandbox.zenodo.org", "zenodo.org"]}]
+APIKEY_GROUPS = [
+    {"name": "zenodo", "targets": ["sandbox.zenodo.org", "zenodo.org"]},
+    {"name": "dataverse", "targets": ["demo.dataverse.org"]},
+]
 
 
 @httmock.urlmatch(
@@ -463,6 +476,69 @@ class ExternalAccountsTestCase(base.TestCase):
             PluginSettings.EXTERNAL_APIKEY_GROUPS,
         ):
             Setting().set(key, SettingDefault.defaults[key])
+
+    def test_dataverse_apikey(self):
+        from girder.plugins.wholetale.constants import SettingDefault, PluginSettings
+
+        Setting().set(PluginSettings.EXTERNAL_AUTH_PROVIDERS, [AUTH_PROVIDERS[2]])
+        Setting().set(PluginSettings.EXTERNAL_APIKEY_GROUPS, APIKEY_GROUPS)
+
+        @httmock.urlmatch(
+            scheme="https",
+            netloc="demo.dataverse.org",
+            path="/api/users/token",
+            method="GET",
+        )
+        def mockDataverseVerification(url, request):
+            if request.headers["X-Dataverse-key"].endswith("valid_key"):
+                return httmock.response(
+                    status_code=200,
+                    content={"id": 123},
+                    headers={},
+                    reason=None,
+                    elapsed=5,
+                    request=request,
+                    stream=False,
+                )
+            else:
+                return httmock.response(
+                    status_code=401,
+                    content={"cause": "reason"},
+                    headers={},
+                    reason="Some reason",
+                    elapsed=5,
+                    request=request,
+                    stream=False,
+                )
+
+        with httmock.HTTMock(mockDataverseVerification, mockOtherRequests):
+            resp = self.request(
+                method="POST",
+                path="/account/dataverse/key",
+                params={"resource_server": "demo.dataverse.org", "key": "key"},
+                user=self.user,
+            )
+            self.assertStatus(resp, 400)
+            self.assertEqual(
+                resp.json["message"], "Key 'key' is not valid for 'demo.dataverse.org'"
+            )
+
+            resp = self.request(
+                method="POST",
+                path="/account/dataverse/key",
+                params={"resource_server": "demo.dataverse.org", "key": "valid_key"},
+                user=self.user,
+            )
+            self.assertStatusOk(resp)
+
+        # Return to defaults
+        for key in (
+            PluginSettings.EXTERNAL_AUTH_PROVIDERS,
+            PluginSettings.EXTERNAL_APIKEY_GROUPS,
+        ):
+            Setting().set(key, SettingDefault.defaults[key])
+        self.user["otherTokens"] = []
+        User().save(self.user)
 
     def test_adding_apikeys(self):
         from girder.plugins.wholetale.constants import SettingDefault, PluginSettings

--- a/server/lib/__init__.py
+++ b/server/lib/__init__.py
@@ -15,9 +15,12 @@ from .resolvers import Resolvers, DOIResolver, ResolutionException
 from .import_providers import ImportProviders
 from .http_provider import HTTPImportProvider
 from .null_provider import NullImportProvider
+from .dataone.auth import DataONEVerificator
 from .dataone.provider import DataOneImportProvider
+from .dataverse.auth import DataverseVerificator
 from .dataverse.provider import DataverseImportProvider
 from .globus.globus_provider import GlobusImportProvider
+from .zenodo.auth import ZenodoVerificator
 from .zenodo.provider import ZenodoImportProvider
 
 
@@ -33,6 +36,16 @@ IMPORT_PROVIDERS.addProvider(DataOneImportProvider())
 IMPORT_PROVIDERS.addProvider(HTTPImportProvider())
 # just throws exceptions
 IMPORT_PROVIDERS.addProvider(NullImportProvider())
+
+
+Verificators = {
+    "zenodo": ZenodoVerificator,
+    "dataverse": DataverseVerificator,
+    "dataoneprod": DataONEVerificator,
+    "dataonedev": DataONEVerificator,
+    "dataonestage": DataONEVerificator,
+    "dataonestage2": DataONEVerificator,
+}
 
 
 def pids_to_entities(pids, user=None, base_url=None, lookup=True):

--- a/server/lib/dataone/auth.py
+++ b/server/lib/dataone/auth.py
@@ -1,0 +1,7 @@
+class DataONEVerificator:
+    def __init__(self, resource_server, key):
+        self.key = key
+        self.resource_server = resource_server
+
+    def verify(self):
+        pass

--- a/server/lib/dataverse/auth.py
+++ b/server/lib/dataverse/auth.py
@@ -1,0 +1,21 @@
+import requests
+from girder.exceptions import RestException
+
+
+class DataverseVerificator:
+    def __init__(self, resource_server, key):
+        self.key = key
+        self.resource_server = resource_server
+        self.token_url = "https://{}/api/users/token".format(resource_server)
+
+    def verify(self):
+        headers = {
+            "X-Dataverse-key": "{}".format(self.key),
+        }
+        try:
+            r = requests.get(self.token_url, headers=headers)
+            r.raise_for_status()
+        except requests.exceptions.HTTPError:
+            raise RestException(
+                "Key '{}' is not valid for '{}'".format(self.key, self.resource_server)
+            )

--- a/server/lib/zenodo/auth.py
+++ b/server/lib/zenodo/auth.py
@@ -1,0 +1,29 @@
+import requests
+from girder.exceptions import RestException
+
+
+class ZenodoVerificator:
+    def __init__(self, resource_server, key):
+        self.key = key
+        self.resource_server = resource_server
+        self.create_deposition_url = (
+            "https://" + resource_server + "/api/deposit/depositions"
+        )
+        self.delete_deposition_url = self.create_deposition_url + "/{}"
+
+    def verify(self):
+        headers = {
+            "Authorization": "Bearer {}".format(self.key),
+            "Content-Type": "application/json",
+        }
+        try:
+            r = requests.post(self.create_deposition_url, data="{}", headers=headers)
+            r.raise_for_status()
+            r = requests.delete(
+                self.delete_deposition_url.format(r.json()["id"]), headers=headers
+            )
+            r.raise_for_status()
+        except requests.exceptions.HTTPError:
+            raise RestException(
+                "Key '{}' is not valid for '{}'".format(self.key, self.resource_server)
+            )

--- a/server/rest/account.py
+++ b/server/rest/account.py
@@ -13,6 +13,7 @@ from girder.plugins.oauth import constants as OAuthConstants
 from girder.plugins.oauth import providers
 
 from ..constants import PluginSettings
+from ..lib import Verificators
 
 
 class Account(Resource):
@@ -334,6 +335,8 @@ class Account(Resource):
 
         except KeyError:
             raise RestException('Unknown provider "%s".' % provider)
+
+        Verificators[provider](resource_server, key).verify()
 
         user_tokens = user.get("otherTokens", [])
         for i, user_token in enumerate(user_tokens):


### PR DESCRIPTION
## How to test?
1. Go to https://dashboard.local.wholetale.org/settings, open the Dev Console
1. Add zenodo/dataverse key that's invalid
1. Key should not be accepted, exception should be thrown in the console
1. Add a valid zenodo/dataverse key
1. Auth provider should be connected.