### PR TITLE
Verify that D1 token is a valid JWT

### DIFF
--- a/plugin_tests/accounts_test.py
+++ b/plugin_tests/accounts_test.py
@@ -678,8 +678,26 @@ class ExternalAccountsTestCase(base.TestCase):
             method="POST",
             path="/account/dataoneprod/key",
             params={
-                "resource_server": "sandbox.zenodo.org",
+                "resource_server": "cn.dataone.org",
                 "key": "dataone_token",
+                "key_type": "dataone",
+            },
+            user=self.user,
+        )
+        self.assertStatus(resp, 400)
+        self.assertEqual(resp.json["message"], "Invalid JWT Token: 'dataone_token'")
+
+        example_jwt = (
+           "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpv"
+           "aG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        )
+
+        resp = self.request(
+            method="POST",
+            path="/account/dataoneprod/key",
+            params={
+                "resource_server": "cn.dataone.org",
+                "key": example_jwt,
                 "key_type": "dataone",
             },
             user=self.user,
@@ -692,7 +710,7 @@ class ExternalAccountsTestCase(base.TestCase):
         self.assertEqual(
             user_token,
             {
-                "access_token": "dataone_token",
+                "access_token": example_jwt,
                 "provider": "dataoneprod",
                 "resource_server": "cn.dataone.org",
                 "token_type": "dataone",

--- a/server/lib/dataone/auth.py
+++ b/server/lib/dataone/auth.py
@@ -1,7 +1,16 @@
+import jwt
+from girder.exceptions import RestException
+
+
 class DataONEVerificator:
     def __init__(self, resource_server, key):
         self.key = key
         self.resource_server = resource_server
 
     def verify(self):
-        pass
+        try:
+            jwt.PyJWT().decode(
+                self.key, options={"verify_signature": False, "verify_exp": True}
+            )
+        except jwt.exceptions.DecodeError:
+            raise RestException(f"Invalid JWT Token: '{self.key}'")


### PR DESCRIPTION
This should at least prevent a situation when we store an empty string due to some magical circumstances.