### PR TITLE
Drop obsolete folderId and narrative from Tales

### DIFF
--- a/plugin_tests/import_test.py
+++ b/plugin_tests/import_test.py
@@ -15,8 +15,6 @@ from girder import config
 from girder.models.token import Token
 
 
-SCRIPTDIRS_NAME = None
-DATADIRS_NAME = None
 DATA_PATH = os.path.join(
     os.path.dirname(os.environ["GIRDER_TEST_DATA_PREFIX"]),
     "data_src",
@@ -56,9 +54,6 @@ def setUpModule():
     from girder.plugins.jobs.constants import JobStatus
     from girder.plugins.wholetale.models.tale import Tale
     from girder.plugins.wholetale.constants import ImageStatus
-
-    global SCRIPTDIRS_NAME, DATADIRS_NAME
-    from girder.plugins.wholetale.constants import SCRIPTDIRS_NAME, DATADIRS_NAME
 
 
 def tearDownModule():

--- a/server/constants.py
+++ b/server/constants.py
@@ -7,8 +7,6 @@ from girder import events
 API_VERSION = "2.1"
 CATALOG_NAME = "WholeTale Catalog"
 WORKSPACE_NAME = "WholeTale Workspaces"
-DATADIRS_NAME = "WholeTale Data Mountpoints"
-SCRIPTDIRS_NAME = "WholeTale Narrative"
 DEFAULT_IMAGE_ICON = (
     "https://raw.githubusercontent.com/whole-tale/dashboard/master/public/"
     "images/whole_tale_logo.png"

--- a/server/rest/instance.py
+++ b/server/rest/instance.py
@@ -17,7 +17,7 @@ instanceSchema = {
     'type': 'object',
     'required': [
         '_accessLevel', '_id', '_modelType', 'containerId',
-        'containerPath', 'created', 'digest', 'folderId',
+        'containerPath', 'created', 'digest',
         'frontendId', 'imageId',  'lastActivity', 'mountPoint',
         'status', 'userId', 'when'
     ],

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -372,7 +372,6 @@ class Tale(Resource):
                 illustration=tale.get('illustration', DEFAULT_ILLUSTRATION),
                 authors=tale.get('authors', default_author),
                 category=tale.get('category', 'science'),
-                narrative=tale.get('narrative'),
                 licenseSPDX=tale.get('licenseSPDX'),
                 relatedIdentifiers=tale.get('relatedIdentifiers'),
             )
@@ -521,7 +520,6 @@ class Tale(Resource):
             illustration=tale.get('illustration', DEFAULT_ILLUSTRATION),
             authors=tale.get('authors', default_author),
             category=tale.get('category', 'science'),
-            narrative=tale.get('narrative'),
             licenseSPDX=tale.get('licenseSPDX'),
             status=TaleStatus.PREPARING,
             relatedIdentifiers=tale.get('relatedIdentifiers'),

--- a/server/schema/tale.py
+++ b/server/schema/tale.py
@@ -38,28 +38,12 @@ taleModel = {
         "imageInfo": {
             "$ref": "#/definitions/imageInfo"
         },
-        "folderId": {
-            "type": "string",
-            "description": "ID of a folder containing copy of tale['dataSet']"
-        },
-        "narrativeId": {
-            "type": "string",
-            "description": "ID of a folder containing copy of tale['narrative']"
-        },
         "dataSet": {
             "$ref": "#/definitions/dataSet"
         },
         "workspaceId": {
             "type": "string",
             "description": "ID of a folder containing Tale's workspace"
-        },
-        "narrative": {
-            "type": "array",
-            "items": {
-                'type': 'string',
-                'description': "Girder Item id"
-            },
-            "description": "List of Girder Items containing Tale's narrative"
         },
         "format": {
             "type": "integer",
@@ -152,7 +136,6 @@ taleModel = {
         ],
         "description": "#### Markdown Editor",
         "doi": "doi:x.xx.xxx",
-        "folderId": "5c4887409759c200017b2316",
         "format": 4,
         "icon": ("https://raw.githubusercontent.com/whole-tale/jupyter-base/"
                  "master/squarelogo-greytext-orangebody-greymoons.png"),
@@ -165,8 +148,6 @@ taleModel = {
             'digest': 'sha256:9aaece098841b13cdc64ea6756767357f5c9eb1ab10f67b9e67a90960b894053',
             'fullName': 'registry.local.wholetale.org/5c3cd7faa697bf0001ce6cc0-1547494547'
         },
-        "narrative": [],
-        "narrativeId": "5c4887409759c200017b2319",
         "public": False,
         "publishInfo": [
             {


### PR DESCRIPTION
This PR removes support for two unused "features" from Tale model: "old" data folder and narrative folder. It's a first step for a new and *better* handling of auxiliary folders. The only remaining folder is `workspace` but I plan to move it where it belongs, i.e. `wt_home_dirs` plugin.