### PR TITLE
Decrease the amount of Tale().updateTale calls during import

### DIFF
--- a/plugin_tests/git_test.py
+++ b/plugin_tests/git_test.py
@@ -179,11 +179,10 @@ class GitImportTestCase(base.TestCase):
             )
             # Confirm events
             events = get_events(self, since)
-            self.assertEqual(len(events), 4)
+            self.assertEqual(len(events), 3)
             self.assertEqual(events[0]['data']['event'], 'wt_tale_created')
             self.assertEqual(events[1]['data']['event'], 'wt_import_started')
-            self.assertEqual(events[2]['data']['event'], 'wt_tale_updated')
-            self.assertEqual(events[3]['data']['event'], 'wt_import_completed')
+            self.assertEqual(events[2]['data']['event'], 'wt_import_completed')
             shutil.rmtree(workspace_path)
             os.mkdir(workspace_path)
             Tale().remove(tale)
@@ -198,11 +197,10 @@ class GitImportTestCase(base.TestCase):
         self.assertEqual(tale["status"], TaleStatus.ERROR)
         # Confirm events
         events = get_events(self, since)
-        self.assertEqual(len(events), 4)
+        self.assertEqual(len(events), 3)
         self.assertEqual(events[0]['data']['event'], 'wt_tale_created')
         self.assertEqual(events[1]['data']['event'], 'wt_import_started')
-        self.assertEqual(events[2]['data']['event'], 'wt_tale_updated')
-        self.assertEqual(events[3]['data']['event'], 'wt_import_failed')
+        self.assertEqual(events[2]['data']['event'], 'wt_import_failed')
         Tale().remove(tale)
 
     def testGitImport(self):
@@ -235,10 +233,9 @@ class GitImportTestCase(base.TestCase):
         )
         # Confirm events
         events = get_events(self, since)
-        self.assertEqual(len(events), 3)
+        self.assertEqual(len(events), 2)
         self.assertEqual(events[0]['data']['event'], 'wt_import_started')
-        self.assertEqual(events[1]['data']['event'], 'wt_tale_updated')
-        self.assertEqual(events[2]['data']['event'], 'wt_import_completed')
+        self.assertEqual(events[1]['data']['event'], 'wt_import_completed')
         shutil.rmtree(workspace_path)
         os.mkdir(workspace_path)
 

--- a/plugin_tests/import_failures_test.py
+++ b/plugin_tests/import_failures_test.py
@@ -201,7 +201,7 @@ class TaskFailTestCase(base.TestCase):
             job = Job().load(job["_id"], force=True)
         self.assertEqual(job["status"], JobStatus.ERROR)
         Job().remove(job)
-        tale = Tale().load(new_tale["_id"], force=True)
+        new_tale = Tale().load(new_tale["_id"], force=True)
         self.assertEqual(new_tale["status"], TaleStatus.ERROR)
         Tale().remove(tale)
         Tale().remove(new_tale)

--- a/plugin_tests/import_test.py
+++ b/plugin_tests/import_test.py
@@ -221,7 +221,7 @@ class ImportTaleTestCase(base.TestCase):
         self.model("image", "wholetale").remove(image)
 
     def testTaleImportBinder(self):
-        since = datetime.now().isoformat()
+        since = datetime.utcnow().isoformat()
         def before_record_cb(request):
             if request.host == "localhost":
                 return None
@@ -274,7 +274,6 @@ class ImportTaleTestCase(base.TestCase):
                     assert instance_id == self._id
                     return {"_id": self._id, "status": InstanceStatus.RUNNING}
 
-            since = datetime.utcnow().isoformat()
             with mock.patch(
                 "girder.plugins.wholetale.models.instance.Instance", fakeInstance
             ):
@@ -329,13 +328,12 @@ class ImportTaleTestCase(base.TestCase):
         )
 
         # Confirm notifications
-        time.sleep(0.1)
+        time.sleep(1)
         events = get_events(self, since)
         self.assertEqual(
             {
                 "wt_tale_created",
                 "wt_import_started",
-                "wt_tale_updated",
                 "wt_import_completed"
             },
             event_types(events, {"taleId": str(tale["_id"])})

--- a/server/tasks/copy_workspace.py
+++ b/server/tasks/copy_workspace.py
@@ -35,12 +35,10 @@ def run(job):
             dirs_exist_ok=True,
         )
         events.trigger("wholetale.tale.copied", (old_tale, new_tale))
-        new_tale["status"] = TaleStatus.READY
-        Tale().updateTale(new_tale)
+        Tale().update({"_id": new_tale["_id"]}, update={"$set": {"status": TaleStatus.READY}})
         jobModel.updateJob(job, status=JobStatus.SUCCESS, log="Copying finished")
     except Exception:
-        new_tale["status"] = TaleStatus.ERROR
-        Tale().updateTale(new_tale)
+        Tale().update({"_id": new_tale["_id"]}, update={"$set": {"status": TaleStatus.ERROR}})
         t, val, tb = sys.exc_info()
         log = "%s: %s\n%s" % (t.__name__, repr(val), traceback.extract_tb(tb))
         jobModel.updateJob(job, status=JobStatus.ERROR, log=log)

--- a/server/tasks/import_git_repo.py
+++ b/server/tasks/import_git_repo.py
@@ -81,9 +81,7 @@ def run(job):
             raise RuntimeError("Failed to import from git:\n {}".format(str(exc)))
 
         # Tale is ready to be built
-        tale = Tale().load(tale["_id"], user=user)  # Refresh state
-        tale["status"] = TaleStatus.READY
-        tale = Tale().updateTale(tale)
+        Tale().update({"_id": tale["_id"]}, update={"$set": {"status": TaleStatus.READY}})
 
         # 4. Wait for container to show up
         if spawn:
@@ -119,9 +117,7 @@ def run(job):
         if not has_dot_git_already and os.path.isdir(dot_git):
             shutil.rmtree(dot_git, ignore_errors=True)
         if change_status:
-            tale = Tale().load(tale["_id"], user=user)  # Refresh state
-            tale["status"] = TaleStatus.ERROR
-            tale = Tale().updateTale(tale)
+            Tale().update({"_id": tale["_id"]}, update={"$set": {"status": TaleStatus.ERROR}})
         jobModel.updateJob(
             job,
             progressTotal=progressTotal,


### PR DESCRIPTION
As a result there should be less spurious notifications sent to the users, which should make whole-tale/ngx-dashboard#181 less noticeable. Also updating a single field instead of entire documents seems like a right thing to do in case of status updates.

### How to test?
It's basically a noop PR. Not sure how to test it properly... Do some imports and confirm everything still works?