### PR TITLE
Add notifications for shared events

### DIFF
--- a/plugin_tests/import_test.py
+++ b/plugin_tests/import_test.py
@@ -290,7 +290,7 @@ class ImportTaleTestCase(base.TestCase):
                 job = Job().findOne({"type": "wholetale.import_binder"})
                 self.assertEqual(json.loads(job["kwargs"])["taleId"]["$oid"], tale["_id"])
 
-                for i in range(300):
+                for i in range(600):
                     if job["status"] in {JobStatus.SUCCESS, JobStatus.ERROR}:
                         break
                     time.sleep(0.1)

--- a/plugin_tests/import_test.py
+++ b/plugin_tests/import_test.py
@@ -380,11 +380,11 @@ class ImportTaleTestCase(base.TestCase):
         )
 
         events = get_events(self, since)
-        self.assertEqual(len(events), 6)
+        self.assertEqual(len(events), 7)
         self.assertEqual(events[0]['data']['event'], 'wt_tale_created')
         self.assertEqual(events[1]['data']['event'], 'wt_import_started')
         # 3 events are wt_tale_updated from import process changing tale state
-        self.assertEqual(events[5]['data']['event'], 'wt_import_completed')
+        self.assertEqual(events[6]['data']['event'], 'wt_import_completed')
 
         self.model("image", "wholetale").remove(image)
 

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -747,7 +747,7 @@ class TaleTestCase(base.TestCase):
         events = get_events(self, since)
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0]['data']['event'], 'wt_tale_created')
-        self.assertEqual(events[0]['data']['resourceId'], tale['_id'])
+        self.assertEqual(events[0]['data']['affectedResourceIds']['taleId'], tale['_id'])
 
         from girder.constants import AccessType
         # Update the access control list for the tale by adding the admin
@@ -780,7 +780,7 @@ class TaleTestCase(base.TestCase):
         events = get_events(self, since, user=self.admin)
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0]['data']['event'], 'wt_tale_shared')
-        self.assertEqual(events[0]['data']['resourceId'], tale['_id'])
+        self.assertEqual(events[0]['data']['affectedResourceIds']['taleId'], tale['_id'])
 
         # Update tale, confirm notifications
         since = datetime.now().isoformat()
@@ -802,12 +802,12 @@ class TaleTestCase(base.TestCase):
         events = get_events(self, since, user=self.user)
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0]['data']['event'], 'wt_tale_updated')
-        self.assertEqual(events[0]['data']['resourceId'], tale['_id'])
+        self.assertEqual(events[0]['data']['affectedResourceIds']['taleId'], tale['_id'])
 
         events = get_events(self, since, user=self.admin)
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0]['data']['event'], 'wt_tale_updated')
-        self.assertEqual(events[0]['data']['resourceId'], tale['_id'])
+        self.assertEqual(events[0]['data']['affectedResourceIds']['taleId'], tale['_id'])
 
         # Remove admin and confirm notification
         input_tale_access = {
@@ -831,7 +831,7 @@ class TaleTestCase(base.TestCase):
         events = get_events(self, since, user=self.admin)
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0]['data']['event'], 'wt_tale_unshared')
-        self.assertEqual(events[0]['data']['resourceId'], tale['_id'])
+        self.assertEqual(events[0]['data']['affectedResourceIds']['taleId'], tale['_id'])
 
         # Re-add admin user to test delete notification
         resp = self.request(
@@ -850,12 +850,12 @@ class TaleTestCase(base.TestCase):
         events = get_events(self, since, user=self.user)
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0]['data']['event'], 'wt_tale_removed')
-        self.assertEqual(events[0]['data']['resourceId'], tale['_id'])
+        self.assertEqual(events[0]['data']['affectedResourceIds']['taleId'], tale['_id'])
 
         events = get_events(self, since, user=self.admin)
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0]['data']['event'], 'wt_tale_removed')
-        self.assertEqual(events[0]['data']['resourceId'], tale['_id'])
+        self.assertEqual(events[0]['data']['affectedResourceIds']['taleId'], tale['_id'])
 
     def tearDown(self):
         self.model('user').remove(self.user)

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -747,7 +747,7 @@ class TaleTestCase(base.TestCase):
         events = get_events(self, since)
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0]['data']['event'], 'wt_tale_created')
-        self.assertEqual(events[0]['data']['resource'], tale['_id'])
+        self.assertEqual(events[0]['data']['resourceId'], tale['_id'])
 
         from girder.constants import AccessType
         # Update the access control list for the tale by adding the admin
@@ -780,7 +780,7 @@ class TaleTestCase(base.TestCase):
         events = get_events(self, since, user=self.admin)
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0]['data']['event'], 'wt_tale_shared')
-        self.assertEqual(events[0]['data']['resource'], tale['_id'])
+        self.assertEqual(events[0]['data']['resourceId'], tale['_id'])
 
         # Update tale, confirm notifications
         since = datetime.now().isoformat()
@@ -802,12 +802,12 @@ class TaleTestCase(base.TestCase):
         events = get_events(self, since, user=self.user)
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0]['data']['event'], 'wt_tale_updated')
-        self.assertEqual(events[0]['data']['resource'], tale['_id'])
+        self.assertEqual(events[0]['data']['resourceId'], tale['_id'])
 
         events = get_events(self, since, user=self.admin)
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0]['data']['event'], 'wt_tale_updated')
-        self.assertEqual(events[0]['data']['resource'], tale['_id'])
+        self.assertEqual(events[0]['data']['resourceId'], tale['_id'])
 
         # Remove admin and confirm notification
         input_tale_access = {
@@ -831,7 +831,7 @@ class TaleTestCase(base.TestCase):
         events = get_events(self, since, user=self.admin)
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0]['data']['event'], 'wt_tale_unshared')
-        self.assertEqual(events[0]['data']['resource'], tale['_id'])
+        self.assertEqual(events[0]['data']['resourceId'], tale['_id'])
 
         # Re-add admin user to test delete notification
         resp = self.request(
@@ -850,12 +850,12 @@ class TaleTestCase(base.TestCase):
         events = get_events(self, since, user=self.user)
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0]['data']['event'], 'wt_tale_removed')
-        self.assertEqual(events[0]['data']['resource'], tale['_id'])
+        self.assertEqual(events[0]['data']['resourceId'], tale['_id'])
 
         events = get_events(self, since, user=self.admin)
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0]['data']['event'], 'wt_tale_removed')
-        self.assertEqual(events[0]['data']['resource'], tale['_id'])
+        self.assertEqual(events[0]['data']['resourceId'], tale['_id'])
 
     def tearDown(self):
         self.model('user').remove(self.user)

--- a/plugin_tests/tests_helpers.py
+++ b/plugin_tests/tests_helpers.py
@@ -4,3 +4,15 @@ import httmock
 @httmock.all_requests
 def mockOtherRequest(url, request):
     raise Exception('Unexpected url %s' % str(request.url))
+
+
+def get_events(test, since, user=None):
+    if not user:
+        user = test.user
+
+    resp = test.request(
+        path="/notification", method='GET',
+        user=user, params={'since': since})
+    test.assertStatusOk(resp)
+
+    return [event for event in resp.json if event['type'] == 'wt_event']

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -459,6 +459,7 @@ def load(info):
     events.bind('jobs.job.update.after', 'wholetale', updateNotification)
     events.bind('model.file.validate', 'wholetale', validateFileLink)
     events.bind('oauth.auth_callback.after', 'wholetale', store_other_globus_tokens)
+
     info['apiRoot'].account = Account()
     info['apiRoot'].repository = Repository()
     info['apiRoot'].license = License()

--- a/server/models/instance.py
+++ b/server/models/instance.py
@@ -135,7 +135,7 @@ class Instance(AccessControlledModel):
         ).apply_async()
         instanceTask.get(timeout=TASK_TIMEOUT)
 
-        notify_event([str(user["_id"])], "wt_instance_deleting", "instance",
+        notify_event([user["_id"]], "wt_instance_deleting", "instance",
                      instance['_id'])
 
         try:
@@ -153,7 +153,7 @@ class Instance(AccessControlledModel):
         # TODO: handle error
         self.remove(instance)
 
-        notify_event([str(user["_id"])], "wt_instance_deleted", "instance",
+        notify_event([user["_id"]], "wt_instance_deleted", "instance",
                      instance['_id'])
 
     def createInstance(self, tale, user, name=None, save=True, spawn=True):
@@ -226,7 +226,7 @@ class Instance(AccessControlledModel):
 
             (buildTask | volumeTask | serviceTask).apply_async()
 
-            notify_event([str(tale["creatorId"])], "wt_instance_launching", "instance",
+            notify_event([tale["creatorId"]], "wt_instance_launching", "instance",
                          instance['_id'])
         return instance
 
@@ -307,14 +307,14 @@ def finalizeInstance(event):
             if "sessionId" in service:
                 instance["sessionId"] = ObjectId(service["sessionId"])
 
-            notify_event([str(tale["creatorId"])], "wt_instance_running", "instance",
+            notify_event([instance["creatorId"]], "wt_instance_running", "instance",
                          instance['_id'])
         elif (
             status == JobStatus.ERROR
             and instance["status"] != InstanceStatus.ERROR  # noqa
         ):
             instance['status'] = InstanceStatus.ERROR
-            notify_event([str(tale["creatorId"])], "wt_instance_error", "instance",
+            notify_event([tale["creatorId"]], "wt_instance_error", "instance",
                          instance['_id'])
         elif (
             status in (JobStatus.QUEUED, JobStatus.RUNNING)

--- a/server/models/instance.py
+++ b/server/models/instance.py
@@ -135,8 +135,8 @@ class Instance(AccessControlledModel):
         ).apply_async()
         instanceTask.get(timeout=TASK_TIMEOUT)
 
-        notify_event([instance["creatorId"]], "wt_instance_deleting", "instance",
-                     instance['_id'])
+        notify_event([instance['creatorId']], 'wt_instance_deleting',
+                     {'taleId': instance['taleId'], 'instanceId': instance['_id']})
 
         try:
             queue = 'celery@{}'.format(instance['containerInfo']['nodeId'])
@@ -153,8 +153,8 @@ class Instance(AccessControlledModel):
         # TODO: handle error
         self.remove(instance)
 
-        notify_event([instance["creatorId"]], "wt_instance_deleted", "instance",
-                     instance['_id'])
+        notify_event([instance["creatorId"]], "wt_instance_deleted",
+                     {'taleId': instance['taleId'], 'instanceId': instance['_id']})
 
     def createInstance(self, tale, user, name=None, save=True, spawn=True):
         if not name:
@@ -226,8 +226,8 @@ class Instance(AccessControlledModel):
 
             (buildTask | volumeTask | serviceTask).apply_async()
 
-            notify_event([instance["creatorId"]], "wt_instance_launching", "instance",
-                         instance['_id'])
+            notify_event([instance["creatorId"]], "wt_instance_launching",
+                         {'taleId': instance['taleId'], 'instanceId': instance['_id']})
         return instance
 
 
@@ -307,15 +307,15 @@ def finalizeInstance(event):
             if "sessionId" in service:
                 instance["sessionId"] = ObjectId(service["sessionId"])
 
-            notify_event([instance["creatorId"]], "wt_instance_running", "instance",
-                         instance['_id'])
+            notify_event([instance["creatorId"]], "wt_instance_running",
+                         {'taleId': instance['taleId'], 'instanceId': instance['_id']})
         elif (
             status == JobStatus.ERROR
             and instance["status"] != InstanceStatus.ERROR  # noqa
         ):
             instance['status'] = InstanceStatus.ERROR
-            notify_event([instance["creatorId"]], "wt_instance_error", "instance",
-                         instance['_id'])
+            notify_event([instance["creatorId"]], "wt_instance_error",
+                         {'taleId': instance['taleId'], 'instanceId': instance['_id']})
         elif (
             status in (JobStatus.QUEUED, JobStatus.RUNNING)
             and instance["status"] != InstanceStatus.LAUNCHING  # noqa

--- a/server/models/instance.py
+++ b/server/models/instance.py
@@ -135,7 +135,7 @@ class Instance(AccessControlledModel):
         ).apply_async()
         instanceTask.get(timeout=TASK_TIMEOUT)
 
-        notify_event([user["_id"]], "wt_instance_deleting", "instance",
+        notify_event([instance["creatorId"]], "wt_instance_deleting", "instance",
                      instance['_id'])
 
         try:
@@ -153,7 +153,7 @@ class Instance(AccessControlledModel):
         # TODO: handle error
         self.remove(instance)
 
-        notify_event([user["_id"]], "wt_instance_deleted", "instance",
+        notify_event([instance["creatorId"]], "wt_instance_deleted", "instance",
                      instance['_id'])
 
     def createInstance(self, tale, user, name=None, save=True, spawn=True):
@@ -226,7 +226,7 @@ class Instance(AccessControlledModel):
 
             (buildTask | volumeTask | serviceTask).apply_async()
 
-            notify_event([tale["creatorId"]], "wt_instance_launching", "instance",
+            notify_event([instance["creatorId"]], "wt_instance_launching", "instance",
                          instance['_id'])
         return instance
 
@@ -314,7 +314,7 @@ def finalizeInstance(event):
             and instance["status"] != InstanceStatus.ERROR  # noqa
         ):
             instance['status'] = InstanceStatus.ERROR
-            notify_event([tale["creatorId"]], "wt_instance_error", "instance",
+            notify_event([instance["creatorId"]], "wt_instance_error", "instance",
                          instance['_id'])
         elif (
             status in (JobStatus.QUEUED, JobStatus.RUNNING)

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -207,7 +207,7 @@ class Tale(AccessControlledModel):
 
         if save:
             tale = self.save(tale)
-            notify_event([creator["_id"]], "wt_tale_created", "tale", tale['_id'])
+            notify_event([creator["_id"]], "wt_tale_created", {"taleId": tale['_id']})
 
         return tale
 
@@ -242,7 +242,7 @@ class Tale(AccessControlledModel):
         tale['updated'] = datetime.datetime.utcnow()
         ret = self.save(tale)
         users = [user['id'] for user in tale['access']['users']]
-        notify_event(users, "wt_tale_updated", "tale", str(tale["_id"]))
+        notify_event(users, "wt_tale_updated", {"taleId": tale['_id']})
         return ret
 
     def setAccessList(self, doc, access, save=False, user=None, force=False,
@@ -277,8 +277,8 @@ class Tale(AccessControlledModel):
                                       force=force)
 
         added, removed = diff_access(doc['access'], access)
-        notify_event(added, "wt_tale_shared", "tale", str(doc["_id"]))
-        notify_event(removed, "wt_tale_unshared", "tale", str(doc["_id"]))
+        notify_event(added, "wt_tale_shared", {"taleId": str(doc["_id"])})
+        notify_event(removed, "wt_tale_unshared", {"taleId": str(doc["_id"])})
 
         doc = super().setAccessList(
             doc, access, user=user, save=save, force=force)

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -402,12 +402,25 @@ class Tale(AccessControlledModel):
             **new_tale
         )
 
+        resource = {
+            "type": "wt_zip_import",
+            "tale_id": tale["_id"],
+            "tale_title": tale["title"]
+        }
+        notification = init_progress(
+            resource, user, "Importing Tale", "Initializing", 1
+        )
+
         job = Job().createLocalJob(
             title='Import Tale from zip', user=user,
             type='wholetale.import_tale', public=False, _async=True,
             module='girder.plugins.wholetale.tasks.import_tale',
             args=(temp_dir, manifest_file),
-            kwargs={'taleId': tale["_id"]}
+            kwargs={'taleId': tale["_id"]},
+            otherFields={
+                "taleId": tale["_id"],
+                "wt_notification_id": str(notification["_id"])
+            },
         )
         Job().scheduleJob(job)
         return tale

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -207,7 +207,7 @@ class Tale(AccessControlledModel):
 
         if save:
             tale = self.save(tale)
-            notify_event([str(creator["_id"])], "wt_tale_created", "tale", tale['_id'])
+            notify_event([creator["_id"]], "wt_tale_created", "tale", tale['_id'])
 
         return tale
 
@@ -241,7 +241,7 @@ class Tale(AccessControlledModel):
         """
         tale['updated'] = datetime.datetime.utcnow()
         ret = self.save(tale)
-        users = [str(user['id']) for user in tale['access']['users']]
+        users = [user['id'] for user in tale['access']['users']]
         notify_event(users, "wt_tale_updated", "tale", str(tale["_id"]))
         return ret
 

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -7,7 +7,6 @@ import pathlib
 import shutil
 import textwrap
 from urllib.parse import urlparse
-
 from girder import events
 from girder.api import access
 from girder.api.rest import iterBody
@@ -34,6 +33,7 @@ from ..lib.dataone import DataONELocations  # TODO: get rid of it
 from ..lib.manifest import Manifest
 from ..lib.exporters.bag import BagTaleExporter
 from ..lib.exporters.native import NativeTaleExporter
+from ..utils import notify_event
 
 from girder.plugins.worker import getCeleryApp
 
@@ -174,6 +174,7 @@ class Tale(Resource):
             event = events.trigger('tale.update_citation', eventParams)
             if len(event.responses):
                 taleObj = self._model.updateTale(event.responses[-1])
+
         return taleObj
 
     @access.user
@@ -198,6 +199,9 @@ class Tale(Resource):
             shutil.rmtree(workspace["fsPath"], ignore_errors=True)
             Folder().remove(workspace, progress=ctx)
         self._model.remove(tale)
+
+        users = [str(user['id']) for user in tale['access']['users']]
+        notify_event(users, "wt_tale_removed", "tale", str(tale["_id"]))
 
     @access.user
     @filtermodel(model='tale', plugin='wholetale')

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -201,7 +201,7 @@ class Tale(Resource):
         self._model.remove(tale)
 
         users = [str(user['id']) for user in tale['access']['users']]
-        notify_event(users, "wt_tale_removed", "tale", str(tale["_id"]))
+        notify_event(users, "wt_tale_removed", {"taleId": str(tale["_id"])})
 
     @access.user
     @filtermodel(model='tale', plugin='wholetale')

--- a/server/tasks/import_binder.py
+++ b/server/tasks/import_binder.py
@@ -83,7 +83,7 @@ def run(job):
     progressCurrent = 0
 
     try:
-        notify_event([user["_id"]], "wt_import_started", "tale", tale['_id'])
+        notify_event([user["_id"]], "wt_import_started", {"taleId": tale['_id']})
 
         # 0. Spawn instance in the background
         if spawn:
@@ -231,7 +231,7 @@ def run(job):
         else:
             instance = None
 
-        notify_event([user["_id"]], "wt_import_completed", "tale", tale['_id'])
+        notify_event([user["_id"]], "wt_import_completed", {"taleId": tale['_id']})
 
     except Exception:
         tale = Tale().load(tale["_id"], user=user)  # Refresh state
@@ -247,7 +247,7 @@ def run(job):
             status=JobStatus.ERROR,
             log=log,
         )
-        notify_event([user["_id"]], "wt_import_failed", "tale", tale['_id'])
+        notify_event([user["_id"]], "wt_import_failed", {"taleId": tale['_id']})
         raise
 
     # To get rid of ObjectId's, dates etc.

--- a/server/tasks/import_binder.py
+++ b/server/tasks/import_binder.py
@@ -83,7 +83,7 @@ def run(job):
     progressCurrent = 0
 
     try:
-        notify_event([str(user["_id"])], "wt_import_started", "tale", tale['_id'])
+        notify_event([user["_id"]], "wt_import_started", "tale", tale['_id'])
 
         # 0. Spawn instance in the background
         if spawn:
@@ -231,7 +231,7 @@ def run(job):
         else:
             instance = None
 
-        notify_event([str(user["_id"])], "wt_import_completed", "tale", tale['_id'])
+        notify_event([user["_id"]], "wt_import_completed", "tale", tale['_id'])
 
     except Exception:
         tale = Tale().load(tale["_id"], user=user)  # Refresh state
@@ -247,7 +247,7 @@ def run(job):
             status=JobStatus.ERROR,
             log=log,
         )
-        notify_event([str(user["_id"])], "wt_import_failed", "tale", tale['_id'])
+        notify_event([user["_id"]], "wt_import_failed", "tale", tale['_id'])
         raise
 
     # To get rid of ObjectId's, dates etc.

--- a/server/tasks/import_git_repo.py
+++ b/server/tasks/import_git_repo.py
@@ -43,7 +43,7 @@ def run(job):
     progressCurrent = 0
 
     try:
-        notify_event(users, "wt_import_started", "tale", tale['_id'])
+        notify_event(users, "wt_import_started", {"taleId": tale['_id']})
 
         workspace = Folder().load(tale["workspaceId"], force=True)
         has_dot_git_already = os.path.isdir(os.path.join(workspace["fsPath"], ".git"))
@@ -114,7 +114,7 @@ def run(job):
         else:
             instance = None
 
-        notify_event(users, "wt_import_completed", "tale", tale['_id'])
+        notify_event(users, "wt_import_completed", {"taleId": tale['_id']})
 
     except Exception as exc:
         dot_git = os.path.join(workspace["fsPath"], ".git")
@@ -132,7 +132,7 @@ def run(job):
             status=JobStatus.ERROR,
             log=str(exc),
         )
-        notify_event(users, "wt_import_failed", "tale", tale['_id'])
+        notify_event(users, "wt_import_failed", {"taleId": tale['_id']})
         raise
 
     # To get rid of ObjectId's, dates etc.

--- a/server/tasks/import_tale.py
+++ b/server/tasks/import_tale.py
@@ -42,7 +42,7 @@ def run(job):
     progressCurrent = 0
 
     try:
-        notify_event([str(user["_id"])], "wt_import_started", "tale", tale['_id'])
+        notify_event([user["_id"]], "wt_import_started", "tale", tale['_id'])
 
         os.chdir(tale_dir)
         mp = ManifestParser(manifest_file)
@@ -141,7 +141,7 @@ def run(job):
             progressMessage="Tale created",
         )
 
-        notify_event([str(user["_id"])], "wt_import_completed", "tale", tale['_id'])
+        notify_event([user["_id"]], "wt_import_completed", "tale", tale['_id'])
     except Exception:
         tale = Tale().load(tale["_id"], user=user)  # Refresh state
         tale["status"] = TaleStatus.ERROR
@@ -149,5 +149,5 @@ def run(job):
         t, val, tb = sys.exc_info()
         log = "%s: %s\n%s" % (t.__name__, repr(val), traceback.extract_tb(tb))
         jobModel.updateJob(job, status=JobStatus.ERROR, log=log)
-        notify_event([str(user["_id"])], "wt_import_failed", "tale", tale['_id'])
+        notify_event([user["_id"]], "wt_import_failed", "tale", tale['_id'])
         raise

--- a/server/tasks/import_tale.py
+++ b/server/tasks/import_tale.py
@@ -42,7 +42,7 @@ def run(job):
     progressCurrent = 0
 
     try:
-        notify_event([user["_id"]], "wt_import_started", "tale", tale['_id'])
+        notify_event([user["_id"]], "wt_import_started", {"taleId": tale['_id']})
 
         os.chdir(tale_dir)
         mp = ManifestParser(manifest_file)
@@ -141,7 +141,7 @@ def run(job):
             progressMessage="Tale created",
         )
 
-        notify_event([user["_id"]], "wt_import_completed", "tale", tale['_id'])
+        notify_event([user["_id"]], "wt_import_completed", {"taleId": tale['_id']})
     except Exception:
         tale = Tale().load(tale["_id"], user=user)  # Refresh state
         tale["status"] = TaleStatus.ERROR
@@ -149,5 +149,5 @@ def run(job):
         t, val, tb = sys.exc_info()
         log = "%s: %s\n%s" % (t.__name__, repr(val), traceback.extract_tb(tb))
         jobModel.updateJob(job, status=JobStatus.ERROR, log=log)
-        notify_event([user["_id"]], "wt_import_failed", "tale", tale['_id'])
+        notify_event([user["_id"]], "wt_import_failed", {"taleId": tale['_id']})
         raise

--- a/server/tasks/import_tale.py
+++ b/server/tasks/import_tale.py
@@ -24,7 +24,7 @@ from ..lib import pids_to_entities, register_dataMap
 from ..lib.dataone import DataONELocations  # TODO: get rid of it
 from ..lib.manifest_parser import ManifestParser
 from ..models.tale import Tale
-from ..utils import getOrCreateRootFolder
+from ..utils import getOrCreateRootFolder, notify_event
 
 
 def run(job):
@@ -42,6 +42,8 @@ def run(job):
     progressCurrent = 0
 
     try:
+        notify_event([str(user["_id"])], "wt_import_started", "tale", tale['_id'])
+
         os.chdir(tale_dir)
         mp = ManifestParser(manifest_file)
 
@@ -138,6 +140,8 @@ def run(job):
             progressCurrent=progressCurrent,
             progressMessage="Tale created",
         )
+
+        notify_event([str(user["_id"])], "wt_import_completed", "tale", tale['_id'])
     except Exception:
         tale = Tale().load(tale["_id"], user=user)  # Refresh state
         tale["status"] = TaleStatus.ERROR
@@ -145,4 +149,5 @@ def run(job):
         t, val, tb = sys.exc_info()
         log = "%s: %s\n%s" % (t.__name__, repr(val), traceback.extract_tb(tb))
         jobModel.updateJob(job, status=JobStatus.ERROR, log=log)
+        notify_event([str(user["_id"])], "wt_import_failed", "tale", tale['_id'])
         raise

--- a/server/utils.py
+++ b/server/utils.py
@@ -57,7 +57,7 @@ def notify_event(users, event, modelType, objid):
     data = {
         'event': event,
         'modelType': modelType,
-        'resource': objid,
+        'resourceId': objid,
         'resourceName': 'WT event'
     }
 

--- a/server/utils.py
+++ b/server/utils.py
@@ -65,8 +65,6 @@ def notify_event(users, event, modelType, objid):
 
     for user_id in users:
         user = User().load(user_id, force=True)
-        # Why doesn't logger work for me?
-        print("NOTIFYING %s %s" % (user_id, str(data)))
         Notification().createNotification(
             type="wt_event", data=data, user=user, expires=expires)
 

--- a/server/utils.py
+++ b/server/utils.py
@@ -112,8 +112,8 @@ def diff_access(access1, access2):
     """Diff two access lists to identify which users
     were added or removed.
     """
-    existing = [str(user['id']) for user in access1['users']]
-    new = [str(user['id']) for user in access2['users']]
-    added = list(set(new) - set(existing))
-    removed = list(set(existing) - set(new))
+    existing = {str(user['id']) for user in access1['users']}
+    new = {str(user['id']) for user in access2['users']}
+    added = list(new - existing)
+    removed = list(existing - new)
     return (added, removed)

--- a/server/utils.py
+++ b/server/utils.py
@@ -46,18 +46,16 @@ def esc(value):
     return urllib.parse.quote_plus(value)
 
 
-def notify_event(users, event, modelType, objid):
+def notify_event(users, event, affectedIds):
     """
     Notify multiple users of a particular WT event
     :param users: Arrayof user IDs
     :param event: WT Event name
-    :param modelType: Girder model type (e.g., tale)
-    :param objid: Object ID of referenced object
+    :param affectedIds: Map of affected object Ids
     """
     data = {
         'event': event,
-        'modelType': modelType,
-        'resourceId': objid,
+        'affectedResourceIds': affectedIds,
         'resourceName': 'WT event'
     }
 


### PR DESCRIPTION
**Problem**:
Under a number of scenarios, the dashboard must be manually refreshed to reflect changes to underlying data, particularly when a tale is shared with another user (see https://github.com/whole-tale/ngx-dashboard/issues/121).

**Approach:**
This PR adds support for sending specific Girder events to users with access to a Tale for the following:
* Tale is created (`wt_tale_created`), updated (`wt_tale_updated`),  (`wt_tale_removed`)
* Tale is shared (`wt_tale_shared`) or unshared with a user (`wt_tale_unshared`)
* Import is started (`wt_import_started`), completed (`wt_import_completed`) or failed (`wt_import_failed`)
* Instance is started (`wt_instance_launching`), running (`wt_instance_running`), or in error state (`wt_instance_error`)
This PR adds support for sending specific Girder events to users with access to a Tale for the following: Tale is shared with a user, Tale is unshared with a user, Tale is deleted, Tale is updated. This PR also adds progress event notifications for import jobs (should be another PR).

All events have the following format:
```
{
 '_id': '60395380822a8592ebb53562',
 'data': {
   'event': 'wt_tale_created',
   'modelType': 'tale',
   'resource': '6039537f822a8592ebb53560',
   'resourceName': 'WT event'
 },
 'expires': '2021-02-26T21:01:04.015000+00:00',
 'startTime': 1614369664.0172398,
 'time': '2021-02-26T20:01:04.017000+00:00',
 'type': 'wt_event',
 'updated': '2021-02-26T20:01:04.017000+00:00',
 'updatedTime': 1614369664.0172398,
 'userId': '6039537a822a8592ebb5354d'
}
```

Where:
* `type` is always `wt_event` (as a class of events to differentiate from `wt_progress`)
* `data.event` is the name of the specific event
* `modelType` is the type of resource (`tale` or `instance` with this PR)
* `resources` is the ID of the resource

**Future work:**
The following will be addressed in a separate/future PR:
* Events for file/folder updates
* Events for current jobs (build image, publish, log state)

**To Test:**
For each test step, use the `GET /notification` API to see the associated notifications
* Create a Tale (event `wt_tale_created`)
* Share the tale with another user (event `wt_tale_shared` send to other user)
* Unshare the tale with another user (event `wt_tale_unshared` send to other user)
* Share again then update metadata (event `wt_tale_updated` sent to both users)
* Start the instance (events `wt_instance_launching` and `wt_instance_running` to the current user only)
* Stop the instance (events `wt_instance_deleting` and `wt_instance_deleted` to the current user only)
* Delete the tale (event `wt_tale_deleted` sent to both users)
* Import a tale from Github, Zenodo, or as a Binder (events `wt_import_started`, `wt_import_complete`)


