### PR TITLE
Updates to manifest format

### DIFF
--- a/plugin_tests/dataverse_test.py
+++ b/plugin_tests/dataverse_test.py
@@ -342,7 +342,7 @@ class DataverseHarversterTestCase(base.TestCase):
         self.assertEqual(
             [(_["mountPath"], _["_modelType"]) for _ in dataset],
             [
-                (ds_root["name"] + "/", "folder"),
+                (ds_root["name"], "folder"),
                 (f"{ds_subfolder['name']}/Source Data.zip", "item"),
                 (ds_item["name"], "item")
             ]

--- a/plugin_tests/dataverse_test.py
+++ b/plugin_tests/dataverse_test.py
@@ -338,15 +338,8 @@ class DataverseHarversterTestCase(base.TestCase):
             image, dataSet, creator=self.user, title="Blah", public=True
         )
         manifest = Manifest(tale, self.user, expand_folders=True).manifest
-        dataset = ManifestParser.get_dataset_from_manifest(manifest)
-        self.assertEqual(
-            [(_["mountPath"], _["_modelType"]) for _ in dataset],
-            [
-                (ds_root["name"], "folder"),
-                (f"{ds_subfolder['name']}/Source Data.zip", "item"),
-                (ds_item["name"], "item")
-            ]
-        )
+        restored_dataset = ManifestParser.get_dataset_from_manifest(manifest)
+        self.assertEqual(restored_dataset, dataSet)
 
         Tale().remove(tale)
         Image().remove(image)

--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -505,8 +505,8 @@ class ManifestTestCase(base.TestCase):
         # won't be 1:1, reverse dataset will have more items
         dataset = ManifestParser.get_dataset_from_manifest(manifest)
         self.assertEqual(
-            [_["itemId"] for _ in dataset][:-3],
-            [str(_["itemId"]) for _ in self.tale["dataSet"][:-1]]
+            [_["itemId"] for _ in dataset],
+            [str(_["itemId"]) for _ in self.tale["dataSet"]]
         )
 
     def tearDown(self):

--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -409,10 +409,13 @@ class ManifestTestCase(base.TestCase):
         from operator import itemgetter
 
         reference_aggregates = sorted(reference_aggregates, key=itemgetter("uri"))
-        manifest_doc = Manifest(self.tale, self.user)
+        manifest_doc = Manifest(self.tale, self.user, expand_folders=True)
+        tale_dataset_ids = {str(_["itemId"]) for _ in self.tale["dataSet"]}
         for i, aggregate in enumerate(
             sorted(manifest_doc.manifest["aggregates"], key=itemgetter("uri"))
         ):
+            if "schema:identifier" in aggregate:
+                aggregate.pop("schema:identifier")
             self.assertDictEqual(aggregate, reference_aggregates[i])
 
         # Check the datasets

--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -501,8 +501,19 @@ class ManifestTestCase(base.TestCase):
         from server.lib.manifest_parser import ManifestParser
         from server.lib.manifest import Manifest
         manifest = Manifest(self.tale, self.user).manifest
-        # NOTE: http(s) folders are expanded into individual files in manifest so the result
-        # won't be 1:1, reverse dataset will have more items
+        dataset = ManifestParser.get_dataset_from_manifest(manifest)
+        self.assertEqual(
+            [_["itemId"] for _ in dataset],
+            [str(_["itemId"]) for _ in self.tale["dataSet"]]
+        )
+
+        # test it still works if schema:identifier is not present
+        aggregates = []
+        for obj in manifest["aggregates"]:
+            if "schema:identifier" in obj:
+                obj.pop("schema:identifier")
+            aggregates.append(obj)
+        manifest["aggregates"] = aggregates
         dataset = ManifestParser.get_dataset_from_manifest(manifest)
         self.assertEqual(
             [_["itemId"] for _ in dataset],

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -342,16 +342,20 @@ class Manifest:
 
                 if obj['_modelType'] == 'folder':
                     is_root_folder = doc['meta'].get('identifier') == top_identifier
-                    if provider_name == 'HTTP' or (self.expand_folders and not is_root_folder):
+                    try:
+                        if is_root_folder:
+                            uri = top_identifier
+                        else:
+                            uri = provider.getURI(doc, self.user)
+                    except NotImplementedError:
+                        uri = None
+
+                    if uri is None and self.expand_folders and not is_root_folder:
                         external_objects += self._expand_folder_into_items(doc, self.user)
                         continue
 
+                    ext_obj['uri'] = uri or "undefined"
                     ext_obj['name'] = doc['name']
-                    if is_root_folder:
-                        ext_obj['uri'] = top_identifier
-                    else:
-                        ext_obj['uri'] = provider.getURI(doc, self.user)
-                        #  Find path to root?
                     ext_obj['size'] = 0
                     for _, f in Folder().fileList(
                         doc, user=self.user, subpath=False, data=False

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -277,6 +277,7 @@ class Manifest:
                 bundle = self.create_bundle('../data/' + obj['name'], None)
             record = self.create_aggregation_record(obj['uri'], bundle, obj['dataset_identifier'])
             record['size'] = obj['size']
+            record["schema:identifier"] = obj["schema:identifier"]
             self.manifest['aggregates'].append(record)
 
     def _expand_folder_into_items(self, folder, user, relpath=''):
@@ -335,7 +336,8 @@ class Manifest:
                     'dataset_identifier': top_identifier,
                     'provider': provider_name,
                     '_modelType': obj['_modelType'],
-                    'relpath': relpath
+                    'relpath': relpath,
+                    "schema:identifier": str(doc["_id"]),
                 }
 
                 if obj['_modelType'] == 'folder':

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -20,7 +20,7 @@ class Manifest:
     create<someProperty>
     """
 
-    def __init__(self, tale, user, expand_folders=False):
+    def __init__(self, tale, user, expand_folders=True):
         """
         Initialize the manifest document with base variables
         :param tale: The Tale whose data is being serialized

--- a/server/lib/manifest_parser.py
+++ b/server/lib/manifest_parser.py
@@ -23,6 +23,8 @@ class ManifestParser:
                 continue
 
             folder_path = bundle["folder"].replace(data_prefix, "")
+            if folder_path.endswith("/"):
+                folder_path = folder_path[:-1]
             if "filename" in bundle:
                 try:
                     item = Item().load(obj["schema:identifier"], force=True, exc=True)

--- a/server/lib/manifest_parser.py
+++ b/server/lib/manifest_parser.py
@@ -16,6 +16,8 @@ def fold_hierarchy(objs):
     covered_ids = set()
     reiterate = False
 
+    current_ids = set([obj["itemId"] for obj in objs])
+
     for obj in objs:
         mount_path = pathlib.Path(obj["mountPath"])
         if len(mount_path.parts) > 1:
@@ -27,6 +29,9 @@ def fold_hierarchy(objs):
                 parentId = Item().load(obj["itemId"], force=True)["folderId"]
             else:
                 parentId = Folder().load(obj["itemId"], force=True)["parentId"]
+
+            if str(parentId) in current_ids:
+                continue
 
             parent = Folder().load(parentId, force=True)
             covered_ids |= set([str(_["_id"]) for _ in Folder().childItems(parent)])

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -344,6 +344,7 @@ class Tale(Resource):
         return tale
 
     @access.user
+    @filtermodel(model="tale", plugin="wholetale")
     @autoDescribeRoute(
         Description('Create a new tale.')
         .jsonParam('tale', 'A new tale', paramType='body', schema=taleSchema,

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -434,7 +434,7 @@ class Tale(Resource):
         .modelParam('id', model='tale', plugin='wholetale', level=AccessType.READ)
         .param('expandFolders', "If True, folders in Tale's dataSet are recursively "
                "expanded to items in the 'aggregates' section",
-               required=False, dataType='boolean', default=False)
+               required=False, dataType='boolean', default=True)
         .errorResponse('ID was invalid.')
     )
     def generateManifest(self, tale, expandFolders):


### PR DESCRIPTION
This PR introduces a few changes to manifest machinery:

1. Girder UUIDs are now stored in the individual objects in the `aggregates` section under `schema:identifier` field
2. Folder from `dataSet` are only expanded into individual items during manifest creation if `expand_folders` is set and their URI is not well defined (e.g. you cannot request to download a specific folder from DV dataset). Previous it behaved differently:
    1. HTTP folders were *always* expanded regardless `expand_folders` value.
    2. Globus folders were expanded if `expand_folders` were True. This no longer a case, since they have a valid URI.
3. Restoration of a `dataSet` from manifest now uses the new `schema:identifier` and only defaults to the "old ways" if it's not present. This will allow to restore a Tale from a version more easily.
