### PR TITLE
Convert DataONE auth to api_key provider

### DIFF
--- a/plugin_tests/git_test.py
+++ b/plugin_tests/git_test.py
@@ -161,7 +161,7 @@ class GitImportTestCase(base.TestCase):
         with mock.patch(
             "girder.plugins.wholetale.tasks.import_git_repo.Instance", fakeInstance
         ):
-            since = datetime.now().isoformat()
+            since = datetime.utcnow().isoformat()
             # Custom branch
             tale, job = self._import_from_git_repo(
                 f"file://{self.git_repo_dir}@feature"
@@ -189,7 +189,7 @@ class GitImportTestCase(base.TestCase):
             Tale().remove(tale)
 
         # Invalid url
-        since = datetime.now().isoformat()
+        since = datetime.utcnow().isoformat()
         tale, job = self._import_from_git_repo("blah")
         workspace = Folder().load(tale["workspaceId"], force=True)
         workspace_path = workspace["fsPath"]
@@ -211,7 +211,7 @@ class GitImportTestCase(base.TestCase):
         workspace_path = workspace["fsPath"]
 
         # Invalid path
-        since = datetime.now().isoformat()
+        since = datetime.utcnow().isoformat()
         job = self._import_git_repo(tale, "blah")
         self.assertEqual(job["status"], JobStatus.ERROR)
         self.assertTrue("does not appear to be a git repo" in job["log"][0])
@@ -224,7 +224,7 @@ class GitImportTestCase(base.TestCase):
         self.assertEqual(events[1]['data']['event'], 'wt_import_failed')
 
         # Default branch (master)
-        since = datetime.now().isoformat()
+        since = datetime.utcnow().isoformat()
         job = self._import_git_repo(tale, f"file://{self.git_repo_dir}")
         self.assertEqual(job["status"], JobStatus.SUCCESS)
         self.assertTrue(

--- a/plugin_tests/import_test.py
+++ b/plugin_tests/import_test.py
@@ -154,7 +154,7 @@ class ImportTaleTestCase(base.TestCase):
                 assert instance_id == self._id
                 return {"_id": self._id, "status": InstanceStatus.RUNNING}
 
-        since = datetime.now().isoformat()
+        since = datetime.utcnow().isoformat()
         with mock.patch(
             "girder.plugins.wholetale.models.instance.Instance", fakeInstance
         ):
@@ -189,6 +189,14 @@ class ImportTaleTestCase(base.TestCase):
             self.assertEqual(job["status"], JobStatus.SUCCESS)
 
         tale = Tale().load(tale["_id"], force=True)
+        count = 0
+        while not tale["dataSetCitation"]:
+            time.sleep(0.5)
+            tale = Tale().load(tale["_id"], force=True)
+            count += 1
+            if count > 10:
+                break
+
         self.assertEqual(
             tale["dataSetCitation"],
             [
@@ -263,7 +271,7 @@ class ImportTaleTestCase(base.TestCase):
                     assert instance_id == self._id
                     return {"_id": self._id, "status": InstanceStatus.RUNNING}
 
-            since = datetime.now().isoformat()
+            since = datetime.utcnow().isoformat()
             with mock.patch(
                 "girder.plugins.wholetale.models.instance.Instance", fakeInstance
             ):
@@ -342,7 +350,7 @@ class ImportTaleTestCase(base.TestCase):
             ),
         )
 
-        since = datetime.now().isoformat()
+        since = datetime.utcnow().isoformat()
         with mock.patch("fs.copy.copy_fs") as mock_copy:
             with open(
                 os.path.join(DATA_PATH, "604126f45f6bb2c4c997e967.zip"), "rb"

--- a/plugin_tests/instance_test.py
+++ b/plugin_tests/instance_test.py
@@ -198,7 +198,7 @@ class InstanceTestCase(base.TestCase):
     @mock.patch('gwvolman.tasks.shutdown_container')
     @mock.patch('gwvolman.tasks.remove_volume')
     def testInstanceFlow(self, lc, cv, uc, sc, rv):
-        since = datetime.now().isoformat()
+        since = datetime.utcnow().isoformat()
         with mock.patch('girder_worker.task.celery.Task.apply_async', spec=True) \
                 as mock_apply_async:
             resp = self.request(
@@ -255,7 +255,7 @@ class InstanceTestCase(base.TestCase):
             job = jobModel.load(job['_id'], force=True)
             self.assertEqual(job['celeryTaskId'], 'fake_id')
             Job().updateJob(job, log='job running', status=JobStatus.RUNNING)
-            since = datetime.now().isoformat()
+            since = datetime.utcnow().isoformat()
             Job().updateJob(job, log='job ran', status=JobStatus.SUCCESS)
 
             resp = self.request(
@@ -463,7 +463,7 @@ class InstanceTestCase(base.TestCase):
             self.assertEqual(instance['status'], InstanceStatus.ERROR)
 
         # Delete the instance
-        since = datetime.now().isoformat()
+        since = datetime.utcnow().isoformat()
         with mock.patch('girder_worker.task.celery.Task.apply_async', spec=True) \
                 as mock_apply_async:
             resp = self.request(

--- a/plugin_tests/publish_test.py
+++ b/plugin_tests/publish_test.py
@@ -120,15 +120,15 @@ class PublishTestCase(base.TestCase):
             )
             self.assertStatus(resp, 400)
             self.assertEqual(
-                resp.json["message"], "Missing a token for publisher (dataonestage2)."
+                resp.json["message"], "Missing a token for publisher (dataone)."
             )
 
             # "Authenticate" with DataONE
             token = {
                 "access_token": "dataone_token",
-                "provider": "dataonestage2",
+                "provider": "dataone",
                 "resource_server": "cn-stage-2.dataone.org",
-                "token_type": "dataone",
+                "token_type": "apikey",
             }
             self.user["otherTokens"] = [token]
             self.user = User().save(self.user)

--- a/plugin_tests/repository_test.py
+++ b/plugin_tests/repository_test.py
@@ -81,7 +81,7 @@ class RepositoryTestCase(base.TestCase):
         # Pretend we have authorized with DataONE
         self.user["otherTokens"] = [
             {
-                "provider": "dataonestage2",
+                "provider": "dataone",
                 "access_token": "dataone_token",
                 "resource_server": "cn-stage-2.test.dataone.org",
                 "token_type": "dataone",

--- a/server/constants.py
+++ b/server/constants.py
@@ -58,7 +58,7 @@ class SettingDefault:
                 "tags": ["data", "publish"],
                 "url": "",
                 "type": "apikey",
-                "docs_href": "https://zenodo.org/account/settings/applications/tokens/new/",
+                "docs_href": "https://{siteUrl}/account/settings/applications/tokens/new/",
                 "targets": [],
             },
             {
@@ -69,18 +69,22 @@ class SettingDefault:
                 "url": "",
                 "type": "apikey",
                 "docs_href": (
-                    "https://dataverse.harvard.edu/dataverseuser.xhtml?selectTab=apiTokenTab"
+                    "https://{siteUrl}/dataverseuser.xhtml?selectTab=apiTokenTab"
                 ),
                 "targets": [],
             },
             {
-                "name": "dataonestage2",
+                "name": "dataone",
                 "logo": "",
-                "fullName": "DataONE Sandbox",
+                "fullName": "DataONE",
                 "tags": ["publish"],
                 "url": "",
-                "type": "dataone",
-                "state": "unauthorized",
+                "type": "apikey",
+                "docs_href": (
+                    "https://{siteUrl}/portal/token?action=start&"
+                    "target=https%3A//{siteUrl}/portal/token"
+                ),
+                "targets": [],
             },
         ],
         PluginSettings.EXTERNAL_APIKEY_GROUPS: [
@@ -93,6 +97,13 @@ class SettingDefault:
                     "demo.dataverse.org",
                 ],
             },
+            {
+                "name": "dataone",
+                "targets": [
+                    "cn-stage-2.test.dataone.org",
+                    "cn.dataone.org",
+                ]
+            },
         ],
         PluginSettings.ZENODO_EXTRA_HOSTS: [],
         PluginSettings.PUBLISHER_REPOS: [
@@ -103,7 +114,7 @@ class SettingDefault:
             },
             {
                 "repository": "https://dev.nceas.ucsb.edu/knb/d1/mn",
-                "auth_provider": "dataonestage2",
+                "auth_provider": "dataone",
                 "name": "DataONE Dev",
             },
         ],

--- a/server/lib/__init__.py
+++ b/server/lib/__init__.py
@@ -44,6 +44,7 @@ IMPORT_PROVIDERS.addProvider(NullImportProvider())
 Verificators = {
     "zenodo": ZenodoVerificator,
     "dataverse": DataverseVerificator,
+    "dataone": DataONEVerificator,
     "dataoneprod": DataONEVerificator,
     "dataonedev": DataONEVerificator,
     "dataonestage": DataONEVerificator,


### PR DESCRIPTION
Note that except for the change to `server/lib/__init__.py` this PR merely changes the defaults. It can be also done directly via configuring a running instance of Girder.