### PR TITLE
Add default description

### DIFF
--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -1008,17 +1008,18 @@ class TaleWithWorkspaceTestCase(base.TestCase):
         self.model('collection').remove(self.data_collection)
 
     def test_tale_defaults(self):
-        tale = self.model('tale', 'wholetale').createTale(
+        tale = Tale().createTale(
             self.image,
-            [{
-                'itemId': str(ObjectId()),
-                '_modelType': 'item',
-                'mountPath': 'asd'
-            }], creator=self.user, title="Export Tale", public=True, authors=None,
-            description=None)
+            [],
+            creator=self.user,
+            title="Export Tale",
+            public=True,
+            authors=None,
+            description=None
+        )
 
         self.assertTrue(tale['description'] is not None)
-        self.assertTrue(tale['authors'] is None)
+        self.assertTrue(tale['description'].startswith("This Tale"))
 
     def tearDown(self):
         self.model('user').remove(self.user)

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -1007,6 +1007,19 @@ class TaleWithWorkspaceTestCase(base.TestCase):
         self.model('tale', 'wholetale').remove(tale)
         self.model('collection').remove(self.data_collection)
 
+    def test_tale_defaults(self):
+        tale = self.model('tale', 'wholetale').createTale(
+            self.image,
+            [{
+                'itemId': str(ObjectId()),
+                '_modelType': 'item',
+                'mountPath': 'asd'
+            }], creator=self.user, title="Export Tale", public=True, authors=None,
+            description=None)
+
+        self.assertTrue(tale['description'] is not None)
+        self.assertTrue(tale['authors'] is None)
+
     def tearDown(self):
         self.model('user').remove(self.user)
         self.model('user').remove(self.admin)

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -160,6 +160,10 @@ class Tale(AccessControlledModel):
 
         if title is None:
             title = '{} with {}'.format(image['name'], DATADIRS_NAME)
+
+        if description is None:
+            description = f'This Tale, {title}, represents a computational experiment. ' \
+                          f'It contains code, data, and metadata relevant to the experiment.'
         # if illustration is None:
             # Get image from SILS
 


### PR DESCRIPTION
Fixes #373 

Open to suggestions for wording changes in the default description.

To test:

1. Checkout
2. Go to the girder API (The dashboard provides a default Tale description too)
3. POST a new Tale (use the chunk below)
4. Make sure you see the default description

```
{
  "_accessLevel": 2,
  "_id": "5f839b0439895bd373eq5eed",
  "_modelType": "tale",
  "authors": [],
  "category": "science",
  "config": {},
  "copyOfTale": null,
  "created": "2020-10-11T23:53:40.360000+00:00",
  "creatorId": "5f6e609ab2bb2d8dfe456502",
  "dataSet": [],
  "dataSetCitation": [],
  "folderId": "5f839b0439895bd373ea5eef",
  "format": 8,
  "icon": "https://raw.githubusercontent.com/whole-tale/jupyter-base/master/squarelogo-greytext-orangebody-greymoons.png",
  "iframe": true,
  "illustration": "https://raw.githubusercontent.com/whole-tale/dashboard/master/public/images/demo-graph2.jpg",
  "imageId": "5f6e5f16e00a3ce43cd99542",
  "licenseSPDX": "CC-BY-4.0",
  "narrative": [],
  "narrativeId": "5f6e60a3b2bb2d8dfe45650f",
  "public": false,
  "publishInfo": [],
  "relatedIdentifiers": [],
  "status": 1,
  "title": "Test Tale",
  "updated": "2020-10-11T23:53:40.360000+00:00",
  "workspaceId": "5f839b0439895bd373ea5eee"
}
```