### PR TITLE
Git integration

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -68,6 +68,7 @@ add_python_test(dataset
   EXTERNAL_DATA
   plugins/wholetale/dataset_register.txt
 )
+add_python_test(git PLUGIN wholetale)
 add_python_test(publish PLUGIN wholetale)
 add_python_test(notification PLUGIN wholetale)
 add_python_style_test(python_static_analysis_wholetale

--- a/plugin_tests/git_test.py
+++ b/plugin_tests/git_test.py
@@ -84,6 +84,8 @@ class GitImportTestCase(base.TestCase):
             fp.write("MAGIC!")
         r.index.add([self.git_file_on_branch])
         r.index.commit("Commit on a branch")
+        r.head.reference = r.refs["master"]
+        r.head.reset(index=True, working_tree=True)
 
     def _import_git_repo(self, tale, url):
         resp = self.request(

--- a/plugin_tests/git_test.py
+++ b/plugin_tests/git_test.py
@@ -1,0 +1,229 @@
+import git
+import mock
+import os
+import pymongo
+import time
+import tempfile
+import shutil
+from tests import base
+
+from girder.models.folder import Folder
+from girder.models.user import User
+
+
+Tale = None
+Image = None
+Job = None
+JobStatus = None
+ImageStatus = None
+
+
+def setUpModule():
+    base.enabledPlugins.append("wholetale")
+    base.enabledPlugins.append("wt_home_dir")
+    base.enabledPlugins.append("virtual_resources")
+    base.startServer()
+
+    global JobStatus, Tale, ImageStatus, Image, Job
+    from girder.plugins.jobs.constants import JobStatus
+    from girder.plugins.jobs.models.job import Job
+    from girder.plugins.wholetale.models.tale import Tale
+    from girder.plugins.wholetale.models.image import Image
+    from girder.plugins.wholetale.constants import ImageStatus
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class GitImportTestCase(base.TestCase):
+    def setUp(self):
+        super(GitImportTestCase, self).setUp()
+        users = (
+            {
+                "email": "root@dev.null",
+                "login": "admin",
+                "firstName": "Root",
+                "lastName": "van Klompf",
+                "password": "secret",
+            },
+            {
+                "email": "joe@dev.null",
+                "login": "joeregular",
+                "firstName": "Joe",
+                "lastName": "Regular",
+                "password": "secret",
+            },
+        )
+
+        self.admin, self.user = [User().createUser(**user) for user in users]
+        self.image = Image().createImage(
+            name="test my name",
+            creator=self.user,
+            public=True,
+            config=dict(
+                template="base.tpl",
+                buildpack="SomeBuildPack",
+                user="someUser",
+                port=8888,
+                urlPath="",
+            ),
+        )
+
+        self.git_repo_dir = tempfile.mkdtemp()
+        self.git_file_name = "hello.txt"
+        self.git_file_on_branch = "on_branch.txt"
+        r = git.Repo.init(self.git_repo_dir)
+        with open(os.path.join(self.git_repo_dir, self.git_file_name), "w") as fp:
+            fp.write("World!")
+        r.index.add([self.git_file_name])
+        r.index.commit("initial commit")
+        feature = r.create_head("feature")
+        r.head.reference = feature
+        with open(os.path.join(self.git_repo_dir, self.git_file_on_branch), "w") as fp:
+            fp.write("MAGIC!")
+        r.index.add([self.git_file_on_branch])
+        r.index.commit("Commit on a branch")
+
+    def _import_git_repo(self, tale, url):
+        resp = self.request(
+            path=f"/tale/{tale['_id']}/git",
+            method="PUT",
+            user=self.user,
+            params={"url": url},
+        )
+        self.assertStatusOk(resp)
+
+        job = (
+            Job()
+            .find({"type": "wholetale.import_git_repo"})
+            .sort([("created", pymongo.DESCENDING)])
+            .limit(1)
+            .next()
+        )
+
+        for i in range(10):
+            time.sleep(0.5)
+            job = Job().load(job["_id"], force=True, includeLog=True)
+            if job["status"] >= JobStatus.SUCCESS:
+                break
+        return job
+
+    def _import_from_git_repo(self, url):
+        resp = self.request(
+            path="/tale/import",
+            method="POST",
+            user=self.user,
+            params={
+                "url": url,
+                "git": True,
+                "imageId": str(self.image["_id"]),
+                "spawn": True,
+            },
+        )
+        self.assertStatusOk(resp)
+        tale = resp.json
+
+        job = (
+            Job()
+            .find({"type": "wholetale.import_git_repo"})
+            .sort([("created", pymongo.DESCENDING)])
+            .limit(1)
+            .next()
+        )
+
+        for i in range(60):
+            time.sleep(0.5)
+            job = Job().load(job["_id"], force=True, includeLog=True)
+            if job["status"] >= JobStatus.SUCCESS:
+                break
+        tale = Tale().load(tale["_id"], user=self.user)
+        return tale, job
+
+    def testImportGitAsTale(self):
+        from girder.plugins.wholetale.constants import InstanceStatus, TaleStatus
+
+        class fakeInstance(object):
+            _id = "123456789"
+
+            def createInstance(self, tale, user, token, spawn=False):
+                return {"_id": self._id, "status": InstanceStatus.LAUNCHING}
+
+            def load(self, instance_id, user=None):
+                assert instance_id == self._id
+                return {"_id": self._id, "status": InstanceStatus.RUNNING}
+
+        with mock.patch(
+            "girder.plugins.wholetale.tasks.import_git_repo.Instance", fakeInstance
+        ):
+            # Custom branch
+            tale, job = self._import_from_git_repo(
+                f"file://{self.git_repo_dir}@feature"
+            )
+            workspace = Folder().load(tale["workspaceId"], force=True)
+            workspace_path = workspace["fsPath"]
+            self.assertEqual(job["status"], JobStatus.SUCCESS)
+            self.assertTrue(
+                os.path.isfile(os.path.join(workspace["fsPath"], self.git_file_name))
+            )
+            self.assertTrue(
+                os.path.isfile(
+                    os.path.join(workspace["fsPath"], self.git_file_on_branch)
+                )
+            )
+            shutil.rmtree(workspace_path)
+            os.mkdir(workspace_path)
+            Tale().remove(tale)
+
+        # Invalid url
+        tale, job = self._import_from_git_repo("blah")
+        workspace = Folder().load(tale["workspaceId"], force=True)
+        workspace_path = workspace["fsPath"]
+        self.assertEqual(job["status"], JobStatus.ERROR)
+        self.assertTrue("does not appear to be a git repo" in job["log"][0])
+        self.assertEqual(tale["status"], TaleStatus.ERROR)
+        shutil.rmtree(os.path.join(workspace_path, ".git"))
+        Tale().remove(tale)
+
+    def testGitImport(self):
+        tale = Tale().createTale(self.image, [], creator=self.user, public=True)
+        workspace = Folder().load(tale["workspaceId"], force=True)
+        workspace_path = workspace["fsPath"]
+
+        # Invalid path
+        job = self._import_git_repo(tale, "blah")
+        self.assertEqual(job["status"], JobStatus.ERROR)
+        self.assertTrue("does not appear to be a git repo" in job["log"][0])
+        shutil.rmtree(os.path.join(workspace_path, ".git"))
+
+        # Default branch (master)
+        job = self._import_git_repo(tale, f"file://{self.git_repo_dir}")
+        self.assertEqual(job["status"], JobStatus.SUCCESS)
+        self.assertTrue(
+            os.path.isfile(os.path.join(workspace["fsPath"], self.git_file_name))
+        )
+        self.assertFalse(
+            os.path.isfile(os.path.join(workspace["fsPath"], self.git_file_on_branch))
+        )
+        shutil.rmtree(workspace_path)
+        os.mkdir(workspace_path)
+
+        # Custom branch
+        job = self._import_git_repo(tale, f"file://{self.git_repo_dir}@feature")
+        self.assertEqual(job["status"], JobStatus.SUCCESS)
+        self.assertTrue(
+            os.path.isfile(os.path.join(workspace["fsPath"], self.git_file_name))
+        )
+        self.assertTrue(
+            os.path.isfile(os.path.join(workspace["fsPath"], self.git_file_on_branch))
+        )
+        shutil.rmtree(workspace_path)
+        os.mkdir(workspace_path)
+        Tale().remove(tale)
+
+    def tearDown(self):
+        User().remove(self.user)
+        User().remove(self.admin)
+        Image().remove(self.image)
+        shutil.rmtree(self.git_repo_dir)
+        super(GitImportTestCase, self).tearDown()

--- a/plugin_tests/git_test.py
+++ b/plugin_tests/git_test.py
@@ -184,7 +184,6 @@ class GitImportTestCase(base.TestCase):
         self.assertEqual(job["status"], JobStatus.ERROR)
         self.assertTrue("does not appear to be a git repo" in job["log"][0])
         self.assertEqual(tale["status"], TaleStatus.ERROR)
-        shutil.rmtree(os.path.join(workspace_path, ".git"))
         Tale().remove(tale)
 
     def testGitImport(self):
@@ -196,7 +195,8 @@ class GitImportTestCase(base.TestCase):
         job = self._import_git_repo(tale, "blah")
         self.assertEqual(job["status"], JobStatus.ERROR)
         self.assertTrue("does not appear to be a git repo" in job["log"][0])
-        shutil.rmtree(os.path.join(workspace_path, ".git"))
+        if os.path.isdir(os.path.join(workspace_path, ".git")):
+            shutil.rmtree(os.path.join(workspace_path, ".git"))
 
         # Default branch (master)
         job = self._import_git_repo(tale, f"file://{self.git_repo_dir}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ dataone.cli==3.4.7
 validators
 html2markdown
 fs.webdavfs
+GitPython

--- a/server/constants.py
+++ b/server/constants.py
@@ -9,6 +9,14 @@ CATALOG_NAME = "WholeTale Catalog"
 WORKSPACE_NAME = "WholeTale Workspaces"
 DATADIRS_NAME = "WholeTale Data Mountpoints"
 SCRIPTDIRS_NAME = "WholeTale Narrative"
+DEFAULT_IMAGE_ICON = (
+    "https://raw.githubusercontent.com/whole-tale/dashboard/master/public/"
+    "images/whole_tale_logo.png"
+)
+DEFAULT_ILLUSTRATION = (
+    "https://raw.githubusercontent.com/whole-tale/dashboard/master/public/"
+    "images/demo-graph2.jpg"
+)
 
 
 class HarvesterType:

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -148,7 +148,7 @@ class Tale(AccessControlledModel):
     def createTale(self, image, data, creator=None, save=True, title=None,
                    description=None, public=None, config=None, authors=None,
                    icon=None, category=None, illustration=None, narrative=None,
-                   licenseSPDX=WholeTaleLicense.default_spdx(),
+                   licenseSPDX=None,
                    status=TaleStatus.READY, publishInfo=None,
                    relatedIdentifiers=None):
 
@@ -187,7 +187,7 @@ class Tale(AccessControlledModel):
             'publishInfo': publishInfo or [],
             'relatedIdentifiers': relatedIdentifiers or [],
             'updated': now,
-            'licenseSPDX': licenseSPDX,
+            'licenseSPDX': licenseSPDX or WholeTaleLicense.default_spdx(),
             'status': status,
         }
         if public is not None and isinstance(public, bool):
@@ -476,6 +476,37 @@ class Tale(AccessControlledModel):
             module='girder.plugins.wholetale.tasks.import_tale',
             args=(temp_dir, manifest_file),
             kwargs={'taleId': tale["_id"]}
+        )
+        Job().scheduleJob(job)
+        return tale
+
+    def addGitRepo(self, tale, url, user=None, spawn=False, change_status=False, title=None):
+        resource = {
+            "type": "wt_git_import",
+            "tale_id": tale["_id"],
+            "tale_title": tale["title"]
+        }
+        notification = init_progress(
+            resource, user, "Importing from Git", "Initializing", 1
+        )
+
+        job = Job().createLocalJob(
+            title="Import a git repository as a Tale",
+            user=user,
+            type="wholetale.import_git_repo",
+            public=False,
+            _async=True,
+            module="girder.plugins.wholetale.tasks.import_git_repo",
+            args=(url,),
+            kwargs={
+                "taleId": tale["_id"],
+                "spawn": spawn,
+                "change_status": change_status
+            },
+            otherFields={
+                "taleId": tale["_id"],
+                "wt_notification_id": str(notification["_id"])
+            },
         )
         Job().scheduleJob(job)
         return tale

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -2,9 +2,11 @@
 # -*- coding: utf-8 -*-
 import cherrypy
 import json
+import pathlib
 import shutil
 import tempfile
 import textwrap
+from urllib.parse import urlparse
 import zipfile
 
 from girder import events
@@ -35,6 +37,7 @@ from ..lib.dataone import DataONELocations  # TODO: get rid of it
 from ..lib.manifest import Manifest
 from ..lib.exporters.bag import BagTaleExporter
 from ..lib.exporters.native import NativeTaleExporter
+from ..utils import init_progress
 
 from girder.plugins.worker import getCeleryApp
 
@@ -55,12 +58,13 @@ class Tale(Resource):
         self.route('GET', (), self.listTales)
         self.route('GET', (':id',), self.getTale)
         self.route('PUT', (':id',), self.updateTale)
-        self.route('POST', ('import', ), self.createTaleFromDataset)
+        self.route('POST', ('import', ), self.createTaleFromUrl)
         self.route('POST', (), self.createTale)
         self.route('POST', (':id', 'copy'), self.copyTale)
         self.route('DELETE', (':id',), self.deleteTale)
         self.route('GET', (':id', 'access'), self.getTaleAccess)
         self.route('PUT', (':id', 'access'), self.updateTaleAccess)
+        self.route('PUT', (':id', 'git'), self.updateTaleWithGitRepo)
         self.route('GET', (':id', 'export'), self.exportTale)
         self.route('GET', (':id', 'manifest'), self.generateManifest)
         self.route('PUT', (':id', 'build'), self.buildImage)
@@ -216,6 +220,9 @@ class Tale(Resource):
                default=True, required=False, dataType='boolean')
         .param('asTale', 'If True, assume that external dataset is a Tale.',
                default=False, required=False, dataType='boolean')
+        .param('git', "If True, treat the url as a location of a git repo "
+               "that should be imported as the Tale's workspace.",
+               default=False, required=False, dataType='boolean')
         .jsonParam('lookupKwargs', 'Optional keyword arguments passed to '
                    'GET /repository/lookup', requireObject=True, required=False)
         .jsonParam('taleKwargs', 'Optional keyword arguments passed to POST /tale',
@@ -223,7 +230,7 @@ class Tale(Resource):
         .responseClass('tale')
         .errorResponse('You are not authorized to create tales.', 403)
     )
-    def createTaleFromDataset(self, imageId, url, spawn, asTale, lookupKwargs, taleKwargs):
+    def createTaleFromUrl(self, imageId, url, spawn, asTale, git, lookupKwargs, taleKwargs):
         user = self.getCurrentUser()
         if taleKwargs is None:
             taleKwargs = {}
@@ -245,39 +252,49 @@ class Tale(Resource):
             except TypeError:
                 lookupKwargs = dict(dataId=[url])
 
-            dataMap = pids_to_entities(
-                lookupKwargs["dataId"],
-                user=user,
-                base_url=lookupKwargs.get("base_url", DataONELocations.prod_cn),
-                lookup=True
-            )[0]
-            if dataMap["tale"]:
-                provider = IMPORT_PROVIDERS.providerMap[dataMap["repository"]]
-                tale = provider.import_tale(dataMap["dataId"], user)
-                return tale
+            if not git:
+                dataMap = pids_to_entities(
+                    lookupKwargs["dataId"],
+                    user=user,
+                    base_url=lookupKwargs.get("base_url", DataONELocations.prod_cn),
+                    lookup=True
+                )[0]
+                if dataMap["tale"]:  # url points to a published Tale
+                    provider = IMPORT_PROVIDERS.providerMap[dataMap["repository"]]
+                    tale = provider.import_tale(dataMap["dataId"], user)
+                    return tale
 
-            if asTale:
-                relation = "IsDerivedFrom"
+                if asTale:
+                    relation = "IsDerivedFrom"
+                else:
+                    relation = "Cites"
+                related_id = [
+                    {
+                        "relation": relation,
+                        "identifier": dataMap["doi"] or dataMap["dataId"]
+                    }
+                ]
+
+                if "title" not in taleKwargs:
+                    long_name = dataMap["name"]
+                    long_name = long_name.replace('-', ' ').replace('_', ' ')
+                    shortened_name = textwrap.shorten(text=long_name, width=30)
+                    taleKwargs["title"] = f"A Tale for \"{shortened_name}\""
             else:
-                relation = "Cites"
-            related_id = [
-                {
-                    "relation": relation,
-                    "identifier": dataMap["doi"] or dataMap["dataId"]
-                }
-            ]
+                related_id = [{"relation": "IsSupplementTo", "identifier": url}]
+                if "title" not in taleKwargs:
+                    git_url = urlparse(url)
+                    if git_url.netloc == "github.com":
+                        name = "/".join(pathlib.Path(git_url.path).parts[1:3])
+                        taleKwargs["title"] = f"A Tale for \"gh:{name}\""
+                    else:
+                        taleKwargs["title"] = f"A Tale for \"{url}\""
 
             all_related_ids = related_id + taleKwargs.get("relatedIdentifiers", [])
             taleKwargs["relatedIdentifiers"] = [
                 json.loads(rel_id)
                 for rel_id in {json.dumps(_, sort_keys=True) for _ in all_related_ids}
             ]
-
-            if "title" not in taleKwargs:
-                long_name = dataMap["name"]
-                long_name = long_name.replace('-', ' ').replace('_', ' ')
-                shortened_name = textwrap.shorten(text=long_name, width=30)
-                taleKwargs["title"] = "A Tale for \"{}\"".format(shortened_name)
 
             if not (imageId or url):
                 msg = (
@@ -303,16 +320,30 @@ class Tale(Resource):
                 **taleKwargs
             )
 
-            job = Job().createLocalJob(
-                title="Import Tale from external dataset",
-                user=user,
-                type="wholetale.import_binder",
-                public=False,
-                _async=True,
-                module="girder.plugins.wholetale.tasks.import_binder",
-                args=(lookupKwargs,),
-                kwargs={"taleId": tale["_id"], "spawn": spawn, "asTale": asTale},
-            )
+            if not git:
+                job = Job().createLocalJob(
+                    title="Import Tale from external dataset",
+                    user=user,
+                    type="wholetale.import_binder",
+                    public=False,
+                    _async=True,
+                    module="girder.plugins.wholetale.tasks.import_binder",
+                    args=(lookupKwargs,),
+                    kwargs={"taleId": tale["_id"], "spawn": spawn, "asTale": asTale},
+                    otherFields={"taleId": tale["_id"]},
+                )
+            else:
+                job = Job().createLocalJob(
+                    title="Import a git repository as a Tale",
+                    user=user,
+                    type="wholetale.import_git_repo",
+                    public=False,
+                    _async=True,
+                    module="girder.plugins.wholetale.tasks.import_git_repo",
+                    args=(url,),
+                    kwargs={"taleId": tale["_id"], "spawn": spawn},
+                    otherFields={"taleId": tale["_id"]},
+                )
             Job().scheduleJob(job)
         return tale
 
@@ -619,3 +650,50 @@ class Tale(Resource):
             girder_client_token=str(girder_token["_id"]),
         )
         return publishTask.job
+
+    @access.user(scope=TokenScope.DATA_WRITE)
+    @filtermodel(model='tale', plugin='wholetale')
+    @autoDescribeRoute(
+        Description("Add git repo to the Tale workspace")
+        .modelParam(
+            "id",
+            description="The ID of the tale that is going to be modified.",
+            model="tale",
+            plugin="wholetale",
+            level=AccessType.ADMIN,
+        )
+        .param(
+            "url",
+            description="A location of a git repo that should be imported"
+                        "as the Tale's workspace.",
+            required=True,
+        )
+    )
+    def updateTaleWithGitRepo(self, tale, url):
+        resource = {
+            "type": "wt_git_import",
+            "tale_id": tale["_id"],
+            "tale_title": tale["title"]
+        }
+
+        user = self.getCurrentUser()
+        notification = init_progress(
+            resource, user, "Importing from Git", "Initializing", 1
+        )
+
+        job = Job().createLocalJob(
+            title="Import a git repository as a Tale",
+            user=self.getCurrentUser(),
+            type="wholetale.import_git_repo",
+            public=False,
+            _async=True,
+            module="girder.plugins.wholetale.tasks.import_git_repo",
+            args=(url,),
+            kwargs={"taleId": tale["_id"], "spawn": False, "change_status": False},
+            otherFields={
+                "taleId": tale["_id"],
+                "wt_notification_id": str(notification["_id"])
+            },
+        )
+        Job().scheduleJob(job)
+        return tale

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -38,7 +38,8 @@ from ..lib.exporters.native import NativeTaleExporter
 
 from girder.plugins.worker import getCeleryApp
 
-from ..constants import ImageStatus, TaleStatus, PluginSettings
+from ..constants import ImageStatus, TaleStatus, PluginSettings, \
+    DEFAULT_IMAGE_ICON, DEFAULT_ILLUSTRATION
 
 
 addModel('tale', taleSchema, resources='tale')
@@ -288,22 +289,8 @@ class Tale(Resource):
             image = imageModel().load(imageId, user=user, level=AccessType.READ,
                                       exc=True)
 
-            if "icon" not in taleKwargs:
-                taleKwargs["icon"] = image.get(
-                    "icon",
-                    (
-                        "https://raw.githubusercontent.com/"
-                        "whole-tale/dashboard/master/public/"
-                        "images/whole_tale_logo.png"
-                    ),
-                )
-
-            if "illustration" not in taleKwargs:
-                taleKwargs["illustration"] = (
-                    "https://raw.githubusercontent.com/"
-                    "whole-tale/dashboard/master/public/"
-                    "images/demo-graph2.jpg"
-                )
+            taleKwargs.setdefault("icon", image.get("icon", DEFAULT_IMAGE_ICON))
+            taleKwargs.setdefault("illustration", DEFAULT_ILLUSTRATION)
 
             tale = taleModel().createTale(
                 image,
@@ -354,13 +341,8 @@ class Tale(Resource):
                 image, tale['dataSet'], creator=user, save=True,
                 title=tale.get('title'), description=tale.get('description'),
                 public=tale.get('public'), config=tale.get('config'),
-                icon=image.get('icon', ('https://raw.githubusercontent.com/'
-                                        'whole-tale/dashboard/master/public/'
-                                        'images/whole_tale_logo.png')),
-                illustration=tale.get(
-                    'illustration', ('https://raw.githubusercontent.com/'
-                                     'whole-tale/dashboard/master/public/'
-                                     'images/demo-graph2.jpg')),
+                icon=image.get('icon', DEFAULT_IMAGE_ICON),
+                illustration=tale.get('illustration', DEFAULT_ILLUSTRATION),
                 authors=tale.get('authors', default_author),
                 category=tale.get('category', 'science'),
                 narrative=tale.get('narrative'),
@@ -508,13 +490,8 @@ class Tale(Resource):
             image, tale['dataSet'], creator=user, save=True,
             title=tale.get('title'), description=tale.get('description'),
             public=False, config=tale.get('config'),
-            icon=image.get('icon', ('https://raw.githubusercontent.com/'
-                                    'whole-tale/dashboard/master/public/'
-                                    'images/whole_tale_logo.png')),
-            illustration=tale.get(
-                'illustration', ('https://raw.githubusercontent.com/'
-                                 'whole-tale/dashboard/master/public/'
-                                 'images/demo-graph2.jpg')),
+            icon=image.get('icon', DEFAULT_IMAGE_ICON),
+            illustration=tale.get('illustration', DEFAULT_ILLUSTRATION),
             authors=tale.get('authors', default_author),
             category=tale.get('category', 'science'),
             narrative=tale.get('narrative'),

--- a/server/tasks/import_git_repo.py
+++ b/server/tasks/import_git_repo.py
@@ -109,11 +109,9 @@ def run(job):
             instance = None
 
     except Exception as exc:
-        if not has_dot_git_already:
-            shutil.rmtree(
-                os.path.isdir(os.path.join(workspace["fsPath"], ".git")),
-                ignore_errors=True,
-            )
+        dot_git = os.path.join(workspace["fsPath"], ".git")
+        if not has_dot_git_already and os.path.isdir(dot_git):
+            shutil.rmtree(dot_git, ignore_errors=True)
         if change_status:
             tale = Tale().load(tale["_id"], user=user)  # Refresh state
             tale["status"] = TaleStatus.ERROR

--- a/server/tasks/import_git_repo.py
+++ b/server/tasks/import_git_repo.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import git
+import json
+import sys
+import time
+import traceback
+from girder.models.folder import Folder
+from girder.models.token import Token
+from girder.models.user import User
+from girder.utility import JsonEncoder
+from girder.plugins.jobs.constants import JobStatus
+from girder.plugins.jobs.models.job import Job
+
+from ..constants import InstanceStatus, TaleStatus
+from ..models.instance import Instance
+from ..models.tale import Tale
+
+
+def run(job):
+    jobModel = Job()
+    jobModel.updateJob(job, status=JobStatus.RUNNING)
+
+    url, = job["args"]
+    if "@" in url:
+        repo_url, branch = url.split("@")
+    else:
+        repo_url = url
+        branch = "master"
+
+    user = User().load(job["userId"], force=True)
+    tale = Tale().load(job["kwargs"]["taleId"], user=user)
+    spawn = job["kwargs"]["spawn"]
+    change_status = job["kwargs"].get("change_status", True)
+    token = Token().createToken(user=user, days=0.5)
+
+    progressTotal = 1 + int(spawn)
+    progressCurrent = 0
+
+    try:
+        # 1. Checkout the git repo
+        jobModel.updateJob(
+            job,
+            status=JobStatus.RUNNING,
+            progressTotal=progressTotal,
+            progressCurrent=progressCurrent,
+            progressMessage="Cloning the git repo",
+        )
+
+        workspace = Folder().load(tale["workspaceId"], force=True)
+        try:
+            repo = git.Repo.init(workspace["fsPath"])
+            origin = repo.create_remote("origin", repo_url)
+            origin.fetch()
+            repo.create_head(
+                branch, origin.refs[branch]
+            )  # create local branch "master" from remote "master"
+            repo.heads[branch].set_tracking_branch(
+                origin.refs[branch]
+            )  # set local "master" to track remote "master"
+            repo.heads[branch].checkout()  # checkout local "master" to working tree
+        except git.exc.GitCommandError as exc:
+            raise RuntimeError("Failed to import from git:\n {}".format(str(exc)))
+
+        # Tale is ready to be built
+        tale = Tale().load(tale["_id"], user=user)  # Refresh state
+        tale["status"] = TaleStatus.READY
+        tale = Tale().updateTale(tale)
+
+        # 4. Wait for container to show up
+        if spawn:
+            instance = Instance().createInstance(tale, user, token, spawn=spawn)
+            progressCurrent += 1
+            jobModel.updateJob(
+                job,
+                status=JobStatus.RUNNING,
+                log="Waiting for a Tale container",
+                progressTotal=progressTotal,
+                progressCurrent=progressCurrent,
+                progressMessage="Waiting for a Tale container",
+            )
+
+            sleep_step = 5
+            timeout = 15 * 60
+            while instance["status"] == InstanceStatus.LAUNCHING and timeout > 0:
+                time.sleep(sleep_step)
+                instance = Instance().load(instance["_id"], user=user)
+                timeout -= sleep_step
+            if timeout <= 0:
+                raise RuntimeError(
+                    "Failed to launch instance {}".format(instance["_id"])
+                )
+        else:
+            instance = None
+
+    except Exception:
+        if change_status:
+            tale = Tale().load(tale["_id"], user=user)  # Refresh state
+            tale["status"] = TaleStatus.ERROR
+            tale = Tale().updateTale(tale)
+        t, val, tb = sys.exc_info()
+        log = "%s: %s\n%s" % (t.__name__, repr(val), traceback.extract_tb(tb))
+        jobModel.updateJob(
+            job,
+            progressTotal=progressTotal,
+            progressCurrent=progressTotal,
+            progressMessage="Task failed",
+            status=JobStatus.ERROR,
+            log=log,
+        )
+        raise
+
+    # To get rid of ObjectId's, dates etc.
+    tale = json.loads(
+        json.dumps(tale, sort_keys=True, allow_nan=False, cls=JsonEncoder)
+    )
+    instance = json.loads(
+        json.dumps(instance, sort_keys=True, allow_nan=False, cls=JsonEncoder)
+    )
+
+    jobModel.updateJob(
+        job,
+        status=JobStatus.SUCCESS,
+        log="Tale created",
+        progressTotal=progressTotal,
+        progressCurrent=progressTotal,
+        progressMessage="Tale created",
+        otherFields={"result": {"tale": tale, "instance": instance}},
+    )

--- a/server/tasks/import_git_repo.py
+++ b/server/tasks/import_git_repo.py
@@ -69,11 +69,11 @@ def run(job):
                 )
             repo.create_head(
                 branch, origin.refs[branch]
-            )  # create local branch "master" from remote "master"
+            )  # create a local branch default from remote HEAD symref
             repo.heads[branch].set_tracking_branch(
                 origin.refs[branch]
-            )  # set local "master" to track remote "master"
-            repo.heads[branch].checkout()  # checkout local "master" to working tree
+            )  # set the local branch to track the remote default branch
+            repo.heads[branch].checkout()  # checkout the default branch to working tree
         except git.exc.GitCommandError as exc:
             raise RuntimeError("Failed to import from git:\n {}".format(str(exc)))
 


### PR DESCRIPTION
### Rationale

Allows to either import a git repo to a workspace of an existing Tale, or import a remote git repo as a Tale (AinWT flow).

new API:

- `PUT /tale/:id/git` ( for *"Connect to Git repository..."*)
- `POST /tale/import?git=True&url=<git_repo>` ( for *Create New... > Create Tale from Git Repository*)
   this case follow the existing Analyze in WT flow. The only difference is the new `git` boolean parameter in the request that triggers a job which interprets `url` as a git repository url.

### How to test?
1. Checkout and run this branch locally
2. Ensure dependencies are installed: `docker exec -ti $(docker ps --filter=name=wt_girder -q) girder-install plugin plugins/wholetale`
3. t.b.a