### PR TITLE
Track the date of the users' last login

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -3,6 +3,7 @@
 
 import base64
 import copy
+import datetime
 import jsonschema
 import os
 import six
@@ -444,6 +445,7 @@ def store_other_globus_tokens(event):
         else:
             user_tokens.append(token)
     user["otherTokens"] = user_tokens
+    user["lastLogin"] = datetime.datetime.utcnow()
     User().save(user)
 
 
@@ -493,7 +495,7 @@ def load(info):
     info['apiRoot'].user.route('PUT', ('settings',), setUserMetadata)
     info['apiRoot'].user.route('GET', ('settings',), getUserMetadata)
     ModelImporter.model('user').exposeFields(
-        level=AccessType.WRITE, fields=('meta', 'myData'))
+        level=AccessType.WRITE, fields=('meta', 'myData', 'lastLogin'))
     ModelImporter.model('user').exposeFields(
         level=AccessType.ADMIN, fields=('otherTokens',))
 


### PR DESCRIPTION
It's useful since PIs of the project have a nasty habit of asking questions like: "How many users used the system in past n months?" and expecting an immediate answer. Parsing logs to find that out is tedious, so let's keep that in the db.

### How to test?
1. Deploy and login to girder.
1. Using swagger API, call `/user/me` and verify that `lastLogin` field is present and contains the date when you last logged in.