### PR TITLE
use tempdir on default assetstore during import zip

### DIFF
--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -355,13 +355,9 @@ class Tale(AccessControlledModel):
 
     @staticmethod
     def _extractZipPayload(stream):
-        # TODO: Move assetstore type to wholetale.
-        assetstore = next((_ for _ in Assetstore().list() if _['type'] == 101), None)
-        if assetstore:
-            adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
-            tempDir = adapter.tempDir
-        else:
-            tempDir = None
+        assetstore = Assetstore().getCurrent()
+        adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
+        tempDir = adapter.tempDir
 
         with tempfile.NamedTemporaryFile(dir=tempDir) as fp:
             for chunk in stream(2 * 1024 ** 3):


### PR DESCRIPTION
POST /tale/import for zipfiles was relying on WTHomeFSAssetstore which no longer exists... 