### PR TITLE
Correctly update wt_progress for last notification

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,6 +29,7 @@ jobs:
             - VIRTUALENV_EXECUTABLE: "/girder/venv/bin/virtualenv"
             - PYTHON_EXECUTABLE: "/girder/venv/bin/python3"
             - TEST_GROUP: "python"
+            - GIRDER_WT_EVENT_EXP_SECONDS: 60
           command: |
             mkdir /girder/build
             ctest -VV -S /girder/plugins/wholetale/cmake/circle_continuous.cmake

--- a/plugin_tests/instance_test.py
+++ b/plugin_tests/instance_test.py
@@ -68,6 +68,7 @@ class InstanceTestCase(base.TestCase):
         global PluginSettings, instanceCapErrMsg
         from girder.plugins.wholetale.constants import PluginSettings
         from girder.plugins.wholetale.rest.instance import instanceCapErrMsg
+        from girder.plugins.wholetale.utils import init_progress
         self.model('setting').set(
             PluginSettings.INSTANCE_CAP, '2')
         users = ({
@@ -120,6 +121,7 @@ class InstanceTestCase(base.TestCase):
             title='tale two', public=True, config={'memLimit': '1g'})
         self.tale_two["imageInfo"] = fake_imageInfo
         self.model('tale', 'wholetale').save(self.tale_two)
+        self.notification = init_progress({}, self.user, "Fake", ".", 5)
 
     def testInstanceFromImage(self):
         return  # FIXME
@@ -505,7 +507,7 @@ class InstanceTestCase(base.TestCase):
             args=[str(self.tale_one['_id']), False],
             kwargs={},
             otherFields={
-                'wt_notification_id': 'nonexisting',
+                'wt_notification_id': str(self.notification["_id"]),
                 'instance_id': instance['_id']
             }
         )
@@ -537,7 +539,7 @@ class InstanceTestCase(base.TestCase):
             args=[{'instanceId': instance['_id']}],
             kwargs={},
             otherFields={
-                'wt_notification_id': 'nonexisting',
+                'wt_notification_id': str(self.notification["_id"]),
                 'instance_id': instance['_id']
             }
         )

--- a/plugin_tests/notification_test.py
+++ b/plugin_tests/notification_test.py
@@ -45,7 +45,7 @@ class NotificationTestCase(base.TestCase):
         self.admin, self.user = [self.model('user').createUser(**user)
                                  for user in users]
 
-    def testNotification(self):
+    def testSingleJobNotification(self):
         from girder.plugins.jobs.models.job import Job
         from girder.plugins.jobs.constants import JobStatus
         from girder.models.notification import Notification, ProgressState
@@ -76,7 +76,6 @@ class NotificationTestCase(base.TestCase):
         job = Job().updateJob(
             job, status=JobStatus.INACTIVE, progressTotal=2, progressCurrent=0)
         self.assertEqual(job['status'], JobStatus.INACTIVE)
-        time.sleep(1)
         notification = Notification().load(notification['_id'])
         self.assertEqual(notification['data']['state'], ProgressState.QUEUED)
         self.assertEqual(notification['data']['total'], 2)
@@ -91,7 +90,6 @@ class NotificationTestCase(base.TestCase):
         job = Job().updateJob(
             job, status=JobStatus.RUNNING, progressCurrent=1,
             progressMessage="Error test message")
-        time.sleep(1)
         notification = Notification().load(notification['_id'])
         self.assertEqual(notification['data']['state'], ProgressState.ACTIVE)
         self.assertEqual(notification['data']['total'], 2)
@@ -100,12 +98,16 @@ class NotificationTestCase(base.TestCase):
 
         # State change to ERROR
         job = Job().updateJob(job, status=JobStatus.ERROR)
-        time.sleep(1)
         notification = Notification().load(notification['_id'])
         self.assertEqual(notification['data']['state'], ProgressState.ERROR)
         self.assertEqual(notification['data']['total'], 2)
         self.assertEqual(notification['data']['current'], 1)
         self.assertEqual(notification['data']['message'], 'Error test message')
+
+        # new notification
+        notification = init_progress(
+            resource, self.user, 'Test notification', 'Creating job', total
+        )
 
         # New job to test success path
         job = Job().createJob(
@@ -127,17 +129,124 @@ class NotificationTestCase(base.TestCase):
         job = Job().updateJob(
             job, status=JobStatus.RUNNING, progressCurrent=1,
             progressMessage="Success test message")
-        time.sleep(1)
         notification = Notification().load(notification['_id'])
         self.assertEqual(notification['data']['state'], ProgressState.ACTIVE)
         self.assertEqual(notification['data']['total'], 2)
         self.assertEqual(notification['data']['current'], 1)
         self.assertEqual(notification['data']['message'], 'Success test message')
 
-        job = Job().updateJob(job, status=JobStatus.SUCCESS)
-        time.sleep(1)
+        job = Job().updateJob(job, status=JobStatus.SUCCESS, progressCurrent=2)
         notification = Notification().load(notification['_id'])
-        self.assertEqual(notification['data']['state'], ProgressState.ACTIVE)
+        self.assertEqual(notification['data']['state'], ProgressState.SUCCESS)
         self.assertEqual(notification['data']['total'], 2)
-        self.assertEqual(notification['data']['current'], 1)
+        self.assertEqual(notification['data']['current'], 2)
         self.assertEqual(notification['data']['message'], 'Success test message')
+
+    def assertNotification(self, notification_id, state, total, current, msg):
+        from girder.models.notification import Notification
+        notification = Notification().load(notification_id)
+        self.assertEqual(notification['data']['state'], state)
+        self.assertEqual(notification['data']['total'], total)
+        self.assertEqual(notification['data']['current'], current)
+        self.assertEqual(notification['data']['message'], msg)
+
+    def testChainedJobNotification(self):
+        from girder.plugins.jobs.models.job import Job
+        from girder.plugins.jobs.constants import JobStatus
+        from girder.models.notification import Notification, ProgressState
+        from girder.plugins.wholetale.utils import init_progress
+        from girder.plugins.worker.constants import PluginSettings as WorkerPluginSettings
+
+        Setting().set(WorkerPluginSettings.API_URL, 'http://localhost:8080/api/v1')
+
+        total = 5 # 2 + 2 + 1
+        resource = {'type': 'wt_test_build_image', 'instance_id': 'instance_id'}
+
+        notification = init_progress(
+            resource, self.user, 'Test notification', 'Creating job', total
+        )
+
+        # First Job
+        job = Job().createJob(
+            title='First Job',
+            type='test',
+            handler='my_handler',
+            user=self.user,
+            public=False,
+            args=["tale_id"],
+            kwargs={},
+            otherFields={'wt_notification_id': str(notification['_id'])},
+        )
+        # State change to ACTIVE
+        msg = "Some message 1"
+        job = Job().updateJob(
+            job, status=JobStatus.RUNNING, progressCurrent=1, progressTotal=2,
+            progressMessage=msg)
+        self.assertEqual(job['status'], JobStatus.RUNNING)
+        self.assertNotification(notification["_id"], ProgressState.ACTIVE, total, 1, msg)
+
+        msg = "Success msg 1"
+        job = Job().updateJob(
+            job, status=JobStatus.SUCCESS, progressCurrent=2, progressTotal=2,
+            progressMessage=msg)
+        self.assertEqual(job['status'], JobStatus.SUCCESS)
+        self.assertNotification(notification["_id"], ProgressState.ACTIVE, total, 2, msg)
+
+        # Second Job
+        job = Job().createJob(
+            title='Second Job',
+            type='test',
+            handler='my_handler',
+            user=self.user,
+            public=False,
+            args=["tale_id"],
+            kwargs={},
+            otherFields={'wt_notification_id': str(notification['_id'])},
+        )
+        # State change to QUEUE
+        msg = "Some message 1"
+        job = Job().updateJob(
+            job, status=JobStatus.INACTIVE, progressTotal=2, progressCurrent=0,
+            progressMessage=msg)
+        self.assertEqual(job['status'], JobStatus.INACTIVE)
+        self.assertNotification(notification["_id"], ProgressState.QUEUED, total, 2, msg)
+
+        job = Job().updateJob(job, status=JobStatus.QUEUED)
+        self.assertNotification(notification["_id"], ProgressState.QUEUED, total, 2, msg)
+
+        job = Job().updateJob(job, status=JobStatus.RUNNING)
+        self.assertNotification(notification["_id"], ProgressState.ACTIVE, total, 2, msg)
+
+        msg = "Success msg 2"
+        job = Job().updateJob(
+            job, status=JobStatus.SUCCESS, progressCurrent=2, progressTotal=2,
+            progressMessage=msg)
+        self.assertEqual(job['status'], JobStatus.SUCCESS)
+        self.assertNotification(notification["_id"], ProgressState.ACTIVE, total, 4, msg)
+
+        # Final Job
+        job = Job().createJob(
+            title='Final Job',
+            type='test',
+            handler='my_handler',
+            user=self.user,
+            public=False,
+            args=["tale_id"],
+            kwargs={},
+            otherFields={'wt_notification_id': str(notification['_id'])},
+        )
+        msg = "Some message 1"
+        job = Job().updateJob(
+            job, status=JobStatus.INACTIVE, progressTotal=1, progressCurrent=0,
+            progressMessage=msg)
+        self.assertEqual(job['status'], JobStatus.INACTIVE)
+        self.assertNotification(notification["_id"], ProgressState.QUEUED, total, 4, msg)
+
+        job = Job().updateJob(job, status=JobStatus.QUEUED)
+        job = Job().updateJob(job, status=JobStatus.RUNNING)
+        msg = "Success msg 3"
+        job = Job().updateJob(
+            job, status=JobStatus.SUCCESS, progressCurrent=1, progressTotal=1,
+            progressMessage=msg)
+        self.assertEqual(job['status'], JobStatus.SUCCESS)
+        self.assertNotification(notification["_id"], ProgressState.SUCCESS, total, 5, msg)

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -452,7 +452,7 @@ class Tale(AccessControlledModel):
             "tale_title": tale["title"]
         }
         notification = init_progress(
-            resource, user, "Importing Tale", "Initializing", 1
+            resource, user, "Importing Tale", "Initializing", 3
         )
 
         job = Job().createLocalJob(

--- a/server/utils.py
+++ b/server/utils.py
@@ -68,6 +68,8 @@ def notify_event(users, event, affectedIds):
 
 
 def init_progress(resource, user, title, message, total):
+    resource["jobCurrent"] = 0
+    resource["jobId"] = None
     data = {
         'title': title,
         'total': total,

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,3 +1,4 @@
+import os
 import datetime
 import six.moves.urllib as urllib
 
@@ -5,7 +6,9 @@ from girder.utility.model_importer import ModelImporter
 from girder.models.notification import Notification
 from girder.models.user import User
 
+
 NOTIFICATION_EXP_HOURS = 1
+WT_EVENT_EXP_SECONDS = int(os.environ.get("GIRDER_WT_EVENT_EXP_SECONDS", 5))
 
 
 def getOrCreateRootFolder(name, description=""):
@@ -59,7 +62,7 @@ def notify_event(users, event, affectedIds):
         'resourceName': 'WT event'
     }
 
-    expires = datetime.datetime.utcnow() + datetime.timedelta(seconds=5)
+    expires = datetime.datetime.utcnow() + datetime.timedelta(seconds=WT_EVENT_EXP_SECONDS)
 
     for user_id in users:
         user = User().load(user_id, force=True)


### PR DESCRIPTION
If job ended up in a success, and had a correct number of steps defined by progressTotal, it was actually impossible to issue final `wt_progress` message if both job status and progress were updated in the same step.

NOTE I think that logic is still wrong in case we have an intermediate job finishing and the subsequent sub-job has one step...

Requires: https://github.com/whole-tale/girder/pull/13 or prebuilt image: `wholetale/girder:event`