### PR TITLE
Decouple Tale exporting from girder models

### DIFF
--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -5,6 +5,7 @@ import httmock
 import json
 import mock
 import os
+from pathlib import Path
 import pytest
 import re
 import time
@@ -50,6 +51,7 @@ def setUpModule():
     base.enabledPlugins.append('wholetale')
     base.enabledPlugins.append('wt_home_dir')
     base.enabledPlugins.append('virtual_resources')
+    base.enabledPlugins.append('wt_versioning')
     base.startServer()
 
     global JobStatus, Tale, ImageStatus
@@ -590,24 +592,25 @@ class TaleTestCase(base.TestCase):
         with open(os.path.join(workspace["fsPath"], "test_file.txt"), "wb") as f:
             f.write(b"Hello World!")
 
-        export_path = '/tale/{}/export'.format(str(tale['_id']))
         resp = self.request(
-            path=export_path, method='GET', isJson=False, user=self.user)
+            path=f"/tale/{tale['_id']}/export", method='GET', isJson=False, user=self.user)
         with tempfile.NamedTemporaryFile() as fp:
             for content in resp.body:
                 fp.write(content)
             fp.seek(0)
             zip_archive = zipfile.ZipFile(fp, 'r')
-            zip_files = zip_archive.namelist()
+            zip_files = {
+                Path(*Path(_).parts[1:]).as_posix() for _ in zip_archive.namelist()
+            }
         # Check the the manifest.json is present
-        expected_files = [
+        expected_files = {
+            "metadata/environment.json",
             "metadata/manifest.json",
             "README.md",
             "LICENSE",
             "workspace/test_file.txt",
-        ]
-        for content_file in expected_files:
-            self.assertTrue("{}/{}".format(tale["_id"], content_file) in zip_files)
+        }
+        self.assertEqual(expected_files, zip_files)
         self.model('tale', 'wholetale').remove(tale)
 
     @mock.patch('gwvolman.tasks.build_tale_image')
@@ -654,7 +657,7 @@ class TaleTestCase(base.TestCase):
             gca().send_task.return_value = FakeAsyncResult(tale['_id'])
 
             jobModel.scheduleJob(job)
-            for i in range(20):
+            for _ in range(20):
                 job = jobModel.load(job['_id'], force=True)
                 if job['status'] == JobStatus.QUEUED:
                     break
@@ -879,7 +882,7 @@ class TaleWithWorkspaceTestCase(base.TestCase):
 
         copied_file_path = re.sub(workspace['name'], new_tale['_id'], fullPath)
         job = Job().findOne({'type': 'wholetale.copy_workspace'})
-        for i in range(10):
+        for _ in range(10):
             job = Job().load(job['_id'], force=True)
             if job['status'] == JobStatus.SUCCESS:
                 break
@@ -898,12 +901,11 @@ class TaleWithWorkspaceTestCase(base.TestCase):
 
     def testExportBag(self):
         tale = self._create_water_tale()
-        export_path = '/tale/{}/export'.format(str(tale['_id']))
         resp = self.request(
-            path=export_path, method='GET', params={'taleFormat': 'bagit'},
+            path=f"/tale/{tale['_id']}/export", method='GET', params={'taleFormat': 'bagit'},
             isJson=False, user=self.user)
         dirpath = tempfile.mkdtemp()
-        bag_file = os.path.join(dirpath, "{}.zip".format(str(tale['_id'])))
+        bag_file = os.path.join(dirpath, resp.headers["Content-Disposition"].split('"')[1])
         with open(bag_file, 'wb') as fp:
             for content in resp.body:
                 fp.write(content)

--- a/server/lib/exporters/__init__.py
+++ b/server/lib/exporters/__init__.py
@@ -1,11 +1,9 @@
 from hashlib import sha256, md5
+import json
 import magic
 import os
-from girder.utility import hash_state, ziputil
-from girder.constants import AccessType
-from girder.models.folder import Folder
+from girder.utility import hash_state, ziputil, JsonEncoder
 from ..license import WholeTaleLicense
-from ..manifest import Manifest
 
 
 class HashFileStream:
@@ -59,20 +57,27 @@ class TaleExporter:
        README.md: This file"""
     default_bagit = "BagIt-Version: 0.97\nTag-File-Character-Encoding: UTF-8\n"
 
-    def __init__(self, tale, user, algs=None, expand_folders=False, versionId=None):
+    def __init__(self, manifest, environment, workspace_path, algs=None):
+        self.manifest = manifest
+        self.environment = environment
+        if not workspace_path.endswith("/"):
+            workspace_path += "/"
+        self.workspace_path = workspace_path
+
         if algs is None:
             self.algs = ["md5", "sha256"]
-        self.tale = tale
-        self.user = user
-        self.workspace = Folder().load(
-            tale['workspaceId'], user=user, level=AccessType.READ
+
+        zipname = os.path.basename(manifest["dct:hasVersion"]["@id"])
+        self.zip_generator = ziputil.ZipGenerator(zipname)
+        license_spdx = next(
+            (
+                agg["schema:license"]
+                for agg in manifest["aggregates"]
+                if "schema:license" in manifest["aggregates"]
+            ),
+            WholeTaleLicense.default_spdx()
         )
-        self.manifest_obj = Manifest(tale, user, expand_folders, versionId=versionId)
-        self.manifest = self.manifest_obj.manifest
-        self.zip_generator = ziputil.ZipGenerator(str(self.manifest_obj.version["_id"]))
-        self.tale_license = WholeTaleLicense().license_from_spdx(
-            tale.get('licenseSPDX', WholeTaleLicense.default_spdx())
-        )
+        self.tale_license = WholeTaleLicense().license_from_spdx(license_spdx)
         self.state = {}
         for alg in self.algs:
             self.state[alg] = []
@@ -85,15 +90,10 @@ class TaleExporter:
            fullpath - absolute path to a file
            relpath - path to a file relative to workspace root
         """
-
-        workspace_rootpath = self.workspace["fsPath"]
-        if not workspace_rootpath.endswith("/"):
-            workspace_rootpath += "/"
-
-        for curdir, _, files in os.walk(workspace_rootpath):
+        for curdir, _, files in os.walk(self.workspace_path):
             for fname in files:
                 fullpath = os.path.join(curdir, fname)
-                relpath = fullpath.replace(workspace_rootpath, "")
+                relpath = fullpath.replace(self.workspace_path, "")
                 yield fullpath, relpath
 
     @staticmethod
@@ -121,7 +121,7 @@ class TaleExporter:
             self.state[alg].append((zip_path, getattr(hash_file_stream, alg)))
 
     def _agg_index_by_uri(self, uri):
-        aggs = self.manifest_obj.manifest["aggregates"]
+        aggs = self.manifest["aggregates"]
         return next((i for (i, d) in enumerate(aggs) if d['uri'] == uri), None)
 
     def append_aggergate_checksums(self):
@@ -129,7 +129,7 @@ class TaleExporter:
         Takes the md5 checksums and adds them to the files in the 'aggregates' section
         :return: None
         """
-        aggs = self.manifest_obj.manifest["aggregates"]
+        aggs = self.manifest["aggregates"]
         for path, chksum in self.state['md5']:
             uri = "./" + path.replace("data/", "", 1)
             index = self._agg_index_by_uri(uri)
@@ -144,7 +144,7 @@ class TaleExporter:
         :return: None
         """
         magic_wrapper = magic.Magic(mime=True, uncompress=True)
-        aggs = self.manifest_obj.manifest["aggregates"]
+        aggs = self.manifest["aggregates"]
         for fullpath, relpath in self.list_workspace():
             uri = prepended_path + relpath
             index = self._agg_index_by_uri(uri)
@@ -161,10 +161,16 @@ class TaleExporter:
         :type extra_files: dict
         :return: None
         """
-        aggs = self.manifest_obj.manifest["aggregates"]
+        aggs = self.manifest["aggregates"]
         for path, content in extra_files.items():
             uri = "./" + path.replace("data/", "", 1)
             index = self._agg_index_by_uri(uri)
             if index is not None:
                 aggs[index]["wt:mimeType"] = "text/plain"
                 aggs[index]["wt:size"] = len(content)
+
+    @staticmethod
+    def formated_dump(obj, **kwargs):
+        return json.dumps(
+            obj, cls=JsonEncoder, sort_keys=True, allow_nan=False, **kwargs
+        )

--- a/server/lib/exporters/native.py
+++ b/server/lib/exporters/native.py
@@ -6,7 +6,7 @@ class NativeTaleExporter(TaleExporter):
         extra_files = {
             'README.md': self.default_top_readme,
             'LICENSE': self.tale_license['text'],
-            'metadata/environment.json': self.manifest_obj.dump_environment(indent=4),
+            'metadata/environment.json': self.formated_dump(self.environment, indent=4),
         }
 
         # Add files from the workspace
@@ -30,7 +30,7 @@ class NativeTaleExporter(TaleExporter):
         self.append_extras_filesize_mimetypes(extra_files)
 
         for data in self.zip_generator.addFile(
-            lambda: self.manifest_obj.dump_manifest(indent=4), 'metadata/manifest.json'
+            lambda: self.formated_dump(self.manifest, indent=4), 'metadata/manifest.json'
         ):
             yield data
 

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -460,13 +460,16 @@ class Manifest:
             **kwargs
         )
 
-    def dump_environment(self, **kwargs):
+    def get_environment(self):
         image = self.imageModel.load(
             self.tale["imageId"], user=self.user, level=AccessType.READ
         )
         image["taleConfig"] = self.tale.get("config", {})
+        return self.imageModel.filter(image, self.user)
+
+    def dump_environment(self, **kwargs):
         return json.dumps(
-            self.imageModel.filter(image, self.user),
+            self.get_environment(),
             cls=JsonEncoder,
             sort_keys=True,
             allow_nan=False,


### PR DESCRIPTION
This PR converts tale exporters to work solely on information contained in `manifest.json`, `environment.json` (or they "live" equivalents from `Manifest` class) and a physical path to workspace that we bundle. This approach avoids some pitfalls with circular dependencies between Version, Tale, and Manifest and makes what we are exporting more clear.

### How to test?
1. Exports some Tales and see that nothing is changed.
2. (optional) test with https://github.com/whole-tale/wt_versioning/pull/21 and e.g. check that version is created only once and it's actually included in the bag.