### PR TITLE
Force a sessionId to be stored as an ObjectId

### DIFF
--- a/plugin_tests/instance_test.py
+++ b/plugin_tests/instance_test.py
@@ -39,7 +39,7 @@ class FakeAsyncResult(object):
             nodeId='123456',
             mountPoint='/foo/bar',
             volumeName='blah_volume',
-            sessionId='sessionId',
+            sessionId='5ecece693fec11b4854a874d',
             instanceId=self.instanceId
         )
 

--- a/server/models/instance.py
+++ b/server/models/instance.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from bson import ObjectId
 import datetime
 import ssl
 import time
@@ -293,8 +294,9 @@ def finalizeInstance(event):
                 'url': url,
                 'status': InstanceStatus.RUNNING,
                 'containerInfo': containerInfo,
-                'sessionId': service.get('sessionId')
             })
+            if "sessionId" in service:
+                instance["sessionId"] = ObjectId(service["sessionId"])
         elif (
             status == JobStatus.ERROR
             and instance["status"] != InstanceStatus.ERROR  # noqa


### PR DESCRIPTION
Fixes one of the issues found during testing of `wt_versioning`. Since it went unnoticed that long, I think the only way to test it is via `girder-shell` and loading of a *Instance* object.