### PR TITLE
Refactor manifest-to-tale parsing

### DIFF
--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -494,6 +494,18 @@ class ManifestTestCase(base.TestCase):
         self.assertEqual(version_block['@id'], 'https://github.com/whole-tale/repo2docker_wholetale')
         self.assertEqual(version_block['@type'], 'schema:SoftwareApplication')
 
+    def test_dataset_roundtrip(self):
+        from server.lib.manifest_parser import ManifestParser
+        from server.lib.manifest import Manifest
+        manifest = Manifest(self.tale, self.user).manifest
+        # NOTE: http(s) folders are expanded into individual files in manifest so the result
+        # won't be 1:1, reverse dataset will have more items
+        dataset = ManifestParser.get_dataset_from_manifest(manifest)
+        self.assertEqual(
+            [_["itemId"] for _ in dataset][:-3],
+            [str(_["itemId"]) for _ in self.tale["dataSet"][:-1]]
+        )
+
     def tearDown(self):
         self.model("user").remove(self.user)
         self.model("user").remove(self.admin)

--- a/server/lib/manifest_parser.py
+++ b/server/lib/manifest_parser.py
@@ -1,0 +1,102 @@
+import json
+import os
+import pathlib
+
+from girder.models.file import File
+from girder.models.folder import Folder
+
+from .license import WholeTaleLicense
+from ..models.image import Image
+
+
+class ManifestParser:
+    @staticmethod
+    def get_dataset_from_manifest(manifest):
+        """Creates a 'dataSet' using manifest's aggregates section."""
+        dataSet = []
+        for obj in manifest.get("aggregates", []):
+            try:
+                bundle = obj["bundledAs"]
+            except KeyError:
+                continue
+
+            folder_path = bundle["folder"].replace("../data/", "")
+            if "filename" in bundle:
+                file_obj = File().findOne({"linkUrl": obj["uri"]}, fields=["itemId"])
+                itemId = file_obj["itemId"]
+                path = os.path.join(folder_path, bundle["filename"])
+                model_type = "item"
+            else:
+                folder = Folder().findOne({"meta.identifier": obj["uri"]}, fields=[])
+                if not folder:
+                    fname = pathlib.Path(obj["bundledAs"]["folder"]).parts[-1]
+                    # TODO: There should be a better way to do it...
+                    folder = Folder().findOne({"name": fname, "size": obj["size"]}, fields=[])
+                itemId = folder["_id"]
+                path = folder_path
+                model_type = "folder"
+            dataSet.append(
+                dict(mountPath=path, _modelType=model_type, itemId=str(itemId))
+            )
+        return dataSet
+
+    @staticmethod
+    def get_tale_fields_from_manifest(manifest):
+        licenseSPDX = next(
+            (
+                _["schema:license"]
+                for _ in manifest["aggregates"]
+                if "schema:license" in _
+            ),
+            WholeTaleLicense.default_spdx(),
+        )
+
+        authors = [
+            {
+                "firstName": author["schema:givenName"],
+                "lastName": author["schema:familyName"],
+                "orcid": author["@id"],
+            }
+            for author in manifest["schema:author"]
+        ]
+
+        related_ids = [
+            {
+                "identifier": rel_id["DataCite:relatedIdentifier"]["@id"],
+                "relation": rel_id["DataCite:relatedIdentifier"][
+                    "DataCite:relationType"
+                ].split(":")[-1],
+            }
+            for rel_id in manifest.get("DataCite:relatedIdentifiers", [])
+        ]
+        related_ids = [
+            json.loads(rel_id)
+            for rel_id in {json.dumps(_, sort_keys=True) for _ in related_ids}
+        ]
+
+        return {
+            "title": manifest["schema:name"],
+            "description": manifest["schema:description"],
+            "illustration": manifest["schema:image"],
+            "authors": authors,
+            "category": manifest["schema:category"],
+            "licenseSPDX": licenseSPDX,
+            "relatedIdentifiers": related_ids,
+        }
+
+    @staticmethod
+    def get_tale_fields_from_environment(environment):
+        image = Image().findOne({"name": environment["name"]})
+        icon = image.get(
+            "icon",
+            (
+                "https://raw.githubusercontent.com/"
+                "whole-tale/dashboard/master/public/"
+                "images/whole_tale_logo.png"
+            ),
+        )
+        return {
+            "imageId": image["_id"],
+            "icon": icon,
+            "config": environment.get("taleConfig", {}),
+        }

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,4 +55,8 @@ exclude: girder/external/*
 #     N806 - Variable in function should be lowercase.
 #     N812 - Lowercase imported as non lowercase.
 #     W606 - 'async' and 'await' are reserved keywords starting with Python 3.7
-ignore: D100,D101,D102,D103,D104,D105,D107,D200,D201,D202,D203,D204,D205,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812,W606
+#   
+#   Added because of laziness
+#   ~~~~~~~~~~~~~~~~~~~~~~~~~
+#     B902 - blind except Exception: statement
+ignore: D100,D101,D102,D103,D104,D105,D107,D200,D201,D202,D203,D204,D205,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812,W606,B902


### PR DESCRIPTION
This is basically a no-op PR that only refactors code related to parsing `manifest.json` and `enviroment.json` into a Tale. New methods that were moved to `lib.manifest_parser` will come in handy for restoring Tales from previous versions.

### How to test?
1. Create and publish a Tale to Zenodo (preferably with complicated `dataSet` i.e. folder, file, various providers)
2. Remove the Tale (potentially clean girder's db to remove all trace of registered data etc.)
3. Import the Tale

or...

1. Inspect the code since the aforementioned test scenario is already covered by test suite.