### PR TITLE
Export final env config and restore it properly during Tale's import

### DIFF
--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -630,7 +630,7 @@ class TaleTestCase(base.TestCase):
         self.assertEqual(resp.json['imageId'], str(image['_id']))
         self.assertEqual(resp.json['title'], title)
         self.assertEqual(resp.json['description'], description)
-        self.assertEqual(resp.json['config'], config)
+        self.assertEqual(resp.json['config'], {})
         self.assertEqual(resp.json['public'], public)
         self.assertEqual(resp.json['publishInfo'][0]['pid'], 'published_pid')
         self.assertEqual(resp.json['publishInfo'][0]['uri'], 'published_url')

--- a/server/lib/exporters/__init__.py
+++ b/server/lib/exporters/__init__.py
@@ -69,6 +69,7 @@ class TaleExporter:
             fields=['config', 'description', 'icon', 'iframe', 'name', 'tags'],
             level=AccessType.READ,
         )
+        self.image["config"].update(tale.get("config", {}))  # respect config precedence
         self.image.pop('_id')
         self.workspace = Folder().load(
             tale['workspaceId'], user=user, level=AccessType.READ

--- a/server/lib/exporters/__init__.py
+++ b/server/lib/exporters/__init__.py
@@ -1,3 +1,4 @@
+import copy
 from hashlib import sha256, md5
 from girder.utility import hash_state, ziputil
 from girder.constants import AccessType
@@ -69,7 +70,6 @@ class TaleExporter:
             fields=['config', 'description', 'icon', 'iframe', 'name', 'tags'],
             level=AccessType.READ,
         )
-        self.image["config"].update(tale.get("config", {}))  # respect config precedence
         self.image.pop('_id')
         self.workspace = Folder().load(
             tale['workspaceId'], user=user, level=AccessType.READ
@@ -85,6 +85,11 @@ class TaleExporter:
 
     def stream(self):
         raise NotImplementedError
+
+    def get_environment(self):
+        env = copy.deepcopy(self.image)
+        env["taleConfig"] = self.tale.get("config", {})
+        return env
 
     @staticmethod
     def stream_string(string):

--- a/server/lib/exporters/bag.py
+++ b/server/lib/exporters/bag.py
@@ -176,7 +176,7 @@ class BagTaleExporter(TaleExporter):
             (lambda: dump_checksums('sha256'), 'manifest-sha256.txt'),
             (
                 lambda: json.dumps(
-                    self.image,
+                    self.get_environment(),
                     indent=4,
                     cls=JsonEncoder,
                     sort_keys=True,

--- a/server/lib/exporters/native.py
+++ b/server/lib/exporters/native.py
@@ -10,7 +10,7 @@ class NativeTaleExporter(TaleExporter):
             'README.md': self.default_top_readme,
             'LICENSE': self.tale_license['text'],
             'metadata/environment.json': json.dumps(
-                self.image, indent=4, cls=JsonEncoder, sort_keys=True, allow_nan=False
+                self.get_environment(), indent=4, cls=JsonEncoder, sort_keys=True, allow_nan=False
             ),
         }
 

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -456,7 +456,7 @@ class Tale(AccessControlledModel):
             title=manifest["schema:name"],
             description=manifest["schema:description"],
             public=False,
-            config={},
+            config=environment.get("config", {}),
             icon=icon,
             illustration=manifest["schema:image"],
             authors=authors,

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -456,7 +456,7 @@ class Tale(AccessControlledModel):
             title=manifest["schema:name"],
             description=manifest["schema:description"],
             public=False,
-            config=environment.get("config", {}),
+            config=environment.get("taleConfig", {}),
             icon=icon,
             illustration=manifest["schema:image"],
             authors=authors,

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -142,14 +142,18 @@ class Tale(Resource):
             _['itemId'] for _ in taleObj['dataSet']
         }  # XOR between new and old dataSet
 
+        new_imageId = tale.pop("imageId")
+        if new_imageId != str(taleObj["imageId"]):
+            image = imageModel().load(
+                new_imageId, user=self.getCurrentUser(),
+                level=AccessType.READ, exc=True)
+            taleObj["imageId"] = image["_id"]
+            taleObj["config"] = {}  # Has to be reset, after image change
+            if "config" in tale:
+                tale.pop("config")
+
         for keyword in self._model.modifiableFields:
             try:
-                if keyword == 'imageId':
-                    image = imageModel().load(
-                        tale['imageId'], user=self.getCurrentUser(),
-                        level=AccessType.READ, exc=True)
-                    taleObj['imageId'] = image['_id']
-                    continue
                 taleObj[keyword] = tale.pop(keyword)
             except KeyError:
                 pass


### PR DESCRIPTION
With this change we can keep any modifications made to Tale's runtime (memLimit, runPath etc) during publish and properly restore it back.

### How to test?
1. Deploy this locally.
1. Import https://sandbox.zenodo.org/record/509115, run it and prepare to be amazed.