### PR TITLE
Add a stub for imageInfo during Tale creation

### DIFF
--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -138,7 +138,9 @@ class Manifest:
         }
 
     def create_repo2docker_version(self):
-        image_info = self.tale.get("imageInfo", {"repo2docker_version": REPO2DOCKER_VERSION})
+        # TODO: We shouldn't be publishing a Tale that was never built...
+        image_info = self.tale.get("imageInfo", {})
+        image_info.setdefault("repo2docker_version", REPO2DOCKER_VERSION)
         return {
             'schema:hasPart': [{
                 '@id': 'https://github.com/whole-tale/repo2docker_wholetale',

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -177,6 +177,7 @@ class Tale(AccessControlledModel):
             'icon': icon,
             'iframe': image.get('iframe', False),
             'imageId': ObjectId(image['_id']),
+            'imageInfo': {},
             'illustration': illustration,
             'narrative': narrative or [],
             'title': title,


### PR DESCRIPTION
This ensures that a Tale always has `imageInfo` property. Fixes https://github.com/whole-tale/gwvolman/issues/116