### PR TITLE
Update manifest routine wrt a new schema

### DIFF
--- a/plugin_tests/dataverse_test.py
+++ b/plugin_tests/dataverse_test.py
@@ -338,7 +338,7 @@ class DataverseHarversterTestCase(base.TestCase):
             image, dataSet, creator=self.user, title="Blah", public=True
         )
         manifest = Manifest(tale, self.user, expand_folders=True).manifest
-        restored_dataset = ManifestParser.get_dataset_from_manifest(manifest)
+        restored_dataset = ManifestParser(manifest).get_dataset()
         self.assertEqual(restored_dataset, dataSet)
 
         Tale().remove(tale)

--- a/plugin_tests/import_test.py
+++ b/plugin_tests/import_test.py
@@ -177,7 +177,7 @@ class ImportTaleTestCase(base.TestCase):
             job = Job().findOne({"type": "wholetale.import_binder"})
             self.assertEqual(json.loads(job["kwargs"])["taleId"]["$oid"], tale["_id"])
 
-            for i in range(300):
+            for i in range(600):
                 if job["status"] in {JobStatus.SUCCESS, JobStatus.ERROR}:
                     break
                 time.sleep(0.1)
@@ -339,7 +339,7 @@ class ImportTaleTestCase(base.TestCase):
             self.assertEqual(
                 json.loads(job["kwargs"])["taleId"]["$oid"], tale["_id"]
             )
-            for i in range(300):
+            for i in range(600):
                 if job["status"] in {JobStatus.SUCCESS, JobStatus.ERROR}:
                     break
                 time.sleep(0.1)

--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -262,7 +262,7 @@ class ManifestTestCase(base.TestCase):
         manifest_doc = Manifest(self.tale, self.user)
 
         attributes = manifest_doc.create_basic_attributes()
-        self.assertEqual(attributes["schema:identifier"], str(self.tale["_id"]))
+        self.assertEqual(attributes["wt:identifier"], str(self.tale["_id"]))
         self.assertEqual(attributes["schema:name"], self.tale["title"])
         self.assertEqual(attributes["schema:description"], self.tale["description"])
         self.assertEqual(attributes["schema:keywords"], self.tale["category"])
@@ -414,8 +414,8 @@ class ManifestTestCase(base.TestCase):
         for i, aggregate in enumerate(
             sorted(manifest_doc.manifest["aggregates"], key=itemgetter("uri"))
         ):
-            if "schema:identifier" in aggregate:
-                aggregate.pop("schema:identifier")
+            if "wt:identifier" in aggregate:
+                aggregate.pop("wt:identifier")
             self.assertDictEqual(aggregate, reference_aggregates[i])
 
         # Check the datasets

--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -3,6 +3,7 @@ import json
 import os
 import pytest
 from tests import base
+from urllib.parse import quote
 from bson import ObjectId
 from girder.exceptions import AccessException, ValidationException
 from girder.utility.path import lookUpPath
@@ -226,29 +227,29 @@ class ManifestTestCase(base.TestCase):
         tale = Tale().save(tale)
         manifest = Manifest(tale, self.user)
         attrs = manifest.create_related_identifiers()
-        self.assertIn("DataCite:relatedIdentifiers", attrs)
+        self.assertIn("dc:relatedIdentifiers", attrs)
         self.assertEqual(
-            attrs["DataCite:relatedIdentifiers"],
+            attrs["dc:relatedIdentifiers"],
             [
                 {
-                    "DataCite:relatedIdentifier": {
+                    "dc:relatedIdentifier": {
                         "@id": "urn:some_urn",
-                        "DataCite:relationType": "DataCite:Cites",
-                        "DataCite:relatedIdentifierType": "DataCite:URN",
+                        "dc:relationType": "dc:Cites",
+                        "dc:relatedIdentifierType": "dc:URN",
                     }
                 },
                 {
-                    "DataCite:relatedIdentifier": {
+                    "dc:relatedIdentifier": {
                         "@id": "doi:some_doi",
-                        "DataCite:relationType": "DataCite:IsDerivedFrom",
-                        "DataCite:relatedIdentifierType": "DataCite:DOI",
+                        "dc:relationType": "dc:IsDerivedFrom",
+                        "dc:relatedIdentifierType": "dc:DOI",
                     }
                 },
                 {
-                    "DataCite:relatedIdentifier": {
+                    "dc:relatedIdentifier": {
                         "@id": "https://some.url",
-                        "DataCite:relationType": "DataCite:IsIdenticalTo",
-                        "DataCite:relatedIdentifierType": "DataCite:URL",
+                        "dc:relationType": "dc:IsIdenticalTo",
+                        "dc:relatedIdentifierType": "dc:URL",
                     }
                 },
             ],
@@ -337,7 +338,7 @@ class ManifestTestCase(base.TestCase):
         aggregates_section = manifest_doc.manifest["aggregates"]
 
         # Search for workspace file1.csv
-        expected_path = "../workspace/" + "file1.csv"
+        expected_path = "./workspace/" + "file1.csv"
         file_check = any(x for x in aggregates_section if (x["uri"] == expected_path))
         self.assertTrue(file_check)
         os.remove(os.path.join(fspath, "file1.csv"))
@@ -350,61 +351,61 @@ class ManifestTestCase(base.TestCase):
             {
                 "uri": "doi:10.5065/D6862DM8",
                 "bundledAs": {
-                    "folder": "../data/Humans and Hydrology at High Latitudes: Water Use Information/"
+                    "folder": quote("./data/Humans and Hydrology at High Latitudes: Water Use Information/")
                 },
-                "size": 28848454,
+                "wt:size": 28848454,
             },
             {
                 "uri": "https://cn.dataone.org/cn/v2/resolve/urn:uuid:01a53103-8db1-46b3-967c-b42acf69ae08",
-                "bundledAs": {"folder": "../data/", "filename": "usco2005.xls"},
+                "bundledAs": {"folder": "./data/", "filename": "usco2005.xls"},
                 "schema:isPartOf": "doi:10.5065/D6862DM8",
-                "size": 6427136,
+                "wt:size": 6427136,
             },
             {
                 "uri": "globus://82f1b5c6-6e9b-11e5-ba47-22000b92c6ec//published/publication_113/data/D_whites_darks_AJS.hdf",
                 "bundledAs": {
-                    "folder": "../data/",
+                    "folder": "./data/",
                     "filename": "D_whites_darks_AJS.hdf",
                 },
                 "schema:isPartOf": "doi:10.18126/M2301J",
-                "size": 8786120536,
+                "wt:size": 8786120536,
             },
             {
                 "uri": "globus://82f1b5c6-6e9b-11e5-ba47-22000b92c6ec//published/publication_1106/data/Dmax",
-                "bundledAs": {"folder": "../data/Dmax/"},
+                "bundledAs": {"folder": "./data/Dmax/"},
                 "schema:isPartOf": "doi:10.18126/M2662X",
-                "size": 105050561,
+                "wt:size": 105050561,
             },
             {
                 "uri": "https://www.gw-openscience.org/s/events/BBH_events_v3.json",
-                "bundledAs": {"folder": "../data/", "filename": "BBH_events_v3.json"},
-                "size": 2202,
+                "bundledAs": {"folder": "./data/", "filename": "BBH_events_v3.json"},
+                "wt:size": 2202,
             },
             {
                 "uri": "https://www.gw-openscience.org/s/events/GW170104/GW170104_4_template.hdf5",
                 "bundledAs": {
-                    "folder": "../data/GW170104/",
+                    "folder": "./data/GW170104/",
                     "filename": "GW170104_4_template.hdf5",
                 },
-                "size": 1056864,
+                "wt:size": 1056864,
             },
             {
                 "uri": "https://www.gw-openscience.org/s/events/GW170104/H-H1_LOSC_4_V1-1167559920-32.hdf5",
                 "bundledAs": {
-                    "folder": "../data/GW170104/",
+                    "folder": "./data/GW170104/",
                     "filename": "H-H1_LOSC_4_V1-1167559920-32.hdf5",
                 },
-                "size": 1033609,
+                "wt:size": 1033609,
             },
             {
                 "uri": "https://www.gw-openscience.org/s/events/GW170104/L-L1_LOSC_4_V1-1167559920-32.hdf5",
                 "bundledAs": {
-                    "folder": "../data/GW170104/",
+                    "folder": "./data/GW170104/",
                     "filename": "L-L1_LOSC_4_V1-1167559920-32.hdf5",
                 },
-                "size": 1005007,
+                "wt:size": 1005007,
             },
-            {"uri": "../LICENSE", "schema:license": "CC-BY-4.0"},
+            {"uri": "./LICENSE", "schema:license": "CC-BY-4.0"},
         ]
         from operator import itemgetter
 

--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -265,8 +265,8 @@ class ManifestTestCase(base.TestCase):
         self.assertEqual(attributes["schema:identifier"], str(self.tale["_id"]))
         self.assertEqual(attributes["schema:name"], self.tale["title"])
         self.assertEqual(attributes["schema:description"], self.tale["description"])
-        self.assertEqual(attributes["schema:category"], self.tale["category"])
-        self.assertEqual(attributes["schema:version"], self.tale["format"])
+        self.assertEqual(attributes["schema:keywords"], self.tale["category"])
+        self.assertEqual(attributes["schema:schemaVersion"], self.tale["format"])
         self.assertEqual(attributes["schema:image"], self.tale["illustration"])
 
     def _testAddTaleCreator(self):
@@ -422,27 +422,27 @@ class ManifestTestCase(base.TestCase):
         reference_datasets = [
             {
                 "@id": "doi:10.18126/M2662X",
-                "@type": "Dataset",
-                "name": "A Machine Learning Approach for  Engineering Bulk Metallic Glass Alloys",
-                "identifier": "doi:10.18126/M2662X",
+                "@type": "schema:Dataset",
+                "schema:name": "A Machine Learning Approach for  Engineering Bulk Metallic Glass Alloys",
+                "schema:identifier": "doi:10.18126/M2662X",
             },
             {
                 "@id": "doi:10.18126/M2301J",
-                "@type": "Dataset",
-                "name": "Twin-mediated Crystal Growth: an Enigma Resolved",
-                "identifier": "doi:10.18126/M2301J",
+                "@type": "schema:Dataset",
+                "schema:name": "Twin-mediated Crystal Growth: an Enigma Resolved",
+                "schema:identifier": "doi:10.18126/M2301J",
             },
             {
                 "@id": "doi:10.5065/D6862DM8",
-                "@type": "Dataset",
-                "name": "Humans and Hydrology at High Latitudes: Water Use Information",
-                "identifier": "doi:10.5065/D6862DM8",
+                "@type": "schema:Dataset",
+                "schema:name": "Humans and Hydrology at High Latitudes: Water Use Information",
+                "schema:identifier": "doi:10.5065/D6862DM8",
             },
         ]
 
         reference_datasets = sorted(reference_datasets, key=itemgetter("@id"))
         for i, dataset in enumerate(
-            sorted(manifest_doc.manifest["Datasets"], key=itemgetter("@id"))
+            sorted(manifest_doc.manifest["wt:usesDataset"], key=itemgetter("@id"))
         ):
             self.assertDictEqual(dataset, reference_datasets[i])
 
@@ -501,7 +501,7 @@ class ManifestTestCase(base.TestCase):
         from server.lib.manifest_parser import ManifestParser
         from server.lib.manifest import Manifest
         manifest = Manifest(self.tale, self.user).manifest
-        dataset = ManifestParser.get_dataset_from_manifest(manifest)
+        dataset = ManifestParser(manifest).get_dataset()
         self.assertEqual(
             [_["itemId"] for _ in dataset],
             [str(_["itemId"]) for _ in self.tale["dataSet"]]
@@ -514,7 +514,7 @@ class ManifestTestCase(base.TestCase):
                 obj.pop("schema:identifier")
             aggregates.append(obj)
         manifest["aggregates"] = aggregates
-        dataset = ManifestParser.get_dataset_from_manifest(manifest)
+        dataset = ManifestParser(manifest).get_dataset()
         self.assertEqual(
             [_["itemId"] for _ in dataset],
             [str(_["itemId"]) for _ in self.tale["dataSet"]]

--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -227,29 +227,29 @@ class ManifestTestCase(base.TestCase):
         tale = Tale().save(tale)
         manifest = Manifest(tale, self.user)
         attrs = manifest.create_related_identifiers()
-        self.assertIn("dc:relatedIdentifiers", attrs)
+        self.assertIn("datacite:relatedIdentifiers", attrs)
         self.assertEqual(
-            attrs["dc:relatedIdentifiers"],
+            attrs["datacite:relatedIdentifiers"],
             [
                 {
-                    "dc:relatedIdentifier": {
+                    "datacite:relatedIdentifier": {
                         "@id": "urn:some_urn",
-                        "dc:relationType": "dc:Cites",
-                        "dc:relatedIdentifierType": "dc:URN",
+                        "datacite:relationType": "datacite:Cites",
+                        "datacite:relatedIdentifierType": "datacite:URN",
                     }
                 },
                 {
-                    "dc:relatedIdentifier": {
+                    "datacite:relatedIdentifier": {
                         "@id": "doi:some_doi",
-                        "dc:relationType": "dc:IsDerivedFrom",
-                        "dc:relatedIdentifierType": "dc:DOI",
+                        "datacite:relationType": "datacite:IsDerivedFrom",
+                        "datacite:relatedIdentifierType": "datacite:DOI",
                     }
                 },
                 {
-                    "dc:relatedIdentifier": {
+                    "datacite:relatedIdentifier": {
                         "@id": "https://some.url",
-                        "dc:relationType": "dc:IsIdenticalTo",
-                        "dc:relatedIdentifierType": "dc:URL",
+                        "datacite:relationType": "datacite:IsIdenticalTo",
+                        "datacite:relatedIdentifierType": "datacite:URL",
                     }
                 },
             ],

--- a/plugin_tests/zenodo_test.py
+++ b/plugin_tests/zenodo_test.py
@@ -417,7 +417,12 @@ class ZenodoHarversterTestCase(base.TestCase):
             fp = io.BytesIO()
             with zipfile.ZipFile(fp, mode="w") as zf:
                 zf.writestr(
-                    "manifest.json", json.dumps({"@id": "https://data.wholetale.org"})
+                    "manifest.json", json.dumps(
+                        {
+                            "@id": "https://data.wholetale.org",
+                            "@type": "wt:Tale",
+                        }
+                    )
                 )
             fp.seek(0)
             return fp

--- a/server/lib/exporters/__init__.py
+++ b/server/lib/exporters/__init__.py
@@ -131,7 +131,7 @@ class TaleExporter:
         """
         aggs = self.manifest_obj.manifest["aggregates"]
         for path, chksum in self.state['md5']:
-            uri = './' + path
+            uri = "./" + path.replace("data/", "", 1)
             index = self._agg_index_by_uri(uri)
             if index is not None:
                 aggs[index]['wt:md5'] = chksum

--- a/server/lib/exporters/__init__.py
+++ b/server/lib/exporters/__init__.py
@@ -126,7 +126,7 @@ class TaleExporter:
         :return: None
         """
         for path, chksum in self.state['md5']:
-            uri = '../' + path
+            uri = './' + path
             index = next(
                 (
                     i
@@ -136,7 +136,7 @@ class TaleExporter:
                 None,
             )
             if index is not None:
-                self.manifest['aggregates'][index]['md5'] = chksum
+                self.manifest['aggregates'][index]['wt:md5'] = chksum
 
     def append_aggregate_filesize_mimetypes(self, prepended_path):
         """
@@ -158,10 +158,10 @@ class TaleExporter:
             )
 
             if index is not None:
-                self.manifest['aggregates'][index]['mimeType'] = (
+                self.manifest['aggregates'][index]['wt:mimeType'] = (
                     magic_wrapper.from_file(fullpath) or 'application/octet-stream'
                 )
-            self.manifest['aggregates'][index]['size'] = os.path.getsize(fullpath)
+            self.manifest['aggregates'][index]['wt:size'] = os.path.getsize(fullpath)
 
     def append_extras_filesize_mimetypes(self, extra_files):
         """
@@ -171,7 +171,7 @@ class TaleExporter:
         :return: None
         """
         for path, content in extra_files.items():
-            uri = '../' + path
+            uri = './' + path
             index = next(
                 (
                     i
@@ -181,5 +181,5 @@ class TaleExporter:
                 None,
             )
             if index is not None:
-                self.manifest['aggregates'][index]['mimeType'] = 'text/plain'
-                self.manifest['aggregates'][index]['size'] = len(content)
+                self.manifest['aggregates'][index]['wt:mimeType'] = 'text/plain'
+                self.manifest['aggregates'][index]['wt:size'] = len(content)

--- a/server/lib/exporters/__init__.py
+++ b/server/lib/exporters/__init__.py
@@ -59,7 +59,7 @@ class TaleExporter:
        README.md: This file"""
     default_bagit = "BagIt-Version: 0.97\nTag-File-Character-Encoding: UTF-8\n"
 
-    def __init__(self, tale, user, algs=None, expand_folders=False):
+    def __init__(self, tale, user, algs=None, expand_folders=False, versionId=None):
         if algs is None:
             self.algs = ["md5", "sha256"]
         self.tale = tale
@@ -67,9 +67,9 @@ class TaleExporter:
         self.workspace = Folder().load(
             tale['workspaceId'], user=user, level=AccessType.READ
         )
-        self.manifest_obj = Manifest(tale, user, expand_folders)
+        self.manifest_obj = Manifest(tale, user, expand_folders, versionId=versionId)
         self.manifest = self.manifest_obj.manifest
-        self.zip_generator = ziputil.ZipGenerator(str(tale['_id']))
+        self.zip_generator = ziputil.ZipGenerator(str(self.manifest_obj.version["_id"]))
         self.tale_license = WholeTaleLicense().license_from_spdx(
             tale.get('licenseSPDX', WholeTaleLicense.default_spdx())
         )

--- a/server/lib/exporters/bag.py
+++ b/server/lib/exporters/bag.py
@@ -112,19 +112,6 @@ class BagTaleExporter(TaleExporter):
             payload = self.stream_string(content)
             yield from self.dump_and_checksum(payload, path)
 
-        # In Bag there's an additional 'data' folder where everything lives
-        for i in range(len(self.manifest['aggregates'])):
-            uri = self.manifest['aggregates'][i]['uri']
-            # Don't touch any of the extra files
-            if len([key for key in extra_files.keys() if './' + key in uri]):
-                continue
-            # if uri.startswith('../'):
-            #    self.manifest['aggregates'][i]['uri'] = uri.replace('..', '../data')
-            # if 'bundledAs' in self.manifest['aggregates'][i]:
-            #    folder = self.manifest['aggregates'][i]['bundledAs']['folder']
-            #    self.manifest['aggregates'][i]['bundledAs']['folder'] = folder.replace(
-            #        '..', '../data'
-            #    )
         # Update manifest with hashes
         self.append_aggergate_checksums()
 

--- a/server/lib/exporters/native.py
+++ b/server/lib/exporters/native.py
@@ -24,7 +24,7 @@ class NativeTaleExporter(TaleExporter):
         self.append_aggergate_checksums()
 
         # Update manifest with filesizes and mimeTypes
-        self.append_aggregate_filesize_mimetypes('../workspace/')
+        self.append_aggregate_filesize_mimetypes('./workspace/')
 
         # Update manifest with filesizes and mimeTypes for extra items
         self.append_extras_filesize_mimetypes(extra_files)

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -117,7 +117,7 @@ class Manifest:
                                         user=self.user,
                                         force=True)
         self.manifest['createdBy'] = {
-            "@id": tale_user['email'],
+            "@id": f"mailto:{tale_user['email']}",
             "@type": "schema:Person",
             "schema:givenName": tale_user.get('firstName', ''),
             "schema:familyName": tale_user.get('lastName', ''),

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -197,7 +197,7 @@ class Manifest:
             "@context": [
                 "https://w3id.org/bundle/context",
                 {"schema": "http://schema.org/"},
-                {"datacite": "http://datacite.org/schema/kernel-4"},
+                {"datacite": "https://schema.datacite.org/meta/kernel-4.3/#"},
                 {"wt": "https://vocabularies.wholetale.org/wt/1.0/wt#"},
                 {"@base": f"arcp://uid,{self.version['_id']}/data/"},
             ]

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -100,7 +100,7 @@ class Manifest:
             "createdOn": str(self.tale["created"]),
             "schema:keywords": self.tale["category"],
             "schema:description": self.tale.get("description", ""),
-            "schema:identifier": str(self.tale["_id"]),
+            "wt:identifier": str(self.tale["_id"]),
             "schema:image": self.tale["illustration"],
             "schema:name": self.tale["title"],
             "schema:schemaVersion": self.tale["format"],
@@ -281,7 +281,7 @@ class Manifest:
                 bundle = self.create_bundle('../data/' + obj['name'], None)
             record = self.create_aggregation_record(obj['uri'], bundle, obj['dataset_identifier'])
             record['size'] = obj['size']
-            record["schema:identifier"] = obj["schema:identifier"]
+            record["wt:identifier"] = obj["wt:identifier"]
             self.manifest['aggregates'].append(record)
 
     def _expand_folder_into_items(self, folder, user, relpath=''):
@@ -341,7 +341,7 @@ class Manifest:
                     'provider': provider_name,
                     '_modelType': obj['_modelType'],
                     'relpath': relpath,
-                    "schema:identifier": str(doc["_id"]),
+                    "wt:identifier": str(doc["_id"]),
                 }
 
                 if obj['_modelType'] == 'folder':

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -198,7 +198,7 @@ class Manifest:
                 "https://w3id.org/bundle/context",
                 {"schema": "http://schema.org/"},
                 {"datacite": "https://schema.datacite.org/meta/kernel-4.3/#"},
-                {"wt": "https://vocabularies.wholetale.org/wt/1.0/wt#"},
+                {"wt": "https://vocabularies.wholetale.org/wt/1.0/"},
                 {"@base": f"arcp://uid,{self.version['_id']}/data/"},
             ]
         }

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -168,19 +168,19 @@ class Manifest:
     def create_related_identifiers(self):
         def derive_id_type(identifier):
             if identifier.lower().startswith("doi"):
-                return "dc:DOI"
+                return "datacite:DOI"
             elif identifier.lower().startswith("http"):
-                return "dc:URL"
+                return "datacite:URL"
             elif identifier.lower().startswith("urn"):
-                return "dc:URN"
+                return "datacite:URN"
 
         return {
-            "dc:relatedIdentifiers": [
+            "datacite:relatedIdentifiers": [
                 {
-                    "dc:relatedIdentifier": {
+                    "datacite:relatedIdentifier": {
                         "@id": rel_id["identifier"],
-                        "dc:relationType": "dc:" + rel_id["relation"],
-                        "dc:relatedIdentifierType": derive_id_type(rel_id["identifier"]),
+                        "datacite:relationType": "datacite:" + rel_id["relation"],
+                        "datacite:relatedIdentifierType": derive_id_type(rel_id["identifier"]),
                     }
                 }
                 for rel_id in self.tale["relatedIdentifiers"]
@@ -197,7 +197,7 @@ class Manifest:
             "@context": [
                 "https://w3id.org/bundle/context",
                 {"schema": "http://schema.org/"},
-                {"dc": "http://datacite.org/schema/kernel-4"},
+                {"datacite": "http://datacite.org/schema/kernel-4"},
                 {"wt": "https://vocabularies.wholetale.org/wt/1.0/wt#"},
                 {"@base": f"arcp://uid,{self.version['_id']}/data/"},
             ]

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -95,16 +95,17 @@ class Manifest:
         """
 
         return {
-            "@id": 'https://data.wholetale.org/api/v1/tale/' + str(self.tale['_id']),
-            "createdOn": str(self.tale['created']),
-            "schema:name": self.tale['title'],
-            "schema:description": self.tale.get('description', str()),
-            "schema:category": self.tale['category'],
-            "schema:identifier": str(self.tale['_id']),
-            "schema:version": self.tale['format'],
-            "schema:image": self.tale['illustration'],
+            "@id": f"https://data.wholetale.org/api/v1/tale/{self.tale['_id']}",
+            "@type": "wt:Tale",
+            "createdOn": str(self.tale["created"]),
+            "schema:keywords": self.tale["category"],
+            "schema:description": self.tale.get("description", ""),
+            "schema:identifier": str(self.tale["_id"]),
+            "schema:image": self.tale["illustration"],
+            "schema:name": self.tale["title"],
+            "schema:schemaVersion": self.tale["format"],
             "aggregates": list(),
-            "Datasets": list()
+            "wt:usesDataset": list(),
         }
 
     def add_tale_creator(self):
@@ -182,10 +183,10 @@ class Manifest:
         """
         return {
             "@context": [
+                "https://w3id.org/bundle/context",
                 {"schema": "http://schema.org/"},
                 {"DataCite": "http://datacite.org/schema/kernel-4"},
-                {"Datasets": {"@type": "@id"}},
-                "https://w3id.org/bundle/context"
+                {"wt": "https://vocabularies.wholetale.org/wt/1.0/wt#"},
             ]
         }
 
@@ -205,9 +206,9 @@ class Manifest:
             identifier = folder['meta']['identifier']
             return {
                 "@id": identifier,
-                "@type": "Dataset",
-                "name": folder['name'],
-                "identifier": identifier,
+                "@type": "schema:Dataset",
+                "schema:name": folder['name'],
+                "schema:identifier": identifier,
                 # "publisher": self.publishers[provider]
             }
 
@@ -257,12 +258,12 @@ class Manifest:
         """
         Handle objects that are in the dataSet, ie files that point to external sources.
         Some of these sources may be datasets from publishers. We need to save information
-        about the source so that they can added to the Datasets section.
+        about the source so that they can added to the wt:usesDataset section.
         """
         external_objects, dataset_top_identifiers = self._parse_dataSet()
 
         # Add records of all top-level dataset identifiers that were used in the Tale:
-        # "Datasets"
+        # "wt:usesDataset"
         for identifier in dataset_top_identifiers:
             # Assuming Folder model implicitly ignores "datasets" that are
             # single HTTP files which is intended behavior
@@ -389,7 +390,7 @@ class Manifest:
         for folder_id in self.datasets:
             dataset_record = self.create_dataset_record(folder_id)
             if dataset_record:
-                self.manifest['Datasets'].append(dataset_record)
+                self.manifest["wt:usesDataset"].append(dataset_record)
 
     def create_bundle(self, folder, filename):
         """

--- a/server/lib/manifest_parser.py
+++ b/server/lib/manifest_parser.py
@@ -95,7 +95,7 @@ class ManifestParser:
         self.manifest["@type"] = "wt:Tale"
         self.manifest["schema:schemaVersion"] = self.manifest.pop("schema:version")
         self.manifest["schema:keywords"] = self.manifest.pop("schema:category")
-        self.manifest["wt:internalIdentifier"] = self.manifest.pop("schema:identifier")
+        self.manifest["wt:identifier"] = self.manifest.pop("schema:identifier")
         new_context = [
             obj
             for obj in self.manifest["@context"]
@@ -104,7 +104,7 @@ class ManifestParser:
         new_context += [
             {_NEW_DATACITE_KEY: "http://datacite.org/schema/kernel-4"},
             {"wt": "https://vocabularies.wholetale.org/wt/1.0/wt#"},
-            {"@base": f"arcp://uid,{self.manifest['wt:internalIdentifier']}/data/"},
+            {"@base": f"arcp://uid,{self.manifest['wt:identifier']}/data/"},
         ]
         self.manifest["@context"] = new_context
 

--- a/server/lib/manifest_parser.py
+++ b/server/lib/manifest_parser.py
@@ -123,7 +123,7 @@ class ManifestParser:
                 folder_path = folder_path[:-1]
             if "filename" in bundle:
                 try:
-                    item = Item().load(obj["schema:identifier"], force=True, exc=True)
+                    item = Item().load(obj["wt:identifier"], force=True, exc=True)
                     assert item["name"] == bundle["filename"]
                     itemId = item["_id"]
                 except (KeyError, ValidationException, AssertionError):
@@ -137,7 +137,7 @@ class ManifestParser:
                 fname = Path(bundle["folder"]).parts[-1]
                 try:
                     folder = Folder().load(
-                        obj["schema:identifier"], force=True, exc=True
+                        obj["wt:identifier"], force=True, exc=True
                     )
                     assert folder["name"] == fname
                 except (KeyError, ValidationException, AssertionError):

--- a/server/lib/manifest_parser.py
+++ b/server/lib/manifest_parser.py
@@ -97,6 +97,8 @@ class ManifestParser:
             }
             for ds in self.manifest.pop("Datasets")
         ]
+        if not self.manifest["createdBy"]["@id"].startswith("mailto:"):
+            self.manifest["createdBy"]["@id"] = f"mailto:{self.manifest['createdBy']['@id']}"
 
     def get_external_data_ids(self):
         dataIds = [obj["schema:identifier"] for obj in self.manifest["wt:usesDataset"]]

--- a/server/lib/manifest_parser.py
+++ b/server/lib/manifest_parser.py
@@ -12,7 +12,7 @@ from .license import WholeTaleLicense
 from ..models.image import Image
 
 
-_NEW_DATACITE_KEY = "dc"
+_NEW_DATACITE_KEY = "datacite"
 
 
 def rename_dc(data):
@@ -143,7 +143,9 @@ class ManifestParser:
             rel_ids = self.manifest.pop("DataCite:relatedIdentifiers")
         else:
             rel_ids = []
-        self.manifest["dc:relatedIdentifiers"] = [rename_dc(_id) for _id in rel_ids]
+        self.manifest[f"{_NEW_DATACITE_KEY}:relatedIdentifiers"] = [
+            rename_dc(_id) for _id in rel_ids
+        ]
 
     def get_external_data_ids(self):
         dataIds = [obj["schema:identifier"] for obj in self.manifest["wt:usesDataset"]]

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -25,7 +25,7 @@ from ..constants import TaleStatus
 from ..schema.misc import related_identifiers_schema
 from ..utils import getOrCreateRootFolder, init_progress
 from ..lib.license import WholeTaleLicense
-from ..lib.manifest_parser import ManifestParser as mp
+from ..lib.manifest_parser import ManifestParser
 
 from gwvolman.tasks import build_tale_image, BUILD_TALE_IMAGE_STEP_TOTAL
 
@@ -335,9 +335,8 @@ class Tale(AccessControlledModel):
                     raise GirderException("Provided file doesn't contain a Tale manifest")
 
                 try:
-                    manifest = json.loads(z.read(manifest_file).decode())
-                    # TODO: is there a better check?
-                    manifest['@id'].startswith('https://data.wholetale.org')
+                    mp = ManifestParser(json.loads(z.read(manifest_file).decode()))
+                    assert mp.is_valid()
                 except Exception as e:
                     raise GirderException(
                         "Couldn't read manifest.json or not a Tale: {}".format(str(e))
@@ -360,7 +359,7 @@ class Tale(AccessControlledModel):
                 # ../.. etc., is taken care of by zipfile.extractall, but in the end we're still
                 # unzipping an untrusted content. What could possibly go wrong...?
                 z.extractall(path=temp_dir)
-        return temp_dir, manifest_file, manifest, environment
+        return temp_dir, manifest_file, mp.manifest, environment
 
     def createTaleFromStream(
         self, stream, user=None, publishInfo=None, relatedIdentifiers=None
@@ -369,9 +368,10 @@ class Tale(AccessControlledModel):
             stream
         )
 
+        mp = ManifestParser(manifest)
         new_tale = mp.get_tale_fields_from_environment(environment)
         image = imageModel().load(new_tale.pop("imageId"), user=user, level=AccessType.READ)
-        new_tale.update(mp.get_tale_fields_from_manifest(manifest))
+        new_tale.update(mp.get_tale_fields())
 
         if relatedIdentifiers is None:
             relatedIdentifiers = []
@@ -393,7 +393,7 @@ class Tale(AccessControlledModel):
             )
         )
 
-        # We don't call mp.get_dataset_from_manifest now, cause it might require
+        # We don't call mp.get_dataset now, cause it might require
         # a registration step. It's going to be called inside import_tale job.
 
         tale = self.createTale(
@@ -450,7 +450,8 @@ class Tale(AccessControlledModel):
         NOTE: it will be missing a lot of keywords that makes it a model,
         e.g. _id, acls etc.
         """
-        restored_tale = mp.get_tale_fields_from_manifest(manifest)
+        mp = ManifestParser(manifest)
+        restored_tale = mp.get_tale_fields()
         restored_tale.update(mp.get_tale_fields_from_environment(environment))
-        restored_tale["dataSet"] = mp.get_dataset_from_manifest(manifest)
+        restored_tale["dataSet"] = mp.get_dataset()
         return restored_tale

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -33,7 +33,7 @@ from gwvolman.tasks import build_tale_image, BUILD_TALE_IMAGE_STEP_TOTAL
 # Whenever the Tale object schema is modified (e.g. fields are added or
 # removed) increase `_currentTaleFormat` to retroactively apply those
 # changes to existing Tales.
-_currentTaleFormat = 8
+_currentTaleFormat = 9
 
 
 class Tale(AccessControlledModel):

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -4,10 +4,8 @@ import cherrypy
 import json
 import pathlib
 import shutil
-import tempfile
 import textwrap
 from urllib.parse import urlparse
-import zipfile
 
 from girder import events
 from girder.api import access
@@ -18,9 +16,7 @@ from girder.api.rest import Resource, filtermodel, RestException,\
     setResponseHeader, setContentDisposition
 
 from girder.constants import AccessType, SortDir, TokenScope
-from girder.utility import assetstore_utilities
 from girder.utility.progress import ProgressContext
-from girder.models.assetstore import Assetstore
 from girder.models.folder import Folder
 from girder.models.token import Token
 from girder.models.setting import Setting
@@ -35,7 +31,6 @@ from ..models.image import Image as imageModel
 from ..lib import pids_to_entities, IMPORT_PROVIDERS
 from ..lib.dataone import DataONELocations  # TODO: get rid of it
 from ..lib.manifest import Manifest
-from ..lib.manifest_parser import ManifestParser
 from ..lib.exporters.bag import BagTaleExporter
 from ..lib.exporters.native import NativeTaleExporter
 
@@ -538,59 +533,6 @@ class Tale(Resource):
         )
         Job().scheduleJob(job)
         return new_tale
-
-    @staticmethod
-    def _extractZipPayload():
-        # TODO: Move assetstore type to wholetale.
-        assetstore = next((_ for _ in Assetstore().list() if _['type'] == 101), None)
-        if assetstore:
-            adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
-            tempDir = adapter.tempDir
-        else:
-            tempDir = None
-
-        with tempfile.NamedTemporaryFile(dir=tempDir) as fp:
-            for chunk in iterBody(2 * 1024 ** 3):
-                fp.write(chunk)
-            fp.seek(0)
-            if not zipfile.is_zipfile(fp):
-                raise RestException("Provided file is not a zipfile")
-
-            with zipfile.ZipFile(fp) as z:
-                manifest_file = next(
-                    (_ for _ in z.namelist() if _.endswith('manifest.json')),
-                    None
-                )
-                if not manifest_file:
-                    raise RestException("Provided file doesn't contain a Tale manifest")
-
-                try:
-                    manifest_obj = json.loads(z.read(manifest_file).decode())
-                    mp = ManifestParser(manifest_obj)
-                    assert mp.is_valid()
-                except Exception as e:
-                    raise RestException(
-                        "Couldn't read manifest.json or not a Tale: {}".format(str(e))
-                    )
-
-                env_file = next(
-                    (_ for _ in z.namelist() if _.endswith("environment.json")),
-                    None
-                )
-                try:
-                    environment = json.loads(z.read(env_file).decode())
-                except Exception as e:
-                    raise RestException(
-                        "Couldn't read environment.json or not a Tale: {}".format(str(e))
-                    )
-
-                # Extract files to tmp on workspace assetstore
-                temp_dir = tempfile.mkdtemp(dir=tempDir)
-                # In theory malicious content like: abs path for a member, or relative path with
-                # ../.. etc., is taken care of by zipfile.extractall, but in the end we're still
-                # unzipping an untrusted content. What could possibly go wrong...?
-                z.extractall(path=temp_dir)
-        return temp_dir, manifest_file, mp.manifest, environment
 
     @access.user(scope=TokenScope.DATA_WRITE)
     @filtermodel(model=Job)

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -406,19 +406,20 @@ class Tale(Resource):
         .modelParam('id', model='tale', plugin='wholetale', level=AccessType.READ)
         .param('taleFormat', 'Format of the exported Tale', required=False,
                enum=['bagit', 'native'], strip=True, default='native')
+        .param('versionId', 'Specific version to export', required=False)
         .responseClass('tale')
         .produces('application/zip')
         .errorResponse('ID was invalid.', 404)
         .errorResponse('You are not authorized to export this tale.', 403)
     )
-    def exportTale(self, tale, taleFormat):
+    def exportTale(self, tale, taleFormat, versionId):
         user = self.getCurrentUser()
-        zip_name = str(tale['_id'])
+        zip_name = str(versionId or tale['_id'])
 
         if taleFormat == 'bagit':
-            exporter = BagTaleExporter(tale, user, expand_folders=True)
+            exporter = BagTaleExporter(tale, user, expand_folders=True, versionId=versionId)
         elif taleFormat == 'native':
-            exporter = NativeTaleExporter(tale, user)
+            exporter = NativeTaleExporter(tale, user, versionId=versionId)
 
         setResponseHeader('Content-Type', 'application/zip')
         setContentDisposition(zip_name + '.zip')

--- a/server/tasks/import_tale.py
+++ b/server/tasks/import_tale.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import json
 import os
 import pathlib
 import sys
@@ -41,8 +40,7 @@ def run(job):
 
     try:
         os.chdir(tale_dir)
-        with open(manifest_file, "r") as manifest_fp:
-            manifest = json.load(manifest_fp)
+        mp = ManifestParser(manifest_file)
 
         # 1. Register data
         progressCurrent += 1
@@ -53,12 +51,7 @@ def run(job):
             progressCurrent=progressCurrent,
             progressMessage="Registering external data",
         )
-        dataIds = [obj["identifier"] for obj in manifest["Datasets"]]
-        dataIds += [
-            obj["uri"]
-            for obj in manifest["aggregates"]
-            if obj["uri"].startswith("http")
-        ]
+        dataIds = mp.get_external_data_ids()
         if dataIds:
             dataMap = pids_to_entities(
                 dataIds, user=user, base_url=DataONELocations.prod_cn, lookup=True
@@ -72,7 +65,7 @@ def run(job):
             )
 
         # 2. Construct the dataSet
-        dataSet = ManifestParser.get_dataset_from_manifest(manifest, data_prefix="../data/data/")
+        dataSet = mp.get_dataset(data_prefix="../data/data/")
 
         # 3. Update Tale's dataSet
         update_citations = {_["itemId"] for _ in tale["dataSet"]} ^ {

--- a/server/tasks/import_tale.py
+++ b/server/tasks/import_tale.py
@@ -65,7 +65,7 @@ def run(job):
             )
 
         # 2. Construct the dataSet
-        dataSet = mp.get_dataset(data_prefix="../data/data/")
+        dataSet = mp.get_dataset()
 
         # 3. Update Tale's dataSet
         update_citations = {_["itemId"] for _ in tale["dataSet"]} ^ {


### PR DESCRIPTION
Implementation of https://github.com/whole-tale/serialization-format/pull/2 for testing. I refactor `ManifestParser` a bit to be more flexible and perform autoupdate of schema in case of old schema version.

### Note
Needs https://github.com/whole-tale/wt_versioning/pull/19 to work properly.