### PR TITLE
Relax the rules on importing Tales

### DIFF
--- a/server/lib/dataone/integration.py
+++ b/server/lib/dataone/integration.py
@@ -53,7 +53,7 @@ def dataoneDataImport(self, uri, title, environment, api, apiToken, force):
     data_map = DataOneImportProvider().lookup(entity)
     doi = data_map.doi or data_map.dataId
     if not force:
-        redirect_if_tale_exists(user, self.getCurrentToken(), doi)
+        redirect_if_tale_exists(self.getCurrentToken(), doi)
 
     query = dict()
     query['uri'] = uri

--- a/server/lib/dataverse/integration.py
+++ b/server/lib/dataverse/integration.py
@@ -147,7 +147,7 @@ def dataverseExternalTools(
         title, _, doi = DataverseImportProvider._parse_dataset(urlparse(url))
 
     if not force:
-        redirect_if_tale_exists(user, self.getCurrentToken(), doi)
+        redirect_if_tale_exists(self.getCurrentToken(), doi)
 
     if fullDataset and (fileId or filePid):
         url = _dataset_full_url(site, doi)

--- a/server/lib/integration_utils.py
+++ b/server/lib/integration_utils.py
@@ -17,15 +17,16 @@ def autologin(args=None):
     raise cherrypy.HTTPRedirect(oauth_providers["Globus"])  # TODO: hardcoded var
 
 
-def redirect_if_tale_exists(user, token, doi):
+def redirect_if_tale_exists(token, doi):
+
+    # Check to see if the incoming request is for a Tale that has been published
     existing_tale_id = Tale().findOne(
         query={
-            "creatorId": user["_id"],
-            "relatedIdentifiers.identifier": {"$eq": doi},
-            "relatedIdentifiers.relation": {"$in": ["IsDerivedFrom", "Cites"]},
+            "publishInfo.pid": {"$eq": doi},
         },
         fields={"_id"},
     )
+
     if existing_tale_id:
         # TODO: Make base url a plugin setting, defaulting to dashboard.<domain>
         dashboard_url = os.environ.get(


### PR DESCRIPTION
I was doing some testing and found that some of the published DataONE Tales aren't properly redirecting to the right Tale. After checking things out I realized that (in DataONE's case) we should be checking the value of the associated pid since its a 1-1 mapping. The published Tale also shouldn't be restricted to the user, that way other people can land on it.

I pulled some of this out of utils module since it's a check that's specific to DataONE, and not valid for Dataverse.

To Test:
1. Make a Tale public
2. Publish the Tale to Dev DataONE
2. Wait a few minutes for it to be processed by the coordinating node
3. Sign into Whole Tale with a new account
4. Use the 'Analyze in WT' button on the dataset landing page to be directed to the Tale

