### PR TITLE
Decrease notification expiration time

### DIFF
--- a/server/utils.py
+++ b/server/utils.py
@@ -59,7 +59,7 @@ def notify_event(users, event, affectedIds):
         'resourceName': 'WT event'
     }
 
-    expires = datetime.datetime.utcnow() + datetime.timedelta(hours=NOTIFICATION_EXP_HOURS)
+    expires = datetime.datetime.utcnow() + datetime.timedelta(seconds=5)
 
     for user_id in users:
         user = User().load(user_id, force=True)


### PR DESCRIPTION
Reduces event notification expiration time for events that do not require user acknowledgment to 5s.  This should resolve the problem identified in https://github.com/whole-tale/ngx-dashboard/pull/139#issuecomment-801423095.

To test:
* As user 1, create and share tale with user 2 with both users actively logged in
* User 1 and user 2 select metadata page in edit mode
* User 1 edits tale metadata and saves, user 2 confirms sync modal appears and selects either yes or no
* Wait 30s
* Sync modal should not reappear