### PR TITLE
Update ContainerConfig schema

### DIFF
--- a/server/schema/misc.py
+++ b/server/schema/misc.py
@@ -139,6 +139,14 @@ containerConfigSchema = {
     "description": "A subset of docker runtime configuration used for Tales",
     "type": "object",
     "properties": {
+        "buildpack": {
+            "type": "string",
+            "description": "Repo2docker's BuildPack to use",
+        },
+        "repo2docker_version": {
+            "type": "string",
+            "description": "Repo2docker image used for build",
+        },
         "command": {
             "type": "string",
             "description": "Command to run when the container starts",


### PR DESCRIPTION
Adds:
* "buildpack" - we have been using it for a long time already
* "repo2docker_version" - it will allow to build tales with a specific version of r2d in the (not so distant) future