### PR TITLE
Export & Publish Versions

### DIFF
--- a/plugin_tests/publish_test.py
+++ b/plugin_tests/publish_test.py
@@ -131,7 +131,7 @@ class PublishTestCase(base.TestCase):
                 path="/tale/{_id}/publish".format(**self.tale),
                 method="PUT",
                 user=self.user,
-                params={"repository": remoteMemberNode},
+                params={"repository": remoteMemberNode, "versionId": "1234"},
             )
             self.assertStatusOk(resp)
 
@@ -154,7 +154,7 @@ class PublishTestCase(base.TestCase):
                 path="/tale/{_id}/publish".format(**self.tale),
                 method="PUT",
                 user=self.user,
-                params={"repository": repository},
+                params={"repository": repository, "versionId": "1234"},
             )
             self.assertStatus(resp, 400)
             self.assertEqual(

--- a/server/lib/exporters/__init__.py
+++ b/server/lib/exporters/__init__.py
@@ -68,7 +68,7 @@ class TaleExporter:
         self.user = user
         self.version = Folder().load(
             versionId, user=user, level=AccessType.READ)
-        self.manifest_obj = Manifest(tale, user, versionId, expand_folders, is_export=is_export)
+        self.manifest_obj = Manifest(tale, user, expand_folders, is_export=is_export, version_id=versionId)
         self.manifest = self.manifest_obj.manifest
         self.zip_generator = ziputil.ZipGenerator(str(self.manifest_obj.version["_id"]))
         self.tale_license = WholeTaleLicense().license_from_spdx(
@@ -86,7 +86,7 @@ class TaleExporter:
            fullpath - absolute path to a file
            relpath - path to a file relative to workspace root
         """
-        workspace_rootpath = str(Path(self.version["fsPath"])) + "/workspace/"
+        workspace_rootpath = str(self.version["fsPath"] + "/workspace/")
         for curdir, _, files in os.walk(workspace_rootpath):
             for fname in files:
                 fullpath = os.path.join(curdir, fname)

--- a/server/lib/exporters/__init__.py
+++ b/server/lib/exporters/__init__.py
@@ -61,14 +61,14 @@ class TaleExporter:
        README.md: This file"""
     default_bagit = "BagIt-Version: 0.97\nTag-File-Character-Encoding: UTF-8\n"
 
-    def __init__(self, tale, user, versionId, algs=None, expand_folders=False):
+    def __init__(self, tale, user, versionId, algs=None, expand_folders=False, is_export=False):
         if algs is None:
             self.algs = ["md5", "sha256"]
         self.tale = tale
         self.user = user
         self.version = Folder().load(
             versionId, user=user, level=AccessType.READ)
-        self.manifest_obj = Manifest(tale, user, versionId, expand_folders)
+        self.manifest_obj = Manifest(tale, user, versionId, expand_folders, is_export=is_export)
         self.manifest = self.manifest_obj.manifest
         self.zip_generator = ziputil.ZipGenerator(str(self.manifest_obj.version["_id"]))
         self.tale_license = WholeTaleLicense().license_from_spdx(

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -342,7 +342,7 @@ class Manifest:
                 objects from external_objects
 
         """
-        if dataSet is None and self.version is None and self.is_export:
+        if dataSet is None and self.is_export:
             version_path = Path(self.version["fsPath"])
             with open((version_path / "manifest.json").as_posix(), "r") as fp:
                 manifest = json.load(fp)

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -13,7 +13,7 @@ from gwvolman.constants import REPO2DOCKER_VERSION
 
 from .license import WholeTaleLicense
 from . import IMPORT_PROVIDERS
-
+from .manifest_parser import ManifestParser
 
 class Manifest:
     """
@@ -24,7 +24,7 @@ class Manifest:
     create<someProperty>
     """
 
-    def __init__(self, tale, user, versionId, expand_folders=True):
+    def __init__(self, tale, user, version_id, expand_folders=True, is_export=False):
         """
         Initialize the manifest document with base variables
         :param tale: The Tale whose data is being serialized
@@ -35,8 +35,9 @@ class Manifest:
         """
         self.tale = tale
         self.user = user
+        self.is_export = is_export
         self.version = Folder().load(
-                versionId, user=self.user, level=AccessType.READ, exc=True
+                version_id, user=self.user, level=AccessType.READ, exc=True
             )
         self.expand_folders = expand_folders
 
@@ -319,6 +320,13 @@ class Manifest:
                 objects from external_objects
 
         """
+        if dataSet is None and self.version is None and self.is_export is True:
+            version_path = Path(self.version["fsPath"])
+            with open((version_path / "manifest.json").as_posix(), "r") as fp:
+                manifest = json.load(fp)
+                parser = ManifestParser(manifest)
+                dataSet = parser.get_dataset()
+
         if dataSet is None:
             dataSet = self.tale['dataSet']
 

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -424,7 +424,7 @@ class Tale(Resource):
             versionId = next(last_version, {"_id": None})["_id"]
 
         if taleFormat == 'bagit':
-            exporter = BagTaleExporter(tale, user, versionId, expand_folders=True)
+            exporter = BagTaleExporter(tale, user, versionId, expand_folders=True, is_export=True)
         elif taleFormat == 'native':
             exporter = NativeTaleExporter(tale, user, versionId=versionId)
 


### PR DESCRIPTION
With the new addition of versioned Tales, we need a way to export particular versions. This means that the external data, the workspace, and manifest all reflect the state of a particular version.


### Changes:
- We can pass a version into the manifest so that we get version specific metadata in it (the version workspace, etc)
- A version is required to publish and export a Tale. On export and publish, a version is automatically created if a version isn't passed to the endpoint.

### Testing:
You'll need the following branches
 - [Versioning](https://github.com/whole-tale/wt_versioning/pull/21)
 - [gwvolman](https://github.com/whole-tale/gwvolman/pull/133)
 - [dashboard](https://github.com/whole-tale/ngx-dashboard/pull/140)
 
 There are a number of combinatorial ways of testing this. In all of the cases, it's important to verify that the manifest is correct, that the workspace exported/published is correct, and that the dashboard is giving the proper behavior.


#### Exporting

#### Exporting Different Versions
1. Create an empty Tale
2. Add workspace files and data sets
3. Save a version
4. Export the version on the context menu
5. Confirm that the workspace is correct, that the manifest lists all relevant files, and that that properly describes the dataset
6. Remove some of the files and save a version
7. Export the first version
8. Confirm that the exported Tale is the same as the initial export
9. Export the latest version
10. Confirm that the workspace and manifest reflect the second state of the Tale

#### Exporting a Default Version
1. Create an empty Tale
2. Add workspace files and data sets
3. Export the Tale
4. Confirm that a new version was created in the versions panel
5. Confirm that the exported Tale reflects what's in the dashboard

#### Publishing
1. Create a new Tale
2. Add some files to it, but not a version
3. Connect to Zenodo or DataONE
4. Publish the Tale
5. Note that there's a new version in the version panel
6. Confirm that the data files in the published artifact are correct
