### PR TITLE
Updates to copy_workspace job

### DIFF
--- a/plugin_tests/import_failures_test.py
+++ b/plugin_tests/import_failures_test.py
@@ -4,6 +4,7 @@ import json
 import time
 from tests import base
 from girder import config
+from girder.models.folder import Folder
 
 
 JobStatus = None
@@ -173,7 +174,16 @@ class TaskFailTestCase(base.TestCase):
             public=True,
             config={"memLimit": "2g"},
         )
-
+        new_tale = Tale().createTale(
+            self.image,
+            [],
+            creator=self.admin,
+            title="tale one (copy)",
+            public=True,
+            config={"memLimit": "2g"},
+        )
+        new_workspace = Folder().load(new_tale["workspaceId"], force=True)
+        Folder().remove(new_workspace)  # oh no!
         job = Job().createLocalJob(
             title='Copy "{title}" workspace'.format(**tale),
             user=self.user,
@@ -181,8 +191,7 @@ class TaskFailTestCase(base.TestCase):
             public=False,
             _async=True,
             module="girder.plugins.wholetale.tasks.copy_workspace",
-            args=(tale["workspaceId"], "non_existing"),
-            kwargs={"user": self.user, "tale": tale},
+            args=(tale, new_tale),
         )
         Job().scheduleJob(job)
         for i in range(300):
@@ -192,9 +201,10 @@ class TaskFailTestCase(base.TestCase):
             job = Job().load(job["_id"], force=True)
         self.assertEqual(job["status"], JobStatus.ERROR)
         Job().remove(job)
-        tale = Tale().load(tale["_id"], force=True)
-        self.assertEqual(tale["status"], TaleStatus.ERROR)
+        tale = Tale().load(new_tale["_id"], force=True)
+        self.assertEqual(new_tale["status"], TaleStatus.ERROR)
         Tale().remove(tale)
+        Tale().remove(new_tale)
 
     def tearDown(self):
         self.model("user").remove(self.user)

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -568,8 +568,7 @@ class Tale(Resource):
             title='Copy "{title}" workspace'.format(**tale), user=user,
             type='wholetale.copy_workspace', public=False, _async=True,
             module='girder.plugins.wholetale.tasks.copy_workspace',
-            args=(tale["workspaceId"], new_tale["workspaceId"]),
-            kwargs={'user': user, 'tale': new_tale}
+            args=(tale, new_tale),
         )
         Job().scheduleJob(job)
         return new_tale

--- a/server/tasks/copy_workspace.py
+++ b/server/tasks/copy_workspace.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os
+from pathlib import Path
 import shutil
 import sys
 import traceback
+from girder import events
 from girder.constants import AccessType
 from girder.models.folder import Folder
+from girder.models.user import User
 from girder.plugins.jobs.constants import JobStatus
 from girder.plugins.jobs.models.job import Job
 
@@ -18,25 +20,27 @@ def run(job):
     jobModel = Job()
     jobModel.updateJob(job, status=JobStatus.RUNNING)
 
-    src_workspace_id, dest_workspace_id = job["args"]
-    user = job["kwargs"]["user"]
-    tale = job["kwargs"]["tale"]
+    old_tale, new_tale = job["args"]
+    user = User().load(new_tale["creatorId"], force=True)
 
     try:
         source_workspace = Folder().load(
-            src_workspace_id, user=user, exc=True, level=AccessType.READ
+            old_tale["workspaceId"], user=user, exc=True, level=AccessType.READ
         )
-        workspace = Folder().load(dest_workspace_id, user=user, exc=True)
+        workspace = Folder().load(new_tale["workspaceId"], user=user, exc=True)
 
-        if os.path.isdir(workspace["fsPath"]):
-            os.rmdir(workspace["fsPath"])  # TODO: in py38 use dirs_exist_ok below
-        shutil.copytree(source_workspace["fsPath"], workspace["fsPath"])
-        tale["status"] = TaleStatus.READY
-        Tale().updateTale(tale)
+        shutil.copytree(
+            Path(source_workspace["fsPath"]),
+            Path(workspace["fsPath"]),
+            dirs_exist_ok=True,
+        )
+        events.trigger("wholetale.tale.copied", (old_tale, new_tale))
+        new_tale["status"] = TaleStatus.READY
+        Tale().updateTale(new_tale)
         jobModel.updateJob(job, status=JobStatus.SUCCESS, log="Copying finished")
     except Exception:
-        tale["status"] = TaleStatus.ERROR
-        Tale().updateTale(tale)
+        new_tale["status"] = TaleStatus.ERROR
+        Tale().updateTale(new_tale)
         t, val, tb = sys.exc_info()
         log = "%s: %s\n%s" % (t.__name__, repr(val), traceback.extract_tb(tb))
         jobModel.updateJob(job, status=JobStatus.ERROR, log=log)


### PR DESCRIPTION
* operate on Tale objects rather than paths
* emit 'wholetale.tale.copied' for other plugins to consume

# How to test?
1. Depends on https://github.com/whole-tale/girder/pull/10
1. Register a Ligo Tale
2. Copy and launch. Verify it succeeds.