### PR TITLE
Add Tale status to swagger spec/schema

### DIFF
--- a/server/schema/tale.py
+++ b/server/schema/tale.py
@@ -31,6 +31,11 @@ taleModel = {
             "type": ["string", "null"],
             "description": "The description of the Tale (Markdown)"
         },
+        "status": {
+            "type": "integer",
+            "enum": [0, 1, 2],
+            "description": "Status of the tale import (Preparing, Ready, Error)"
+        },
         "imageId": {
             "type": "string",
             "description": "ID of a WT Image used by the Tale"


### PR DESCRIPTION
## Problem
Tale `status` field is not defined in the Swagger spec, though it is provided in the example value for a Tale. 

## Approach
Add a definition for the `status` property to the Tale schema. We should ensure that the attributes required by any clients (UI + worker, at the very least) are defined in the schema in case we ever need to re-generate the code (e.g. when switching frameworks, writing a new client, etc)

Note that even with this change, the Swagger spec produced by `/api/v1/describe` is not a truly "valid" Swagger spec... see https://github.com/whole-tale/girder_wholetale/issues/358 for more details on what would likely be a more controversial set of changes

## How to Test
1. Checkout and run this branch locally
2. View https://girder.local.wholetale.org/api/v1/describe
    * You should see the full Swagger spec for this instance of Girder (including the WT and associated plugins) displayed here
3. Search the Swagger spec for `Preparing`
    * You should see that the `status` property is now part of the full swagger spec generated by the `/api/v1/describe` endpoint

