### PR TITLE
Fix tale title field name in buildImage

### DIFF
--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -323,7 +323,7 @@ class Tale(AccessControlledModel):
         resource = {
             'type': 'wt_build_image',
             'tale_id': tale['_id'],
-            'title_title': tale['title']
+            'tale_title': tale['title']
         }
 
         token = Token().createToken(user=user, days=0.5)


### PR DESCRIPTION
## Problem
Tale title is not displayed properly on rebuild notifications.

## Approach
Fix typo in `buildImage` in one of the field names