### PR TITLE
Re-order the context

### DIFF
--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -171,16 +171,16 @@ class Manifest:
 
     def create_context(self):
         """
-        Creates the manifest namespace. When a new vocabulary is used, it shoud
+        Creates the manifest namespace. When a new vocabulary is used, it should
         get added here.
         :return: A structure defining the used vocabularies
         """
         return {
             "@context": [
-                "https://w3id.org/bundle/context",
                 {"schema": "http://schema.org/"},
                 {"DataCite": "http://datacite.org/schema/kernel-4"},
-                {"Datasets": {"@type": "@id"}}
+                {"Datasets": {"@type": "@id"}},
+                "https://w3id.org/bundle/context"
             ]
         }
 


### PR DESCRIPTION
Fixes #416

To Test

1. Checkout
2. Export a Tale
3. Open the manifest
4. Check that the ordering has `https://w3id.org/bundle/context` at the end