### PR TITLE
Add endpoint to check whether user is authorized to access an instance

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import base64
+import cherrypy
 import copy
 import datetime
 import jsonschema
@@ -21,6 +22,7 @@ from girder.models.notification import Notification, ProgressState
 from girder.models.user import User
 from girder.plugins.jobs.constants import JobStatus
 from girder.plugins.jobs.models.job import Job as JobModel
+from girder.plugins.oauth.rest import OAuth as OAuthResource
 from girder.plugins.worker import getCeleryApp
 from girder.utility import assetstore_utilities, setting_utilities
 from girder.utility.model_importer import ModelImporter
@@ -285,6 +287,24 @@ def setUserMetadata(self, params):
     return self.model('user').save(user)
 
 
+@access.public
+@autoDescribeRoute(
+    Description('Initiate oauth login flow')
+    .param('redirect', 'URL to redirect to after login', required=False)
+)
+@boundHandler()
+def signIn(self, redirect):
+    user = self.getCurrentUser()
+
+    # If there's no user, initiate the oauth flow with this endpoint
+    # as the callback along with the fhost parameter
+    if user is None:
+        oauth_providers = OAuthResource().listProviders(params={"redirect": redirect})
+        raise cherrypy.HTTPRedirect(oauth_providers["Globus"])
+    else:
+        raise cherrypy.HTTPRedirect(redirect)
+
+
 @access.user
 @autoDescribeRoute(
     Description('Get a set of items and folders.')
@@ -472,6 +492,8 @@ def load(info):
 
     info['apiRoot'].user.route('PUT', ('settings',), setUserMetadata)
     info['apiRoot'].user.route('GET', ('settings',), getUserMetadata)
+    info['apiRoot'].user.route('GET', ('sign_in',), signIn)
+
     ModelImporter.model('user').exposeFields(
         level=AccessType.WRITE, fields=('meta', 'myData', 'lastLogin'))
     ModelImporter.model('user').exposeFields(

--- a/server/rest/instance.py
+++ b/server/rest/instance.py
@@ -244,7 +244,7 @@ class Instance(Resource):
 
         if user is None:
             # If no user, redirect to authentication endpoint to initiate oauth flow
-            redirect = 'https://{forwarded_host}{forwarded_uri}'
+            redirect = f'https://{forwarded_host}{forwarded_uri}'
             # As a forward-auth request, the host is the origin (e.g., tmp-xxx.*)
             # but we need to redirect to Girder.
             raise cherrypy.HTTPRedirect(

--- a/server/rest/instance.py
+++ b/server/rest/instance.py
@@ -10,6 +10,11 @@ from girder.plugins.jobs.constants import JobStatus
 from girder.plugins.worker import getCeleryApp
 from ..constants import PluginSettings, InstanceStatus
 from ..models.instance import Instance as instanceModel
+from urllib.parse import urlparse, parse_qs
+import cherrypy
+from girder.models.token import Token
+from girder.models.user import User
+from girder.plugins.oauth.rest import OAuth as OAuthResource
 
 
 instanceSchema = {
@@ -85,6 +90,7 @@ class Instance(Resource):
         self.route('GET', (':id',), self.getInstance)
         self.route('DELETE', (':id',), self.deleteInstance)
         self.route('PUT', (':id',), self.updateInstance)
+        self.route('GET', ('authorize', ), self.authorize)
 
         events.bind('jobs.job.update.after', 'wholetale', self.handleUpdateJob)
 
@@ -222,3 +228,92 @@ class Instance(Resource):
         elif status in (JobStatus.QUEUED, JobStatus.RUNNING):
             instance['status'] = InstanceStatus.LAUNCHING
         self._model.updateInstance(instance)
+
+    @access.public
+    @autoDescribeRoute(
+        Description('Make authorization decision for instance based on forwarded URL')
+        .param('fhost', 'Forwarded host', required=False)
+        .param('redirect', 'If true, redirect to fhost',
+               default=True, required=False, dataType='boolean')
+    )
+    def authorize(self, fhost, redirect):
+        """
+        Intended for use with traefik forwardauth
+
+        Does the user have access to the instance specified by the host name
+        in the 'fhost' parameter or the X-Forwarded-Host header?
+
+        Assumes the following flow:
+
+        * User accesses instance tmp-xxx.wholetale.org
+        * Traefik forwardauth calls this endpoint with "X-Forwarded-Host" set to the
+          host name and "X-Forwarded-Uri" set to "/"
+        * In the initial request, we don't know who the user is, so run them
+          through the oauth flow with this endpoint as the callback (requires)
+          changing the Globus Auth config). Set the "fhost" parameter to the
+          forwarded host name.
+        * At the end of the Globus auth flow, we'll have a user and know the
+          forwarded host. Redirect to the original forwarded host with the
+          "?token=x" query string.
+        * In the subsequent request for https://tmp-xxx.wholetale.org/?token=xxx,
+          forward autho will be called with the token in the X-Forwarded-Uri.
+          Get the token and load the user, checkif they actually have access to this
+          instance. If so, return 200. If not return 403.
+        """
+
+        # TODO: Why is this none when I call as a logged in user?
+        user = self.getCurrentUser()
+
+        # The X-Forwarded-Uri header means this is a forwardauth request.
+        # Check for an existing token and load the user if present.
+        furi = cherrypy.request.headers.get('X-Forwarded-Uri')
+        if furi:
+            qs = parse_qs(urlparse(furi).query)
+            if 'token' in qs:
+                token = Token().load(qs['token'][0], force=True, objectId=False)
+                user = User().load(token["userId"], force=True)
+
+        # If there's no user, initiate the oauth flow with this endpoint
+        # as the callback along with the fhost parameter
+        if user is None:
+            fhost = cherrypy.request.headers.get('X-Forwarded-Host')
+            # With forwardauth, the base will be https://tmp-xxx...
+            # TODO: fix hardcode
+            cherrypy.request.base = "https://girder.local.wholetale.org"
+            redirect = cherrypy.request.base + cherrypy.request.app.script_name
+            redirect += cherrypy.request.path_info + "?"
+            redirect += "&fhost=" + fhost
+            redirect += "&token={girderToken}"
+            oauth_providers = OAuthResource().listProviders(params={"redirect": redirect})
+            raise cherrypy.HTTPRedirect(oauth_providers["Globus"])
+
+        # If the fhost parameter is set and we have a user, this is the Globus
+        # auth callback. Redirect to the original service with the token.
+        if not fhost:
+            fhost = cherrypy.request.headers.get('X-Forwarded-Host')
+        elif redirect:
+            # Redirect to the requested host to set the token
+            # Can't set a cookie on tmp-xxx.* from girder.*
+            # self.sendAuthTokenCookie(user, domain=fhost)
+            token = self.getCurrentToken()["_id"]
+            redirect = "https://" + fhost + "/?token=" + token
+            raise cherrypy.HTTPRedirect(redirect)
+
+        # At this point we have a user and the fhost from  either a querystring
+        # parameter or forwarded header. Check to see if the user has access
+        # to the instance.
+        instances = list(self._model.list(user=user, currentUser=user))
+        access = False
+        # TODO: hardcode for testing only
+        if fhost == "whoami.local.wholetale.org":
+            access = True
+        for instance in instances:
+            url = urlparse(instance['url'])
+            if fhost == url.netloc:
+                access = True
+                break
+
+        if not access:
+            raise RestException('Access denied for instance', code=403)
+        else:
+            return fhost


### PR DESCRIPTION
See https://github.com/whole-tale/deploy-dev/pull/44 for test and https://github.com/whole-tale/whole-tale/issues/94 for problem description.

This PR adds the `/instance/authorize` and `/user/sign_in` endpoints intended to work with Traefik forward authentication to determine whether a user has access to an instance by hostname.