### PR TITLE
Refactor manifest/environment serialization

### DIFF
--- a/server/lib/exporters/native.py
+++ b/server/lib/exporters/native.py
@@ -1,5 +1,3 @@
-import json
-from girder.utility import JsonEncoder
 from . import TaleExporter
 
 
@@ -8,9 +6,7 @@ class NativeTaleExporter(TaleExporter):
         extra_files = {
             'README.md': self.default_top_readme,
             'LICENSE': self.tale_license['text'],
-            'metadata/environment.json': json.dumps(
-                self.get_environment(), indent=4, cls=JsonEncoder, sort_keys=True, allow_nan=False
-            ),
+            'metadata/environment.json': self.manifest_obj.dump_environment(indent=4),
         }
 
         # Add files from the workspace
@@ -34,7 +30,7 @@ class NativeTaleExporter(TaleExporter):
         self.append_extras_filesize_mimetypes(extra_files)
 
         for data in self.zip_generator.addFile(
-            lambda: json.dumps(self.manifest, indent=4), 'metadata/manifest.json'
+            lambda: self.manifest_obj.dump_manifest(indent=4), 'metadata/manifest.json'
         ):
             yield data
 

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -25,7 +25,7 @@ from ..constants import TaleStatus
 from ..schema.misc import related_identifiers_schema
 from ..utils import getOrCreateRootFolder, init_progress
 from ..lib.license import WholeTaleLicense
-from ..lib.manifest_parser import ManifestParser
+from ..lib.manifest_parser import ManifestParser as mp
 
 from gwvolman.tasks import build_tale_image, BUILD_TALE_IMAGE_STEP_TOTAL
 
@@ -369,9 +369,9 @@ class Tale(AccessControlledModel):
             stream
         )
 
-        new_tale = ManifestParser.get_tale_fields_from_environment(environment)
+        new_tale = mp.get_tale_fields_from_environment(environment)
         image = imageModel().load(new_tale.pop("imageId"), user=user, level=AccessType.READ)
-        new_tale.update(ManifestParser.get_tale_fields_from_manifest(manifest))
+        new_tale.update(mp.get_tale_fields_from_manifest(manifest))
 
         if relatedIdentifiers is None:
             relatedIdentifiers = []
@@ -393,7 +393,7 @@ class Tale(AccessControlledModel):
             )
         )
 
-        # We don't call ManifestParser.get_dataset_from_manifest now, cause it might require
+        # We don't call mp.get_dataset_from_manifest now, cause it might require
         # a registration step. It's going to be called inside import_tale job.
 
         tale = self.createTale(

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -442,3 +442,15 @@ class Tale(AccessControlledModel):
         )
         Job().scheduleJob(job)
         return tale
+
+    def restoreTale(self, manifest: dict, environment: dict):
+        """
+        Restore a Tale from manifest/environment JSON.
+
+        NOTE: it will be missing a lot of keywords that makes it a model,
+        e.g. _id, acls etc.
+        """
+        restored_tale = mp.get_tale_fields_from_manifest(manifest)
+        restored_tale.update(mp.get_tale_fields_from_environment(environment))
+        restored_tale["dataSet"] = mp.get_dataset_from_manifest(manifest)
+        return restored_tale


### PR DESCRIPTION
Extracting serialization into separate methods, allows to easily reuse them elsewhere. One particular place I have in mind is using Tale -> Manifest -> Tale cycle for easy in-between-versions comparison of Tale objects, but that's a separate PR (though partially hinted in tests here)