### PR TITLE
fix: bagit was using wrong keyword for filename

### DIFF
--- a/server/lib/exporters/bag.py
+++ b/server/lib/exporters/bag.py
@@ -128,7 +128,7 @@ class BagTaleExporter(TaleExporter):
                 continue
             folder = unquote(bundle['bundledAs']['folder'])
             fetch_file += f"{bundle['uri']} {bundle['wt:size']} {folder}"
-            fetch_file += unquote(bundle['bundledAs'].get('wt:filename', ''))
+            fetch_file += unquote(bundle['bundledAs'].get('filename', ''))
             fetch_file += '\n'
 
         now = datetime.now(timezone.utc)


### PR DESCRIPTION
Fixing a typo that was introduced in https://github.com/whole-tale/girder_wholetale/pull/446 and broke `fetch.txt` format.