### PR TITLE
Dataverse provider updates

### DIFF
--- a/plugin_tests/data/dataone_lookup.txt
+++ b/plugin_tests/data/dataone_lookup.txt
@@ -1,0 +1,724 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: HEAD
+    uri: https://doi.org/10.18739/A2ND53
+  response:
+    body:
+      string: ''
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 6636b8f2490a2a4e-ORD
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      Content-Type:
+      - text/html;charset=utf-8
+      Date:
+      - Tue, 22 Jun 2021 16:06:11 GMT
+      Expect-CT:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Expires:
+      - Tue, 22 Jun 2021 16:41:47 GMT
+      Location:
+      - https://arcticdata.io/catalog/#view/doi:10.18739/A2ND53
+      NEL:
+      - '{"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v2?s=YZXn5hYWu8TP4O8Whtal69Tk9oxwAXhWkdEK2pP7bW50yLtYN7vFy%2FofKREf7iscPB1lTHB75LQLT3PEM8Q1XSJQ93rV9DbxmxedioFmc1HqgP0MsrpbEk4sgVHteodj"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept
+      alt-svc:
+      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
+        ma=86400
+      cf-request-id:
+      - 0ad611eb6d00002a4e11ba7000000001
+    status:
+      code: 302
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: HEAD
+    uri: https://arcticdata.io/catalog/
+  response:
+    body:
+      string: ''
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type, Origin, Cache-Control
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, OPTIONS
+      Access-Control-Allow-Origin:
+      - ''
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2682'
+      Content-Type:
+      - text/html
+      Date:
+      - Tue, 22 Jun 2021 16:06:11 GMT
+      ETag:
+      - '"2882-5bfdfb8df4446-gzip"'
+      Keep-Alive:
+      - timeout=5, max=100
+      Last-Modified:
+      - Tue, 13 Apr 2021 19:34:43 GMT
+      Server:
+      - Apache/2.4.29 (Ubuntu)
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      - sameorigin
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://iqss.github.io/dataverse-installations/data/data.json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA8092XLbSJLv+xXYftiRI8QSLoLARmysZElua8aWNDq6Y69wFIEiiTYIsHGITW/s
+        v29mVeE+KdkzMxGjpnHUkXdmZSb+958U5Sc/TFIaBDT1ozD56V+V/4KLivK//C/cDumWwdWfLpbU
+        zZKfTvPrHkvc2N/hW3j7bsdCZRXFSswSRmN3w+JEoUkSuT5Nmafs/XSjvI/91E82ymUUZNulT5Us
+        9F/gQbjKEiWNFI/tIviX4tGUknIuWBzMYTpEnzuOrZfXwzVcn2m6AXdUXSvvbKIkzVfuvYQk8Jcx
+        jQ8kW7rEpdWRs9DdfDnAkvFRXdXM8qYbZWEaH/DGJQ2pR6u3wtQPWYjr+uk2imFzF1sW+9WxNzR+
+        YQk8tv6SsLQELb9JOTi/RAC2n+TV/yneXHuu+2XLtkuGq1rRIGEl3CP/C83STQSw5Ev770w3tbkY
+        5P9Oe5B3+fioXAFQEdqsF4lPG6bUH1V8wGKo+CGgCCjkhSnRSknxsZguAY8APT/geMeLj4jtQHl0
+        fRa6LDmF9xQ3AtpaRjGnL0EG+Oidl22VGyA9P81Sxkd4kJSDb9VHUmjKX3rOyeWAyxBgv6RxFPgh
+        xWcuN3THAuWjHwRE6dgMYo0CvSuJGD6RwyO5IYqUXRx5mQvkCkvgOxQk4ONeiqWvI3gV5t/Sr4Bb
+        /rJCX6gP2wxYjQdwGHwjZmvcPA09mAHuxS/Fi/j4KkuzGMZlIRNgSnD4CiPxzcQcGWGkuEBYazER
+        dQHMgnPyLcgp6zs/VWgAJJOtN0qWcM6McVW/Z0CfsFt4H5cIv2N8P4o9+IGDRvswiKgn+LELogC+
+        KIvpmtVhClwOS9lvIiVJM+9QUoyEBIy9o3Hqu/4OpINYs59UyWx5yIVBDqqWPDAMYjvOwrEb8sCY
+        E9Oea7bZLQ3ytRNYFHWThETxekggOJ0C4RNb0hC4plsiXCR+RRB0sPMwt15dTGXWLEljGvjAovgC
+        wNjdIPSAjl98eF6hSsgpChGDZOcKukGmZC6C9rRCkfA7WwYgoBHkSKyCvDgC/LUPWqKk7E6MzAD0
+        hmksKqAXKNFAdqu27iwWIzgBIUuYlxGaDaFk0YmSAhh9SGnfB8GUpV+yOMD7mzTdJf96dta1hjoK
+        0zhjlTli9gWuJCmIecBtXc7ng+73e4JP8gfxOSS7s/1uhkuEBZ5lO+S05Ay2Z5+p+lmJ2hmidiZR
+        S3beqq0wWkpBU4luaY5R7mAZ0dirbhMQusmWsKjtGSwlObv56+PjGRDOb0AYyRnAeJhGH5+VT0Kp
+        loKb0+CDYNsIkNJHupWX/5TUaQr+lb+unOyiPYg9D4XBR1CmsAFQdsCRSUUCJdEq3YM4e6dsWLBL
+        FBybrlZ+IOyOqjmSgOAEUZjA4Kyge/jl+in8ZX8ABvAGUj7IdtZYmGQGlPH4hOcnbgRLQKFPGgoT
+        RJcHpkB1fjHGFsyINdsCvgt23AHrAEtuQQJScZUVQpyzoys0J84ZM5Deym4Dkj7Xw/XxA3/F3IMr
+        l7iP4q+J0MGg5eK0VGEIpCvJ0iW+FOZGyQG0wJYLaBwaFgqrBrDAGNtdwEBY73yXqytYAAyTIyRx
+        N1FA4+AAcAIBzi26Lolt6nMQEA3xMNM0jTi6rVnGmHxIMuTNcuAtcJTvJk2mbMkMXe2UGc+PF8cZ
+        dQOCoIsJTdswnfoMAJ8vbAvmQm1n5/nOhrnu+fFxknKQD86UQkugjmhYVTWVgRTfaRhVCB9YJWaU
+        a+RotwMAZaEw3WtGD+cOwcoZmh5LsGtWfspfywfGZ3Aulh6IIhcraZ8mgkTzRYNAEJQoDAPJGpdg
+        JcECfLAigRCvsxgs6eEdJsrJ5TWf6Prh5vJd272wia6pqlGSoNRdFjEswzSdXtIETZEkoDRgmKPp
+        ckiX9Woysd0BNYZarL2mYYckCL5I9c+8N7okQPiaNrcXA4Tvh6vovFzjINW/j9JkD5IzVwIcrYN2
+        UeuNi5urx4q7cQ/GZ8jA0NkJeQ2SMvBmMQvB4AWhDXzo5maTL19CGQyUxv5wGdhOSFx+WKf54i1l
+        B8KWIwvl6MebX8749PhMBLQbK6AB4jWygxDwoLnQPEfDHocGY5oo1+CUS2TgRJrjWKec8KdtLeZ7
+        O3n/8f6d2GHFDXth9XWDmQGGN6yman6zdM/Ao89ny8X8Z3gGKJP7Xx/FqnGIXwEmIXoifDxYZb64
+        J/KRoFsGnAkKIuJ+073YtHxdLj+fWXgZsO6WSm0YB9z9CYKGEoxC7izC+0R5oHv+Fmr0KDxs/YRJ
+        wYSrXPmIXdhacEhggsIZYzDnoRgRl+Mn1Xn34FyCSNz48KAwkoMkUhhNDmIMNDIQmKhrpawC84oC
+        2Eo9DtyagHnetp91k1hzQ583FaQ+J45qLZyeAEehHpebHdqVZLnvlCo5NvsM5NWQrhsPQ+jqSBji
+        8uYK/Mdezv3gR26cfZu9v2hhO5dMicJ2ALmtHwXRGhYblAgtiGAVR1tOGmieKe9j+g1EThPSmg4G
+        h+5YTU9lZtjEsBeOVnqV3aD2AajU9T1wIUc8yB7To7mwGioegURGrY86Rloi1gXH3AP8UFz0+Rov
+        o7U/hqIPdw+9GLqE5QFMkU9u8FfhXH4AE5HLhcIXOOEjveuyVSQKLDJ3TN1p6VvVIrZq9YKfuD7M
+        X4f5ZG0770TFTYiCI+n3HGu3BtUoX9wXEcoJvoMaXcx1e0CN8ulmsbedJRm3yM7dtU8FdEbw/Pnz
+        fzzVXbd+xowZ2HEYq8wjThXWrISqSmbMvbIyosatQpCZAQzDPTq5gjJe1BKHmkPmhjY35k0edWxi
+        m5Zq9Ud4gEi220Nap5IKxj+zP3w3Os70H8E7zodTey9lVKi4kewbl/39YYeX3kYhMvbbTx9/Jh+v
+        Hx6uHy6m08XDxVUvIdwJTbZlIGRp+N+ZqrIFRe2JOhidbPi/QtdxFEZb//eMKSzFe24U7fjDjgwD
+        +1XhAUQSZbEC//XEQ5xIdsJN9jLuYSsYzIrF7TWPkKZgAqMCQJWQKltxywNPPs5X5rAwxMAtPiKd
+        UnEd1pspfKOw6oBfs1/4ZOgByeA1PvPiv9AwPa1fFy6SmLb+AlMCYScBiYiZQp/BzuhuFwA05KIS
+        hf9Q84cBXL6bBehTnzZvBT4CAdgvRFuteLAaiEO+qoGTQ1sGkqXp8U0G36OYR6zzcH0CTgaYfhK+
+        HOoc5hhakNDlw39mOVwZ98c4Ak4FBP+UVBx+GWgQVg/GIgrgnDY8S2Epgq0LTMfiimcIT3Jwiah0
+        DTY4KAtffKAuvkxua8KyUAzh0GVwpe3bGWBXqapd+nAyVExsy9H0MbPK9UGTklXcKUo+AFxc1iNK
+        mp7aUdyN8t/WrJFI3OXDHXq1g/7QZRwBCYxEAE7kSNJjKOgJXLWYgnLPRNxH+ix5/GoPIAPujwJu
+        pwPOWJjgY5wEonA9AxRt82BbaQJ7fpKAGRfS3LFqRB6GA83mnCzAdtMa6NTATF5oVj86iRtH3OXc
+        xNUhpxlsEogTMd0ZWuZR4GIJZ6+nC92wrKG40nYdUEAPPV+tvq1xt4MkdAU+45ZbnOORpQ7WWqim
+        aTZPYWYLnei2vdBK7d3NXF4+eT2wNxUrb4zgjZ/GXNGH536fhd8Vsqnps8gIbf3Q8hGc9HQNWwZ7
+        arXiR3HASi5yTBDJ8EEtmlaYVG6E2gbPHfna4WfMD9FC/ntwLoxPwzKRQTN0gsMIhHwYCCe6cuaz
+        Qu9+I73kU2WZpcK7xce4dM0PhtgfLvj06/L4M+UOF6iTNSsWUwSju0JtCxBsZtPNdcDe1efzPv6N
+        s4RkoT9Lin15bIBgek7ufgZ5RMNDD9FMZmP/W8dqzlh4toq+ZskZX20vg4/GjTXbhOWP0CUA/ub2
+        4aKfV/HuNWJd7CoP4qTRrseY8IswUh7I4ZGx/MUww/Ur6T5SXIBXzApTojZcrsrFsYhYI66CE7ww
+        /sXKaFJ9gkdW+BlNg/p5oC2oJBCsosg7hdWkmE8ShadVO0EaFoWZQJSbFEZwgwzZh/0BphE3qmgA
+        Nom/zYJKWGZZ6Cii3CF/8OkLFwbWHcU9OQ1iQ3wLS6Yg3YrAnQhP5TJB8lR4wDiVSwt3Cp8CH5YW
+        zM7DRuhvdas/8H9UzVRbYSKiGeqQOUP8MKbsu1gyg97QxadPx3k2x55ODvk8uFHc5zn+wb2Os9Fj
+        5vWnNn0UyESqfbgCWgPfh9vj0hBqMQ+nSMx98NiKhR5PoAHeXvOA4xakOI+Cst8zP+Wmt/SAVzDW
+        rhK8LQ7rihyUXLCK4BCPPUpXCg8j/R2mwYDe4coCGOMbkI9kxVM8vtv6qUz24BwrQpiFwY/jVvyB
+        q4o/8HMEuOqyqQ3VsRfN+M2cGJZtj8fP4rpF3RPCeS15dsptwQKNiY83vRZqJSRzJOWCFTNIjnyJ
+        uQDdRb1E2Z1vh0Ks4vG1M/CkKzmYd6eUBM9P2sqYH3oP0ew+CuBFdA4575zk6V7KfcRXcHn78Nh5
+        vGbPTVVvyyxDt415acq3ZFYJjRre2vreertUO5oYNFN7NS1o+rhoKk7n/efP/Xq+lDw5Vh5G7NDP
+        friJiPIoUiKkDaiI1Ad0oxsqmMfUn/lL5R08/e2QCxqZW5pulhFc6RDYxHAsvV8uFGrSz7Yk8eBP
+        tuWr3KVDWO+28u7xdHpN++Lrk8VFbVHFel5v2BmmpU9A++OOuuz841+eH596sd4EvA6sZACAW16x
+        ZhLdshZ6P48lOB0B8U82XzvB+RE8eeUv8KcHnqMJb4NA0cyFpo0DRaYczrg88Clcivq1dsk4KN4U
+        /rCCuldkDoAgUz5TL44w4rbSojYZq8TUrMWiFXwGf9fsOYhjHs4C7C5n2OIEYURYZZmTjyq6EwOA
+        MPy+rMOjTDS0Lqkfsy+I/zFjbZSsdc0ZMsmYRNl5F2im4f32Uy+qK890nxVvCoV2dXH7SIpTD9aR
+        o46isjpg4WKfPOLRMMjXqvI8VTb+mh/pF4f/tbPIwqFK3vGcW25btRRuk/bmOlFt1W5aViZIjznw
+        cS8bC8sqDF5BbUYntd0yzFcIYEvJRJrrEaRhQr6GdA9rQxeZP3QmI4jJGeUBSCDTGUw0w6wh/I0b
+        OqtgQrz170DJX2BB6wyU1L+xcCK1Zy8pJ3R+5xhi/yHZnebZkx8ss3g9K5XyrNjqxBTP5tnPkcYH
+        aKF+fuXZOTWKmsikdxOY9E45qWpYOUV01og7n4qEeO5h1bI+uF/cYZ5ULWF+4TaK92wtcsjaPloC
+        1k+0ZUUuNJrLMmmjulYeAEM3fZcOzSUSe2rDN7nacogFmkNtRko1mzjzuaGP5auHFW9gMl93axGE
+        DH1TCAzwAQaDnyLiiiXCb8HaE7my8uLflyl19Uw1KsLmbiIP8kjd4g0egFnHQY0JcxpDKJ1vfmPB
+        TgJ8lBkHzKLL66ubiz8lvTnbRVo0qLbyjEae1615GmVZdFJnQlm/IhQteAbwIMVUHTep6USG9Sw3
+        lSqTNThoqfLiJ/7SB8/ycCqKQSpcD8Ien2GYGZ3yU8b6YZLIXWU08ZEH02KJYtoMeKeq8k+V36Is
+        BgmDW8SFC5QmhRvEn+F3PEx285dZym/ziEuZWl5ldjz+ZniIlu8ZM2U9XxxSlltTIhER3LNlR/IX
+        cdSF07TeZwuHqJra6zahvQkziZIF5lZHnXaAcu1mmCbUIwxekYjUd141lA4asvW52Aamr8E2hkn8
+        YXb79KycIO2+6yV1PPj0a55xPYOlSrsNFXNLwwPYGMoTczdhkWpW8aBPYP53RMFV1AIwcaUkiofa
+        MGG/ttyK9Vf3u6k8hgX68GOZntiKgxdMwwsUxKP1h6p1CafNogVkBl6w0CQ+DUxL27Jaqkk1iGUb
+        mtqtm6oSioQpT2AnyXheVtWfAc1AdyCle+iv7lh2qqIl4CepTH8W+EtuPZYJAUItzbx4Bo8Jy7KP
+        lqe4OouRo5kPAbzg0UaOXIV86tIXYxXVSEUHHX+4ee58qZI0n8eCZ7VgsBBwOWlFikwTa0nIdhpX
+        mbmV4vQtktHnZDE3WikVM1slhmOCQdOfMC/smZWf/f2OfAfUrrc9z5c2jOUM/JoKVnsRWMRqm2/0
+        FSqNVUIbGtEde260Ij26RuaqZpo92ZMvIVnhEjijuGEncC/BAJ6WB3kM30zJDv6Zh2IsXigCACvI
+        /S4EWu4/5Bx+rShgruqBhrRHjVwttWpnNIry48ZMl3S7yxJxvpjIsGkRNW88y4plXQRY04dHMhTs
+        EOBYsH+ibJdHaRvvPaZUHsZWqCavu8PLP8O4QZC4G7pKlRV/2Y3BjwHLLRRXYVsipMFCVAvxkgEg
+        QLdtlx8bs7XobA7kZBgLrRmIcIhjgBjsD+WSdcTkoLMclLOII6R2Zv/qY/ljaA9l9tzSR6ivWlvC
+        5VMvwcmYuRSqwixcszS3+JCiDpjQyAGhfPBDLz+SKwqqMAWIZ0wUdLbyWeB1BNN1YizmVjuYvtCI
+        phm9LQ8KIbsR25pUNPcWETvo56HTc5SD14VDMI3L6Y71s4ZypfLM6W6gDRMN868unvpz7wrJDw96
+        LICdrr+D+Dcd0LB2KzJtE2uhm0a3qQaWIh8LM1Y2xWJqzDhOFcfx6CBJyPWMUcW4Z4GFZkMZ8nKi
+        8wBTzMFY6oDAIIpv3t9c9p/BoG0WshQza7EThR+CbKenipv/JOD4uSlZxqcKKolVFnpYXwZQi1lw
+        yJWFKAXBQNUaTfcyvRUsftEnIQtojE9/vny6UU5EFZbMqMbzDapc+vyfFKPsp+i3CLeFKgys0OiF
+        ilxt/teI3uVKi1t5yCKcSHvSNTE5s5KiUCpKXlss1t72ZrU5sdW5bba6tZgLYtuaYXWbh+V5G9BS
+        8nvmJzQpgNipOL53HU0Xkc3Vxcih3c3lw83jRT+h1F2BS+CUSgym3geFp2KwrT+7ACdCeeKZ2GBm
+        4Nl9JSmoasQAhuT8LY8R854wTe+xll57qtxvWBilBxj6FGyI4ufjDlNcRdr3Y+QHyr8ovzLKY5t8
+        wP3Gx5xzzFb0w6/5mQlfVJUw2v7lghh2U2AtbAJO51hLCB/AmND+Uo6b0PsehTtymrcLJF0zda2+
+        nu6Sb7L0s6llWTeXvz72n/+jzcKbv/BQNNJPndwuLi5u8NwT0+8wuRqY+le2lEjmdIEp/lQ54dO0
+        czeMBTENsN/bdfu6zkuUnDEkbnf+LNknvUi87TM3pONQ3OwqdV5n2OuElLNhnJeFZyaxyfwMG978
+        UM5fJWkK0nnccGw9OcU5qTO09BJkGk8pNzDbt1JaX8StxBhPMQ0TtHFOa3ld+OStUF7CjQHupfBS
+        xprhMZnIyI1UUR4iB8TCDikydgENwzxB2PVfQHhU6ju684H0ZsBJJ1Y1Ragr2MTDN8QXsPyRKWTH
+        koo+ny/sEVq5efw4gVDQqqg/Wrau2oKgimanypYl+B8R/sZLAWKWo4uLAuBxWVLBE2JdXpLlKhsf
+        258c2q4eOBqWo+rNkIIJrp6j6/3lmDgZ8f1kTegWG0h5dFsde1oB5vHnzEciZzTppsZKD1mSoDX2
+        CcueKM8qHkfaxQAjlwkIQjgPz3VynyWbrzDYV/835SravsvZPn/2gh8yHCpcn2CM4pFiOOGewUAJ
+        ni4XoQlGRSsCHizkscI8ebXsPhPVgtG44IqtAcTUsU58cBUFX7FtDuF1+806eT4MH4E3DilToksQ
+        4CASLnsfg9uF5MGUVUwx6yBWhzimabcSJAyVGKpmjnaR2QF8vWhL4lcEHwUcfgyVEkOzrTE6rSr2
+        +yilgDmRotlLmXg7jnKbwBWvXjHlE1Xu6Q7Vfv+g8lBe7CGnw8ufby4eKi1YTovgczFIrfBwC+Sq
+        iBiXNuelA+jmgnbgEbNqHw3e1YHn9+dVMaI5Xod/oRN1seg6L7OAOCzbHohOuf6O77HXHLlnVdL4
+        ER6FDqaTMYzqP0cbkPcfox2Kgilx5r4XamV+LdvOIYbuqPNWnhvA0dJVw+iu35LRL250kd8207oy
+        /bAAEyzAo19oMFpxPx5l0u0x4708VjrPNz6MRxGVxTisMhgtaj7ICypbh5g9B5fYCYnzGR7XRHHi
+        brJwnXxD1oc7laGJ8oGh/EZTrag5WUVuJk+DMmHFAdv+JQOghaBO2v7cXMWGJC0BbBFTUweMBbL6
+        NvstY3wZg7VbPcL3uABUb+1WbRVn35ZnsVcxWo5mZUuzXp+HZQ4TD4/1D3dn4I9wFhcRnYDKLo/P
+        v1w044qivIqjXFgAwUHYkPAqRppyCS+mfSyaulUSRJLMF5ZLnr8ngwJFjZVoOwcP4PyyLxyvaEky
+        jB3gKXkKE2OGyTKKvia8ejJhMsGCk0lLSNlENUwwr1tCykYPzXDGcqcCf0lefGy6JDIlRkXV1OqC
+        o+VYlwOLNJl3KK6u8oxfPMvN7KlpVQD3GUcgzyl8s0jU7Gp26JHkral18NSkKd/eeQ0vw8xwc38z
+        wRJHS7RM/1Zugq1PN8otTYQAPXm4uS3MGhqWfDHSE5L3ivrWLE1XYDSkfbBvEyb7SMluwCLlh78a
+        BNE+EUmCMnNKHq+Xo/Eui5jDFBwa6UpizNckKdVzlMSBU3+e0p4tK7lKjUWAygtdP+dSHsiGrWwA
+        FfCPIOAOahzJpkt1ELVsN4vour1YtI6vsfOPZqv2QAFj4O98so6I742ycD1GeESDn2MVwHiM6DPF
+        o+jSm5dRl14KvijaKyxj7NrMvbdDlOWe0sXlz+fPfFDhd+3pQXnMdizGLp1ZyvtpbKIsANeK/XMT
+        /Cb49KpmmK3MDQtPkIDbxyr2qbsmWz45yqhqY5s3ScajwD6l6/nn60+D9tZTNdVf2YmEGqkAG/F6
+        VtTAXVQrnYsIPiYNg268iLu7noI3YrWc1Tkxnbk54KZsWUDKtj1HkPsbm1OPQr1fosOSj+1EdXtz
+        3UxC7cVYx7PdRvIRmX7yjVpQ5jqv5jhVigQ1ouDsVXuqO9uva43/sDl/jqY1HT+e87ewbb3vgK6a
+        8+ezH57zdxSB8jCsMWJT397c/ecEM+Kuu9+ZaIYRo0CvY0EWEjAP7YgIX5Ntz4q2qrn4fogOgOhK
+        0LNxAvjIaCFamlibG0RVDX3elN4mWdhzu+f0v5TdoR99q1UITXW9vkuIdhAtHN6cc86V58tPUfZS
+        K3VrYKcIb4hjcDy7AE+DNx0DJ1i+rcyU9yxYg2/cAqNKLMuxWxmvJrG0udWfbi3BmLmBmIEsh9zY
+        nuLU1pqOheMgA2imqY+cQ3BQi56Nw77lfeQFmFZf+QBA9dQ5pLWOH5wPWpDWyQII1tHbpd/Yfgsb
+        wWj9lanyQA/Wu+LL5WJn9wr6vY+QdieCvDNy0FrEG/o3mbYxlA7/W0B3GP+n5/4yIUufgvvgs298
+        54OIvWe8w9uEYGHrSYUTRWHRcEa8l8cDLZPGIQ6eC7V6d2oWMVSrL/cXIShg9zVr5aCO643pqald
+        TnbH5CItnPyxSbfB63EJFvNIi7b7SCTP+LSAt0c95ZJy4bUyMG+C1ybfM97jcNXPkNelpcLrmu+A
+        TnwxSqjci5eXcjwlwDTxY6dWTm7u7t8peOYYM/EQhuTRNmGiglpX1Tn6ezg+v86H9PIv2MRKhiH/
+        A//OSBi5/haTh7CIDvwTsa4oUVYsFINvWQj/RLnNTxBYQkPuiEdutqOhgllyoFWxVw7Ox5vG43Tg
+        7GSYYKU8MbBCwL/D86JIYb/xTjqRFwVi+LXvwtVAYfglGlELDsNEVbDtKmA7xWcBALAYHmBZ46wJ
+        goIXMKP76yL0MdB1ULAtvdye2AJseOWvQSaG/DXPF60oNfC0abV1ZKhUQd59umHZjt5qT7xYEHXh
+        GMZQPdAuc3ecwqsibZy9fvChxxSP7a9XDwq6tfiFMFmU2csJ+Cy2OE55d8kUBfNptXqtaBktIhaM
+        97URvkLxXSNQYbli4yZcWcKWbrjjDUgF8pafHuBn7eD6+TMA5iaqlXnzcRs9LltnorLJpgi016rr
+        MIUFUxNqrdZO82biPBzF/5sb9Ci6q0vD1Yu7PA6D0SDR2QWXVX5YCjeMx6qYHAAs5dHYEx9vAGxh
+        zCAiCoA1b/fFXQr0UOAWfvRKeDy5I5I3Om8uA5AC2Nhigno3WE5xiGUM8C/tawzBtT89IXaE99KY
+        hWsYK5yGkHa2CVjNhq22MtnxlEsz5nNr4Mzidy8mySGeFDZ+S/yj0+ioTC60Vfn8YAwY3vuyB4OY
+        HRX+/e6FtZp9pmlnfy1xJj5mVLrG0wtt56pVqZY9Mgw9cqreaBbiyWYhpRJwC2Uh9EdVl8IVsEyC
+        fkfyuvKRnbdMUBS+Ymkuj8AqWK8b7XhHjVB+qSVCRRklg3MIieCBSoJ3sQ8wjwcLTwpUFbxXec0T
+        ohUVPigtUPhiB3ERK8Y1YhDC3eTTniprXrHrf6M4fJFPXK4A/Gj4F1IFf0CuHD+8kKVw+Vv5aFs5
+        4meE2sfV6NDB/3ozEUExZi6CkbhD7kOPy9bA8Fu1Y8viTxCW5+UCjyHXqxzTN21M1+kICDFKQGz3
+        9xW7FicejdCGaP/UPVRPFUNbBBML7MbW1/pmCxMsGsPo6fqZjyiy/sBN43MK+328H0IVgfKbo98P
+        h68qcpOoE+gp8OcJ/N3LjPde7HS97eVv5/nyiKgVS3YtvgF/e24sWoHomWmRBUaoRzPyPcYnwxIK
+        nKCWkT+Vkb5Tuv7bgQyAU54/XLy/7IV2FwAtE8yIVh40QHCu20ZPmXQlbARehsuJ9x+6mGEi/CLl
+        5tP1dX9fpoeaDGnUK1TD7Z/AhoEh07xVRCXH8Ez5wDzedqnev+55KYKRVYbOfSebOKq9UNuVJzbR
+        Hc0xx7AEIpgFgKu/H5ZeJUkkSGV+X4GyHWjiGtHLz+z0ou1pasqRiIXfJXsaAC1cwpjKBwCSJ1yN
+        EznPO5LPOOHwhHtnjUmmHZ684tgETBnvuCOTma4Te2E6RqseExwM3QTp2lf0DpiATUgskJUAyLAA
+        /Rt9N6gzDxVkxFBRHd8PhdHA8DivbOYogk2Uez+IUl6+9gBMrtzSknavQ/BxI2WCTuzCkTNfaFZb
+        ShtEW1h6b7S53BOJw39g7YYf7xw9veJJMBi+ekzB0m8khNajvJWDyp7uP8IRL78qPLUDEC41zwCT
+        nFVJKakyKbYWqjbK4a0q5Lin+TclfP6JblZv/pP7ESnrbP0jgyLbXXCQLXAvbh5gFD/EJhldqY0W
+        kI8J9mirFkIHS3U+VzV1oImp0CBxkpHg5Xje/kTTl7cklw/SzWOOiJF+I0XRck1ch2OthZNsicMs
+        MSZ0SUOgORoONxpuQp5/pcVoqe2FQwzbGCt0z8lMpHEQ7GBXjj85yU/vRAvfTh9apkZzykK1jqWW
+        PdTKEQbjO8nuS/mKvPz6msW5Zb8+xW9YUcg1nnfhZ5hc764+DufurKRlyI9TqSxVya0CJOCubw6h
+        hXEig77vlE22peIbtv+s8AnzdJJ8zOIzzUL2xXlM8/Kt35/Ns27rpUGi30fxBgwtz4qJXN6eJsoy
+        84PKx5zxu9f45NX15zvlpDg5FzPwPKYVZgRfsW20juluc1BOfnl+367ynKvENvXWR3VMsAYsU++u
+        qUkib0PJkp1VB5uoKr/bIfiR9KqPtBp+Yn/kH6aoaMZxjXuBMfWUYRVTQYWtVjI8kiJnkCcPeTuX
+        k6erT+/ySpvBTpK8zmmh2S1R6SzIYj7Hb8UOC8vUCybllP1Ns6C5TpArOyrW/XT1MCYCJyQ5L4wh
+        QZYnteWQG6Sg54tPE+il0LN1z/YC+1KgIHtdc5C5QUzHNFrGy0zTDDI3nb7y2pI48kz0jIqVkCri
+        JgTaXqEsx75MPYbecQ23cIyx77CfVzc8jN/LT1M+wt5iW5Mf6rYRYxPT7P3qUSXlaFrpwlv48kiu
+        wVy7kaOV59v3UsKhCTgONHy+eErxW6l3PTl3qECH7VUw+TFtL6i13SmUaJ0Hb9leeR9nYbL33a9t
+        O3VOHMt0Wl+unVkWsUzLGLVVsRolC5dTGGtqR9/XcN2xPKTP5+ZIUOr59nICjgvJV22BhVjjX5vi
+        CrT4iHPRzbDrSyVoBd55YINV6omxX7P8tBo/G94Fxbm0PATPbTpeMd+hXfFj23NV73JE4Lo98K0S
+        yamhO4lRW7hV5524PZqLu9PX+Bc1xNJky3U2taII3z26vPK7Hybr6pmmniG+ZwW+xXmyNJinHyZr
+        c62qD460IIcy4BFUErrnOSEMs0z9uyzojkRLOoGLWmLJIbYzVxetuBdYhZphm6N0y8XSVi6gJpz+
+        xoJmrqsjtdH17F8VxMI68PGDh54PEkP57Ac07D/kfGoJfP6CcMe2PMXF33JHNUxLhZMyuk2wsgDF
+        SLjOPcEixHH4E35fLo3ZFlt7xVgT+YJaT8xQttCqN2hNgKIibIn9niU8uJZSnpjJqzHlFFtAF6wD
+        5BUuqKhK4R5krU6lWCuQKvh6W1FbWd0rlr2hhIR/H8SXe1m7u0vZPYY3egFZKjKWRPoS7/GC3+jN
+        u4BxV7vsEFYsAn6AAIatVUWjv/WJn+Zu9kizG/G9QMwdbCgKTEKoKAauLTYgPDAOlXv78FpA9wAC
+        fjfvgMKvb7DTY5mPJF4vQgHi0ACWB3+w9VaH/jcttWlgO0Rz+hqvtvY/qhuqxWvgJE4teT6W0zRD
+        G+O0X2+O4CPE6a+YVY5duVijzTzvS1NJ/WnCFexgVbWMRVvxWmRhLrSBWikZA8QUgb0/SflWAPxn
+        CsLb/ZEybcp53i9PTwOQzhsuCQuGs0eFd7AaD9sDlYGkX2RRLW8FpTReL7RnV6cvzcEIdxMFvKuz
+        tViMEfhLmvrwZxIKflh04SjccGtgYVfM6iOtAW2k2OJXNGqxbjAS1QOAr1nvCcxkbT/TiK47pt5M
+        hDKwhranaQc3mrmNTSurqUeCpobv/sLCQx/LXKzehg/DXOhDNhYlYBliQsrUGsP/oAGb3T4/TrCq
+        2o8e1YaDS8FiDJ7GvJZFuiKFtnq7nEIm1kp3tsxj5no32UR7l8rT8WJeMPF3WVobr+kA50nM+D2N
+        06JIvT5M9eMUA0N5bAuqPsXTvfr77A+XwaJ5W8H2zvMUZE50XRWI2LyhabBiBeJioTmLMYP1gLOF
+        WdKqQZx63vbmSkRBdfD3f/7p//4fLS5fxk6bAAA=
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Age:
+      - '0'
+      Cache-Control:
+      - max-age=600
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '9833'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 22 Jun 2021 16:06:12 GMT
+      ETag:
+      - W/"608809fd-9b4e"
+      Last-Modified:
+      - Tue, 27 Apr 2021 12:56:29 GMT
+      Server:
+      - GitHub.com
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Fastly-Request-ID:
+      - 5a6411ffd6ce681b7740da5b2ac6971db40d9fbd
+      X-GitHub-Request-Id:
+      - A0C6:1177:3B4614:5659F3:60D1FDB1
+      X-Served-By:
+      - cache-chi21126-CHI
+      X-Timer:
+      - S1624377972.043842,VS0,VE24
+      expires:
+      - Tue, 22 Jun 2021 15:21:45 GMT
+      permissions-policy:
+      - interest-cohort=()
+      x-origin-cache:
+      - HIT
+      x-proxy-cache:
+      - MISS
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.18739%2FA2ND53%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
+  response:
+    body:
+      string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"doi:10.18739/A2ND53\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2ND53","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A2ND53"]}]}}
+
+        '
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type, Location, Content-Length, x-annotator-auth-token,
+        Cache-Control
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - ''
+      Access-Control-Expose-Headers:
+      - Content-Length, Content-Type, Location
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 16:06:12 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Server:
+      - Apache/2.4.48 (Ubuntu)
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.18739%2FA2ND53%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
+  response:
+    body:
+      string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"doi:10.18739/A2ND53\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":1,"start":0,"docs":[{"identifier":"doi:10.18739/A2ND53","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","resourceMap":["resource_map_doi:10.18739/A2ND53"]}]}}
+
+        '
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type, Location, Content-Length, x-annotator-auth-token,
+        Cache-Control
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - ''
+      Access-Control-Expose-Headers:
+      - Content-Length, Content-Type, Location
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 16:06:12 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Server:
+      - Apache/2.4.48 (Ubuntu)
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_doi%3A10.18739%2FA2ND53%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
+  response:
+    body:
+      string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A2ND53\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":3,"start":0,"docs":[{"identifier":"doi:10.18739/A2ND53","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":16006,"title":"Thaw
+        depth in the ITEX plots at Barrow and Atqasuk, Alaska","documents":["doi:10.18739/A2ND53","urn:uuid:dc29f3cf-022a-4a33-9eed-8dc9ba6e0218","urn:uuid:428fcb96-03a9-42b3-81d1-2944ac686e55"]},{"identifier":"urn:uuid:dc29f3cf-022a-4a33-9eed-8dc9ba6e0218","fileName":"2015_Barrow_Atqasuk_ITEX_Thaw_v1.csv","formatId":"text/csv","formatType":"DATA","size":7770},{"identifier":"urn:uuid:428fcb96-03a9-42b3-81d1-2944ac686e55","fileName":"1995-20XX_Barrow_Atqasuk_ITEX_Thaw_metadata-Copy.txt","formatId":"text/plain","formatType":"DATA","size":3971}]}}
+
+        '
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type, Location, Content-Length, x-annotator-auth-token,
+        Cache-Control
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - ''
+      Access-Control-Expose-Headers:
+      - Content-Length, Content-Type, Location
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 16:06:13 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Server:
+      - Apache/2.4.48 (Ubuntu)
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22http%3A%2F%2Fuse.yt%2Fupload%2F944d8537%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
+  response:
+    body:
+      string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"http://use.yt/upload/944d8537\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":0,"start":0,"docs":[]}}
+
+        '
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type, Location, Content-Length, x-annotator-auth-token,
+        Cache-Control
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - ''
+      Access-Control-Expose-Headers:
+      - Content-Length, Content-Type, Location
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 16:06:13 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Server:
+      - Apache/2.4.48 (Ubuntu)
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: HEAD
+    uri: http://use.yt/upload/944d8537
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Disposition:
+      - attachment; filename=nginx.tmpl
+      Content-Length:
+      - '8792'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Tue, 22 Jun 2021 16:06:14 GMT
+      Etag:
+      - '"da39a3ee5e6b4b0d3255bfef95601890afd80709"'
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - identity
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: HEAD
+    uri: http://use.yt/upload/944d8537
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Disposition:
+      - attachment; filename=nginx.tmpl
+      Content-Length:
+      - '8792'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Tue, 22 Jun 2021 16:06:14 GMT
+      Etag:
+      - '"da39a3ee5e6b4b0d3255bfef95601890afd80709"'
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://cn.dataone.org/cn/v2/query/solr/?q=resourceMap:%22resource_map_doi%3A10.18739%2FA2ND53%22&fl=identifier,formatType,title,size,formatId,fileName,documents&rows=1000&start=0&wt=json
+  response:
+    body:
+      string: '{"responseHeader":{"status":0,"QTime":4,"params":{"q":"resourceMap:\"resource_map_doi:10.18739/A2ND53\"","fl":"identifier,formatType,title,size,formatId,fileName,documents","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":3,"start":0,"docs":[{"identifier":"doi:10.18739/A2ND53","formatId":"eml://ecoinformatics.org/eml-2.1.1","formatType":"METADATA","size":16006,"title":"Thaw
+        depth in the ITEX plots at Barrow and Atqasuk, Alaska","documents":["doi:10.18739/A2ND53","urn:uuid:dc29f3cf-022a-4a33-9eed-8dc9ba6e0218","urn:uuid:428fcb96-03a9-42b3-81d1-2944ac686e55"]},{"identifier":"urn:uuid:dc29f3cf-022a-4a33-9eed-8dc9ba6e0218","fileName":"2015_Barrow_Atqasuk_ITEX_Thaw_v1.csv","formatId":"text/csv","formatType":"DATA","size":7770},{"identifier":"urn:uuid:428fcb96-03a9-42b3-81d1-2944ac686e55","fileName":"1995-20XX_Barrow_Atqasuk_ITEX_Thaw_metadata-Copy.txt","formatId":"text/plain","formatType":"DATA","size":3971}]}}
+
+        '
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type, Location, Content-Length, x-annotator-auth-token,
+        Cache-Control
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - ''
+      Access-Control-Expose-Headers:
+      - Content-Length, Content-Type, Location
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 16:06:14 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Server:
+      - Apache/2.4.48 (Ubuntu)
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - identity
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: HEAD
+    uri: http://use.yt/upload/944d8537
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Disposition:
+      - attachment; filename=nginx.tmpl
+      Content-Length:
+      - '8792'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Tue, 22 Jun 2021 16:06:15 GMT
+      Etag:
+      - '"da39a3ee5e6b4b0d3255bfef95601890afd80709"'
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/plugin_tests/data/dataverse_lookup.txt
+++ b/plugin_tests/data/dataverse_lookup.txt
@@ -2,336 +2,147 @@ interactions:
 - request:
     body: null
     headers:
-      Connection: [close]
-      Host: [doi.org]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: HEAD
     uri: https://doi.org/10.7910/DVN/RLMYMR
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      CF-RAY: [484f0a84e8c5ba18-ATL]
-      Connection: [close]
-      Content-Length: ['233']
-      Content-Type: [text/html;charset=utf-8]
-      Date: ['Thu, 06 Dec 2018 13:18:54 GMT']
-      Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-      Expires: ['Thu, 06 Dec 2018 13:30:16 GMT']
-      Location: ['https://dataverse.harvard.edu/citation?persistentId=doi:10.7910/DVN/RLMYMR']
-      Server: [cloudflare]
-      Set-Cookie: ['__cfduid=d55013335cbd7e4c34c8ebd48732d46441544102334; expires=Fri,
-          06-Dec-19 13:18:54 GMT; path=/; domain=.doi.org; HttpOnly']
-      Vary: [Accept]
-    status: {code: 302, message: ''}
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 66366f2fdfe22998-ORD
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '233'
+      Content-Type:
+      - text/html;charset=utf-8
+      Date:
+      - Tue, 22 Jun 2021 15:15:50 GMT
+      Expect-CT:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Expires:
+      - Tue, 22 Jun 2021 15:41:44 GMT
+      Location:
+      - https://dataverse.harvard.edu/citation?persistentId=doi:10.7910/DVN/RLMYMR
+      NEL:
+      - '{"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v2?s=RgqRfVn3Jm96RvhtmYOet5AgN2dK6jBG0%2Fv5M1b06tJ2zr5y0tNNOr4IRcKC3L9KHR%2FAKfQZPyWr6f58kv3bpgSEf2%2Bg4AiwUVC5Hfus%2FQwTLpKYrX6oS98ylsIj3QQu"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept
+      alt-svc:
+      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
+        ma=86400
+      cf-request-id:
+      - 0ad5e3d1eb000029985ca39000000001
+    status:
+      code: 302
+      message: ''
 - request:
     body: null
     headers:
-      Connection: [close]
-      Host: [dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: HEAD
     uri: https://dataverse.harvard.edu/citation?persistentId=doi:10.7910/DVN/RLMYMR
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      Cache-control: [no-cache="set-cookie"]
-      Connection: [Close]
-      Content-Language: [en-US]
-      Content-Type: [text/html;charset=ISO-8859-1]
-      Date: ['Thu, 06 Dec 2018 13:18:54 GMT']
-      Location: ['https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/RLMYMR']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3FE010BDBAE7AE7E438B31BFA0246B9F2DBD3EC37C4E69D8B958E3FBF8CF814030B5CB9749AB70FE33A8BB5BB36A149CB;PATH=/;MAX-AGE=28800]
-    status: {code: 302, message: Found}
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en-US
+      Content-Type:
+      - text/html;charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 15:15:50 GMT
+      Location:
+      - https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/RLMYMR
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=rF7sSsDyjwCKv6T6c2P0cUjDs40EVcsLog4Uch975RP08GURfxXbEMXmsypb2lNo75ZKCKrX6ymemoOzqOvLVeD5ZWXz3Bxq9mHe11tRmQHVJ22aAnKqQHOoztW+;
+        Expires=Tue, 29 Jun 2021 15:15:50 GMT; Path=/
+      - AWSALBCORS=rF7sSsDyjwCKv6T6c2P0cUjDs40EVcsLog4Uch975RP08GURfxXbEMXmsypb2lNo75ZKCKrX6ymemoOzqOvLVeD5ZWXz3Bxq9mHe11tRmQHVJ22aAnKqQHOoztW+;
+        Expires=Tue, 29 Jun 2021 15:15:50 GMT; Path=/; SameSite=None; Secure
+    status:
+      code: 302
+      message: Found
 - request:
     body: null
     headers:
-      Connection: [close]
-      Host: [dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - AWSALB=rF7sSsDyjwCKv6T6c2P0cUjDs40EVcsLog4Uch975RP08GURfxXbEMXmsypb2lNo75ZKCKrX6ymemoOzqOvLVeD5ZWXz3Bxq9mHe11tRmQHVJ22aAnKqQHOoztW+;
+        AWSALBCORS=rF7sSsDyjwCKv6T6c2P0cUjDs40EVcsLog4Uch975RP08GURfxXbEMXmsypb2lNo75ZKCKrX6ymemoOzqOvLVeD5ZWXz3Bxq9mHe11tRmQHVJ22aAnKqQHOoztW+
+      User-Agent:
+      - python-requests/2.25.1
     method: HEAD
     uri: https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/RLMYMR
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      Cache-control: [no-cache="set-cookie"]
-      Connection: [Close]
-      Content-Type: [text/html;charset=UTF-8]
-      Date: ['Thu, 06 Dec 2018 13:18:54 GMT']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [JSESSIONID=3abd12a238aa89fa605dc9730444; Path=/; Secure; HttpOnly,
-        AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3CF6A1B0A2CD5F2F144400DE0E06A10F0DBD3EC37C4E69D8B958E3FBF8CF81403222DF6AABE0F6509EF79AB1D548B7265;PATH=/;MAX-AGE=28800]
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html;charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 15:15:52 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=y/5TABb3Qjcntg4XaBIdQVf0Jf3z69ZgnsJFZEszEBFh6nBvZipn5RsXDqoef+Ikoa6s2AFyf6gs9Os3C+fKfmiv6UNSmC9GKPETN+To6WotfF1PejCHQ2f6UnJl;
+        Expires=Tue, 29 Jun 2021 15:15:50 GMT; Path=/
+      - AWSALBCORS=y/5TABb3Qjcntg4XaBIdQVf0Jf3z69ZgnsJFZEszEBFh6nBvZipn5RsXDqoef+Ikoa6s2AFyf6gs9Os3C+fKfmiv6UNSmC9GKPETN+To6WotfF1PejCHQ2f6UnJl;
+        Expires=Tue, 29 Jun 2021 15:15:50 GMT; Path=/; SameSite=None; Secure
+      - JSESSIONID=44abb5d1589b78a282c3e98c797f; Path=/; Secure; HttpOnly
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.19.1]
-    method: GET
-    uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.7910%2FDVN%2FRLMYMR%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
-  response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"doi:10.7910/DVN/RLMYMR\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":0,"start":0,"docs":[]}}
-
-'}
-    headers:
-      Access-Control-Allow-Credentials: ['true']
-      Access-Control-Allow-Headers: ['Authorization, Content-Type, Location, Content-Length,
-          x-annotator-auth-token']
-      Access-Control-Allow-Methods: ['POST, GET, OPTIONS, PUT, DELETE']
-      Access-Control-Allow-Origin: ['']
-      Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=UTF-8]
-      Date: ['Thu, 06 Dec 2018 13:18:56 GMT']
-      Keep-Alive: ['timeout=5, max=100']
-      Server: [Apache/2.4.7 (Ubuntu)]
-      Transfer-Encoding: [chunked]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Connection: [close]
-      Host: [services.dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
-    method: GET
-    uri: https://services.dataverse.harvard.edu/miniverse/map/installations-json
-  response:
-    body: {string: '{"installations": [{"id": 1740, "name": "Abacus", "full_name":
-        "Abacus (British Columbia Research Libraries'' Data Services) Dataverse",
-        "is_active": true, "description": "Open for researchers associated with British
-        Columbia universities to deposit data.", "lat": 49.259982, "lng": -123.250212,
-        "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/abacus-46x46.jpg",
-        "url": "https://dvn.library.ubc.ca/dvn/", "slug": "abacus", "version": "3.6"},
-        {"id": 1771, "name": "ADA Dataverse", "full_name": "Australian Data Archive",
-        "is_active": true, "description": "The Australian Data Archive provides a
-        national service for collecting, preserving, publishing and accessing digital
-        research data.", "lat": -35.343784, "lng": 149.082977, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/ada-46x46.jpg",
-        "url": "https://dataverse.ada.edu.au/", "slug": "ada-dataverse", "version":
-        "4.6.1"}, {"id": 1773, "name": "AUSSDA Dataverse", "full_name": "Austrian
-        Social Science Data Archive", "is_active": true, "description": "AUSSDA -
-        The Austrian Social Science Data Archive makes social science data accessible,
-        creating opportunities for research and data reuse, benefitting science and
-        society. AUSSDA serves as the Austrian representative in the Consortium of
-        European Social Science Data Archives (CESSDA ERIC).", "lat": 48.210033, "lng":
-        16.363449, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/aussda-46x46.png",
-        "url": "https://data.aussda.at/", "slug": "aussda-dataverse", "version": "4.6.2"},
-        {"id": 1759, "name": "Catalogues (CDSP)", "full_name": "Catalogues (CDSP)",
-        "is_active": true, "description": "Open for researchers and organizations
-        associated with\r\nFrench universities to deposit data. Hosted by the Center
-        for\r\nSocio-Political Data (Sciences Po and CNRS).", "lat": 48.854027, "lng":
-        2.328351, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/catalogues-46x46.png",
-        "url": "https://catalogues.cdsp.sciences-po.fr/", "slug": "catalogues-cdsp",
-        "version": "4.6.1"}, {"id": 1763, "name": "CIFOR", "full_name": "Center for
-        International Forestry Research (CIFOR) Dataverse", "is_active": true, "description":
-        "Center for International Forestry Research (CIFOR) Dataverse", "lat": -6.594293,
-        "lng": 106.806000, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/CIFOR-46x46.png",
-        "url": "https://data.cifor.org/dataverse/s", "slug": "cifor", "version": "4.6"},
-        {"id": 1741, "name": "CIMMYT", "full_name": "CIMMYT Dataverse", "is_active":
-        true, "description": "Free, open access repository of research data and software
-        produced and developed by CIMMYT scientists.", "lat": 19.531535, "lng": -98.846064,
-        "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/cimmyt-46x46.jpg",
-        "url": "http://data.cimmyt.org/", "slug": "cimmyt", "version": "3.0"}, {"id":
-        1764, "name": "CIRAD", "full_name": "CIRAD Dataverse", "is_active": true,
-        "description": "Organisme fran\u00e7ais de recherche agronomique et de coop\u00e9ration
-        internationale pour le d\u00e9veloppement durable des r\u00e9gions tropicales
-        et m\u00e9diterran\u00e9ennes, les activit\u00e9s du CIRAD rel\u00e8vent des
-        sciences du vivant, des sciences sociales et des sciences de l\u2019ing\u00e9nieur
-        appliqu\u00e9es \u00e0 l\u2019agriculture, \u00e0 l\u2019alimentation, \u00e0
-        l\u2019environnement et \u00e0 la gestion des territoires.\r\n\r\nFrench agricultural
-        research and international cooperation organization working for the sustainable
-        development of tropical and Mediterranean regions, CIRAD''s activities concern
-        the life sciences, social sciences and engineering sciences, applied to agriculture,
-        the environment and territorial management.", "lat": 43.650089, "lng": 3.869122,
-        "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/cirad-46x46.jpg",
-        "url": "https://dataverse.cirad.fr/", "slug": "cirad", "version": "4.5"},
-        {"id": 1774, "name": "Dalhousie University Dataverse", "full_name": "Dalhousie
-        University", "is_active": true, "description": "Share, publish and get credit
-        for your data. Find and cite research data from across all research fields.",
-        "lat": 44.637484, "lng": -63.591220, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/dalhousie-46x46.png",
-        "url": "https://dataverse.library.dal.ca", "slug": "dalhousie-university-dataverse",
-        "version": "4.7"}, {"id": 1777, "name": "Data Inra", "full_name": "National
-        Institute of Agricultural Research (INRA)", "is_active": true, "description":
-        "INRA is Europe\u2019s top agricultural research institute and the world\u2019s
-        number two centre for the agricultural sciences. Data Inra is offered by INRA
-        as part of its mission to open the results of its research.\r\n\r\nData Inra
-        will share research data in relation with food, nutrition, agriculture and
-        environment. It includes experimental, simulation and observation data, omic
-        data, survey and text data.\r\n\r\nOnly data produced by or in collaboration
-        with INRA will be hosted in the repository, but anyone can access the metadata
-        and the open data.", "lat": 48.801407, "lng": 2.130122, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/inra-46x46-2.jpg",
-        "url": "https://data.inra.fr/", "slug": "data-inra", "version": "4.8.6"},
-        {"id": 1743, "name": "DataSpace@HKUST", "full_name": "DataSpace@HKUST", "is_active":
-        true, "description": "", "lat": 22.336281, "lng": 114.266721, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/dataspace-46x46.jpg",
-        "url": "https://dataspace.ust.hk/", "slug": "dataspacehkust", "version": "4.2"},
-        {"id": 1762, "name": "Dataverse e-cienciaDatos", "full_name": "Dataverse e-cienciaDatos",
-        "is_active": true, "description": "Repositorio de Datos del Consorcio Madro\u00f1o.",
-        "lat": 40.416775, "lng": -3.749200, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/consorciomadrono-46x46.gif",
-        "url": "https://edatos.consorciomadrono.es/", "slug": "dataverse-e-cienciadatos",
-        "version": "4.9.2"}, {"id": 1742, "name": "DataverseNL", "full_name": "DataverseNL",
-        "is_active": true, "description": "Open for researchers and organizations
-        associated with Dutch universities to deposit data.", "lat": 52.547260, "lng":
-        5.242346, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/logosdataverseNL-46x46.png",
-        "url": "https://dataverse.nl/", "slug": "dataversenl", "version": "4.6.1"},
-        {"id": 1767, "name": "DataverseNO", "full_name": "Dataverse Network Norway",
-        "is_active": true, "description": "Research data archive open for Norwegian
-        research institutions. Operated by UiT The Arctic University of Norway.",
-        "lat": 69.649208, "lng": 18.955324, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/dataverseNO-46x46.png",
-        "url": "https://dataverse.no/", "slug": "dataverseno", "version": "4.7.1"},
-        {"id": 1768, "name": "DR-NTU (Data)", "full_name": "Nanyang Technological
-        University", "is_active": true, "description": "The institutional open access
-        research data repository for Nanyang Technological University (NTU). NTU researchers
-        are encouraged to use DR-NTU (Data) to deposit, publish and archive their
-        final research data in order to make their research data discoverable, accessible
-        and reusable.", "lat": 1.348668, "lng": 103.683104, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/NTULogo_2.gif",
-        "url": "https://researchdata.ntu.edu.sg", "slug": "dr-ntu-data", "version":
-        "4.7.1"}, {"id": 1744, "name": "Fudan University", "full_name": "Fudan University
-        Dataverse", "is_active": true, "description": "Open for Fudan University affiliated
-        researchers to deposit data.", "lat": 31.298531, "lng": 121.501446, "logo":
-        "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/fudan-46x46.png", "url":
-        "http://dvn.fudan.edu.cn/home/", "slug": "fudan-university", "version": "4.x"},
-        {"id": 1745, "name": "Harvard University", "full_name": "Harvard University",
-        "is_active": true, "description": "Share, archive, and get credit for your
-        data. Find and cite data across all research fields.", "lat": 42.380098, "lng":
-        -71.116629, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/harvard-46x46.png",
-        "url": "https://dataverse.harvard.edu", "slug": "harvard-university", "version":
-        "4.8.4"}, {"id": 1746, "name": "HeiDATA", "full_name": "Heidelberg University",
-        "is_active": true, "description": "Open for Heidelberg University affiliated
-        researchers to deposit data.", "lat": 49.398750, "lng": 8.672434, "logo":
-        "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/heidelberg-46x46.jpg",
-        "url": "https://heidata.uni-heidelberg.de/", "slug": "heidata", "version":
-        "4.8.2"}, {"id": 1747, "name": "IBICT", "full_name": "IBICT (Brazil)", "is_active":
-        true, "description": "The network Cariniana, cariniana.ibict.br,  is funded
-        entirely by the Brazilian government and in particular by MCTI (Minist\u00e9rio
-        da Ci\u00eancia, Tecnologia e Inova\u00e7\u00e3o). It is a project for long-term
-        preservation of scientific publications in Brazil.", "lat": -15.805842, "lng":
-        -47.881369, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/ibict-46x46.jpg",
-        "url": "https://repositoriopesquisas.ibict.br/", "slug": "ibict", "version":
-        "4.5.1"}, {"id": 1757, "name": "ICRISAT", "full_name": "ICRISAT", "is_active":
-        true, "description": "International Crops Research Institute for the Semi-Arid
-        Tropics.  Free open data repository of ICRISAT research data including Social
-        science, Phenotypic, Genotypic, Spatial and Soil & Weather data which are
-        linked with open publications.", "lat": 17.385000, "lng": 78.486700, "logo":
-        "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/icrisat-46x46.png", "url":
-        "http://dataverse.icrisat.org/", "slug": "icrisat", "version": "4.8.1"}, {"id":
-        1748, "name": "IISH Dataverse", "full_name": "International Institute of Social
-        History", "is_active": true, "description": "The IISH Dataverse contains micro-,
-        meso-, and macro-level datasets on social and economic history.", "lat": 52.369021,
-        "lng": 4.939226, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/internationalInstituteOfSocialHistory-46x46.jpg",
-        "url": "https://datasets.socialhistory.org/", "slug": "iish-dataverse", "version":
-        "4.3"}, {"id": 1749, "name": "Johns Hopkins University", "full_name": "Johns
-        Hopkins", "is_active": true, "description": "Johns Hopkins University Data
-        Archive", "lat": 39.329055, "lng": -76.620335, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/johns-46x46.jpg",
-        "url": "https://archive.data.jhu.edu/", "slug": "johns-hopkins-university",
-        "version": "4.6"}, {"id": 1750, "name": "Libra Data", "full_name": "Libra
-        Data (University of Virginia)", "is_active": true, "description": "Libra Data
-        is a place for UVA researchers to share data publicly, and is part of the
-        Libra Scholarly Repository suite of services which includes works of UVA scholarship
-        such as articles, books, theses, and data.", "lat": 38.034578, "lng": -78.507394,
-        "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/libra-46x46.jpg",
-        "url": "https://dataverse.lib.virginia.edu/", "slug": "libra-data", "version":
-        "4.7.1"}, {"id": 1776, "name": "LIPI Dataverse", "full_name": "Lembaga Ilmu
-        Pengetahuan Indonesia (LIPI) Dataverse", "is_active": true, "description":
-        "The Repositori Ilmiah Nasional (RIN) is a means to share, preserve, cite,
-        explore, and analyze research data. RIN increases data availability and allows
-        others to reproduce research more easily. Researchers, data authors, publishers,
-        data distributors, and affiliate institutions all receive academic credit
-        and web visibility. Researchers, agencies, and funders have full control over
-        research data.", "lat": -6.228771, "lng": 106.818082, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/LIPI-46x46.png",
-        "url": "https://rin.lipi.go.id", "slug": "lipi-dataverse", "version": "4.6.2"},
-        {"id": 1756, "name": "Maine Dataverse Network", "full_name": "Maine Dataverse
-        Network", "is_active": true, "description": "A service brought to you by the
-        ACG@UMaine. The way Supercomputing should be!", "lat": 44.901349, "lng": -68.671815,
-        "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/uOfMaine-46x46.jpg",
-        "url": "http://dataverse.acg.maine.edu/dvn/", "slug": "maine-dataverse-network",
-        "version": "3.5.1"}, {"id": 1752, "name": "Peking University", "full_name":
-        "Peking University", "is_active": true, "description": "Peking University
-        Open Research Data Platform", "lat": 39.993923, "lng": 116.306539, "logo":
-        "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/peking-46x46.jpg", "url":
-        "http://opendata.pku.edu.cn/", "slug": "peking-university", "version": "4.0"},
-        {"id": 1778, "name": "Qualitative Data Repository", "full_name": "Center for
-        Qualitative and Multi-Method Inquiry", "is_active": true, "description": "QDR
-        curates, stores, preserves, publishes, and enables the download of digital
-        data generated through qualitative and multi-method research in the social
-        sciences. The repository develops and disseminates guidance for managing,
-        sharing, citing, and reusing qualitative data, and contributes to the generation
-        of common standards for doing so. QDR\u2019s overarching goals are to make
-        sharing qualitative data customary in the social sciences, to broaden access
-        to social science data, and to strengthen qualitative and multi-method research.",
-        "lat": 43.038126, "lng": -76.135584, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/qdr-46x46_OwmJ6dD.png",
-        "url": "https://data.qdr.syr.edu/", "slug": "qualitative-data-repository",
-        "version": "4.9.1"}, {"id": 1779, "name": "Reposit\u00f3rio de Dados de Pesquisa
-        da UFABC", "full_name": "Universidade Federal do ABC", "is_active": true,
-        "description": "Este \u00e9 o Reposit\u00f3rio de Dados de Pesquisa da Universidade
-        Federal do ABC", "lat": -23.678437, "lng": -46.563667, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/ufabc-46x46.png",
-        "url": "http://dataverse.ufabc.edu.br/", "slug": "repositorio-de-dados-de-pesquisa-da-ufabc",
-        "version": "8.4.5"}, {"id": 1758, "name": "Scholars Portal", "full_name":
-        "Scholars Portal Dataverse", "is_active": true, "description": "Open for researchers
-        and organizations associated with Ontario universities to deposit data.",
-        "lat": 43.653200, "lng": -79.383200, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/scholarsportal-46x46.jpg",
-        "url": "https://dataverse.scholarsportal.info/", "slug": "scholars-portal",
-        "version": "4.7.1"}, {"id": 1761, "name": "Texas Data Repository Dataverse",
-        "full_name": "Texas Data Repository Dataverse", "is_active": true, "description":
-        "A statewide archive of research data from Texas Digital Library (TDL) member
-        institutions.", "lat": 30.307182, "lng": -97.755996, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/tdl-46x46.png",
-        "url": "https://dataverse.tdl.org/", "slug": "texas-data-repository-dataverse",
-        "version": "4.7.1"}, {"id": 1755, "name": "UAL Dataverse", "full_name": "University
-        of Alberta Libraries Dataverse", "is_active": true, "description": "Open for
-        University of Alberta affiliated researchers to deposit data.", "lat": 53.494321,
-        "lng": -113.549027, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/uOfAlberta-46x46.jpg",
-        "url": "https://dataverse.library.ualberta.ca/dvn/", "slug": "ual-dataverse",
-        "version": "4.9.1"}, {"id": 1772, "name": "UNB Libraries Dataverse", "full_name":
-        "University of New Brunswick Libraries", "is_active": true, "description":
-        "UNB Dataverse is repository for research data collected by researchers and
-        organizations primarily affiliated with the University of New Brunswick.",
-        "lat": 45.964993, "lng": -66.646332, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/unbDataverse-46x46.png",
-        "url": "https://dataverse.lib.unb.ca/", "slug": "unb-libraries-dataverse",
-        "version": "4.8.2"}, {"id": 1751, "name": "UNC Dataverse", "full_name": "Odum
-        Institute for Research in Social Science", "is_active": true, "description":
-        "Open for all researchers worldwide from all disciplines to deposit data.
-        The Odum Institute also offers multiple data curation service levels. For
-        more information, go to http://www.irss.unc.edu/odum/contentPrimary.jsp?nodeid=5.",
-        "lat": 35.905022, "lng": -79.050851, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/unc-46x46.png",
-        "url": "https://dataverse.unc.edu/", "slug": "unc-dataverse", "version": "4.7.1"},
-        {"id": 1765, "name": "University of Manitoba Dataverse", "full_name": "University
-        of Manitoba Dataverse", "is_active": true, "description": "", "lat": 49.895077,
-        "lng": -97.138451, "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/manitoba-46x46.jpg",
-        "url": "https://dataverse.lib.umanitoba.ca/", "slug": "university-of-manitoba-dataverse",
-        "version": "4.8.4"}, {"id": 1775, "name": "UWI", "full_name": "The University
-        of the West Indies", "is_active": true, "description": "The University of
-        the West Indies Research Datasets Repository.", "lat": 18.006372, "lng": -76.747148,
-        "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/uwi-46x46.png",
-        "url": "http://dataverse.sta.uwi.edu/", "slug": "uwi", "version": "4.8.4"},
-        {"id": 1780, "name": "VTTI", "full_name": "Virginia Tech Transportation Institute",
-        "is_active": true, "description": "Transportation data repository maintained
-        by the Virginia Tech Transportation Institute", "lat": 37.189958, "lng": -80.396694,
-        "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/vtti-46x46.png",
-        "url": "https://dataverse.vtti.vt.edu/", "slug": "vtti", "version": "4.9.4"}]}'}
-    headers:
-      Cache-Control: [max-age=7200]
-      Connection: [Close]
-      Content-Length: ['17374']
-      Content-Type: [application/json]
-      Date: ['Thu, 06 Dec 2018 13:18:57 GMT']
-      Expires: ['Thu, 06 Dec 2018 14:05:58 GMT']
-      Last-Modified: ['Thu, 06 Dec 2018 12:05:58 GMT']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips mod_wsgi/3.4
-          Python/2.7.5]
-      X-Frame-Options: [SAMEORIGIN]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Connection: [close]
-      Host: [dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: GET
     uri: https://dataverse.harvard.edu/api/datasets/:persistentId?persistentId=doi:10.7910/DVN/RLMYMR
   response:
-    body: {string: '{"status":"OK","data":{"id":2966297,"identifier":"DVN/RLMYMR","persistentUrl":"https://doi.org/10.7910/DVN/RLMYMR","protocol":"doi","authority":"10.7910","publisher":"Harvard
-        Dataverse","publicationDate":"2016-12-20","storageIdentifier":"s3://10.7910/DVN/RLMYMR","latestVersion":{"id":147203,"storageIdentifier":"s3://10.7910/DVN/RLMYMR","versionNumber":2,"versionMinorNumber":0,"versionState":"RELEASED","productionDate":"Production
-        Date","UNF":"UNF:6:wBvSbRl2RTVRfu9kpjgnrw==","lastUpdateTime":"2018-11-15T16:04:00Z","releaseTime":"2018-11-15T16:04:00Z","createTime":"2018-11-15T16:00:10Z","license":"NONE","termsOfUse":"Attribution
+    body:
+      string: '{"status":"OK","data":{"id":2966297,"identifier":"DVN/RLMYMR","persistentUrl":"https://doi.org/10.7910/DVN/RLMYMR","protocol":"doi","authority":"10.7910","publisher":"Harvard
+        Dataverse","publicationDate":"2016-12-20","storageIdentifier":"s3://10.7910/DVN/RLMYMR","latestVersion":{"id":147203,"datasetId":2966297,"datasetPersistentId":"doi:10.7910/DVN/RLMYMR","storageIdentifier":"s3://10.7910/DVN/RLMYMR","versionNumber":2,"versionMinorNumber":0,"versionState":"RELEASED","UNF":"UNF:6:wBvSbRl2RTVRfu9kpjgnrw==","lastUpdateTime":"2018-11-15T16:04:00Z","releaseTime":"2018-11-15T16:04:00Z","createTime":"2018-11-15T16:00:10Z","license":"NONE","termsOfUse":"Attribution
         is required","disclaimer":"These datasets are provided \"as is\" and in no
         event shall Bioversity International be liable for any damages resulting from
         use of the data. While great effort was taken to obtain high quality data,
@@ -341,7 +152,8 @@ interactions:
         all information which would allow individuals to be identified has been deleted
         from the files. For some of the datasets, the user will need to take care
         in handling missing observations, outlier values and violations of logical
-        consistency. ","metadataBlocks":{"citation":{"displayName":"Citation Metadata","fields":[{"typeName":"title","multiple":false,"typeClass":"primitive","value":"Karnataka
+        consistency. ","fileAccessRequest":false,"metadataBlocks":{"citation":{"displayName":"Citation
+        Metadata","fields":[{"typeName":"title","multiple":false,"typeClass":"primitive","value":"Karnataka
         Diet Diversity and Food Security for Agricultural Biodiversity Assessment"},{"typeName":"author","multiple":true,"typeClass":"compound","value":[{"authorName":{"typeName":"authorName","multiple":false,"typeClass":"primitive","value":"Ntandou-Bouzitou,
         G.D."},"authorAffiliation":{"typeName":"authorAffiliation","multiple":false,"typeClass":"primitive","value":"Bioversity
         International"}},{"authorName":{"typeName":"authorName","multiple":false,"typeClass":"primitive","value":"Kennedy,
@@ -374,8 +186,8 @@ interactions:
         of  August and 30 September 2014 (2 cases 30, 31 of October). For the household
         food security data refer to the previous 30 days of the day of the interview.
         For the infant and child feeding practices, they are in general.\r\nThree
-        villages in the Bijapur District: Mannur, Nandyal, Balaganur were surveyed."}}]},{"typeName":"subject","multiple":true,"typeClass":"controlledVocabulary","value":["Social
-        Sciences","Agricultural Sciences"]},{"typeName":"keyword","multiple":true,"typeClass":"compound","value":[{"keywordValue":{"typeName":"keywordValue","multiple":false,"typeClass":"primitive","value":"DIET"}},{"keywordValue":{"typeName":"keywordValue","multiple":false,"typeClass":"primitive","value":"DIVERSIFICATION"}},{"keywordValue":{"typeName":"keywordValue","multiple":false,"typeClass":"primitive","value":"FOOD
+        villages in the Bijapur District: Mannur, Nandyal, Balaganur were surveyed."}}]},{"typeName":"subject","multiple":true,"typeClass":"controlledVocabulary","value":["Agricultural
+        Sciences","Social Sciences"]},{"typeName":"keyword","multiple":true,"typeClass":"compound","value":[{"keywordValue":{"typeName":"keywordValue","multiple":false,"typeClass":"primitive","value":"DIET"}},{"keywordValue":{"typeName":"keywordValue","multiple":false,"typeClass":"primitive","value":"DIVERSIFICATION"}},{"keywordValue":{"typeName":"keywordValue","multiple":false,"typeClass":"primitive","value":"FOOD
         SECURITY"}},{"keywordValue":{"typeName":"keywordValue","multiple":false,"typeClass":"primitive","value":"FEEDING
         HABITS"}},{"keywordValue":{"typeName":"keywordValue","multiple":false,"typeClass":"primitive","value":"HOUSEHOLDS"}},{"keywordValue":{"typeName":"keywordValue","multiple":false,"typeClass":"primitive","value":"CHILDREN"}}]},{"typeName":"topicClassification","multiple":true,"typeClass":"compound","value":[{"topicClassValue":{"typeName":"topicClassValue","multiple":false,"typeClass":"primitive","value":"SURVEYS"},"topicClassVocab":{"typeName":"topicClassVocab","multiple":false,"typeClass":"primitive","value":"AGROVOC"},"topicClassVocabURI":{"typeName":"topicClassVocabURI","multiple":false,"typeClass":"primitive","value":"http://aims.fao.org/aos/agrovoc/c_7537"}}]},{"typeName":"language","multiple":true,"typeClass":"controlledVocabulary","value":["English"]},{"typeName":"distributor","multiple":true,"typeClass":"compound","value":[{"distributorName":{"typeName":"distributorName","multiple":false,"typeClass":"primitive","value":"Bioversity
         International"},"distributorURL":{"typeName":"distributorURL","multiple":false,"typeClass":"primitive","value":"http://www.bioversityinternational.org/"}}]},{"typeName":"depositor","multiple":false,"typeClass":"primitive","value":"Bioversity
@@ -384,262 +196,310 @@ interactions:
         1.1: CGIAR Research Program on Dryland Agricultural Production Systems"]}]},"geospatial":{"displayName":"Geospatial
         Metadata","fields":[{"typeName":"geographicCoverage","multiple":true,"typeClass":"compound","value":[{"country":{"typeName":"country","multiple":false,"typeClass":"controlledVocabulary","value":"India"},"state":{"typeName":"state","multiple":false,"typeClass":"primitive","value":"Karnataka"},"otherGeographicCoverage":{"typeName":"otherGeographicCoverage","multiple":false,"typeClass":"primitive","value":"Bijapur
         District"}}]}]}},"files":[{"description":"Data","label":"Karnataka_DD&FS_Data-1.tab","restricted":false,"version":2,"datasetVersionId":147203,"dataFile":{"id":3315157,"persistentId":"doi:10.7910/DVN/RLMYMR/WNKD3W","pidURL":"https://doi.org/10.7910/DVN/RLMYMR/WNKD3W","filename":"Karnataka_DD&FS_Data-1.tab","contentType":"text/tab-separated-values","filesize":2321,"description":"Data","storageIdentifier":"s3://dvn-cloud:167181b3a0e-b7e18f26cfad","originalFileFormat":"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet","originalFormatLabel":"MS
-        Excel (XLSX)","UNF":"UNF:6:wBvSbRl2RTVRfu9kpjgnrw==","rootDataFileId":2966302,"previousDataFileId":2966302,"md5":"ca9dea905295ac52db4ea3c7c8bf00e9","checksum":{"type":"MD5","value":"ca9dea905295ac52db4ea3c7c8bf00e9"}}},{"label":"Karnataka_DD&FS_Questionnaire.pdf","restricted":false,"version":1,"datasetVersionId":147203,"dataFile":{"id":2966301,"persistentId":"doi:10.7910/DVN/RLMYMR/UKYKS9","pidURL":"https://doi.org/10.7910/DVN/RLMYMR/UKYKS9","filename":"Karnataka_DD&FS_Questionnaire.pdf","contentType":"application/pdf","filesize":493564,"storageIdentifier":"s3://dvn-cloud:1591ccfc017-1eeea525e902","originalFormatLabel":"UNKNOWN","rootDataFileId":-1,"md5":"d9de390c8f132916b4bb97d6ea0c8ed6","checksum":{"type":"MD5","value":"d9de390c8f132916b4bb97d6ea0c8ed6"}}}]}}}'}
+        Excel Spreadsheet","originalFileSize":700840,"originalFileName":"Karnataka_DD&FS_Data-1.xlsx","UNF":"UNF:6:wBvSbRl2RTVRfu9kpjgnrw==","rootDataFileId":2966302,"previousDataFileId":2966302,"md5":"ca9dea905295ac52db4ea3c7c8bf00e9","checksum":{"type":"MD5","value":"ca9dea905295ac52db4ea3c7c8bf00e9"},"creationDate":"2018-11-15"}},{"label":"Karnataka_DD&FS_Questionnaire.pdf","restricted":false,"version":1,"datasetVersionId":147203,"dataFile":{"id":2966301,"persistentId":"doi:10.7910/DVN/RLMYMR/UKYKS9","pidURL":"https://doi.org/10.7910/DVN/RLMYMR/UKYKS9","filename":"Karnataka_DD&FS_Questionnaire.pdf","contentType":"application/pdf","filesize":493564,"storageIdentifier":"s3://dvn-cloud:1591ccfc017-1eeea525e902","rootDataFileId":-1,"md5":"d9de390c8f132916b4bb97d6ea0c8ed6","checksum":{"type":"MD5","value":"d9de390c8f132916b4bb97d6ea0c8ed6"},"creationDate":"2016-12-20"}}]}}}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-control: [no-cache="set-cookie"]
-      Connection: [Close]
-      Content-Type: [application/json]
-      Date: ['Thu, 06 Dec 2018 13:18:57 GMT']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3FE010BDBAE7AE7E438B31BFA0246B9F2DBD3EC37C4E69D8B958E3FBF8CF814030B5CB9749AB70FE33A8BB5BB36A149CB;PATH=/;MAX-AGE=28800]
-      transfer-encoding: [chunked]
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Headers:
+      - Accept, Content-Type, X-Dataverse-Key
+      Access-Control-Allow-Methods:
+      - PUT, GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 15:15:53 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=kGUimUn2frrMHIwBEbeE8s9m6/1BlBqZ/oOmr9EmVr4Bqb/oRPrtlBk82QbZU5FTizLc9L6GX/9Kl2Cyc3FTIpi2QN2h1esCUhAEfR2veYJ2TaQU2TZ6mAFgViih;
+        Expires=Tue, 29 Jun 2021 15:15:52 GMT; Path=/
+      - AWSALBCORS=kGUimUn2frrMHIwBEbeE8s9m6/1BlBqZ/oOmr9EmVr4Bqb/oRPrtlBk82QbZU5FTizLc9L6GX/9Kl2Cyc3FTIpi2QN2h1esCUhAEfR2veYJ2TaQU2TZ6mAFgViih;
+        Expires=Tue, 29 Jun 2021 15:15:52 GMT; Path=/; SameSite=None; Secure
+      - JSESSIONID=44ac3ebe92b5f7dade2d22f43d0e; Path=/; Secure; HttpOnly
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Connection: [close]
-      Host: [doi.org]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: HEAD
     uri: https://doi.org/10.7910/DVN/RLMYMR/WNKD3W
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      CF-RAY: [484f0a9f2fb3b9b8-ATL]
-      Connection: [close]
-      Content-Length: ['251']
-      Content-Type: [text/html;charset=utf-8]
-      Date: ['Thu, 06 Dec 2018 13:18:58 GMT']
-      Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-      Expires: ['Thu, 06 Dec 2018 14:02:04 GMT']
-      Location: ['https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/RLMYMR/WNKD3W']
-      Server: [cloudflare]
-      Set-Cookie: ['__cfduid=d8bcd75b1098913be4b02225d908069181544102338; expires=Fri,
-          06-Dec-19 13:18:58 GMT; path=/; domain=.doi.org; HttpOnly']
-      Vary: [Accept]
-    status: {code: 302, message: ''}
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 66366f42c9862c4c-ORD
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '251'
+      Content-Type:
+      - text/html;charset=utf-8
+      Date:
+      - Tue, 22 Jun 2021 15:15:53 GMT
+      Expect-CT:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Expires:
+      - Tue, 22 Jun 2021 15:26:15 GMT
+      Location:
+      - https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/RLMYMR/WNKD3W
+      NEL:
+      - '{"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v2?s=DJuarYzle%2Bxko1RrBE2I%2B1RGxVC4efO15UrlDwrbkZKI9JPUudOMxM9miqPdsid5L3xLmoSGWW9BUwy3rmlE8CfJtdXm7jjR9JOO9MsVXzst1GctOe6wQG895QrLJPfq"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept
+      alt-svc:
+      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
+        ma=86400
+      cf-request-id:
+      - 0ad5e3ddc200002c4c2e23b000000001
+    status:
+      code: 302
+      message: ''
 - request:
     body: null
     headers:
-      Connection: [close]
-      Host: [dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: HEAD
     uri: https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/RLMYMR/WNKD3W
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      Cache-control: [no-cache="set-cookie"]
-      Connection: [Close]
-      Content-Type: [text/html;charset=UTF-8]
-      Date: ['Thu, 06 Dec 2018 13:18:58 GMT']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [JSESSIONID=3abe0b30d09c8d49d974081d6c9a; Path=/; Secure; HttpOnly,
-        AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3FE010BDBAE7AE7E438B31BFA0246B9F2DBD3EC37C4E69D8B958E3FBF8CF814030B5CB9749AB70FE33A8BB5BB36A149CB;PATH=/;MAX-AGE=28800]
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html;charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 15:15:54 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=rqxJTNpwNoMsjtL78+rL6vxPp1UtVFoAeyvPffA9odvPnj9T+Yrq1kYi+lq9/v8g2sPOTVERMvazezUaTQh/qkA4ZQu6rAuc3CRQWKZYQwX9NuccFRrJ83GGOHCs;
+        Expires=Tue, 29 Jun 2021 15:15:53 GMT; Path=/
+      - AWSALBCORS=rqxJTNpwNoMsjtL78+rL6vxPp1UtVFoAeyvPffA9odvPnj9T+Yrq1kYi+lq9/v8g2sPOTVERMvazezUaTQh/qkA4ZQu6rAuc3CRQWKZYQwX9NuccFRrJ83GGOHCs;
+        Expires=Tue, 29 Jun 2021 15:15:53 GMT; Path=/; SameSite=None; Secure
+      - JSESSIONID=44ac7107fa9564325a778cbcf840; Path=/; Secure; HttpOnly
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.19.1]
-    method: GET
-    uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.7910%2FDVN%2FRLMYMR%2FWNKD3W%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
-  response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":2,"params":{"q":"identifier:\"doi:10.7910/DVN/RLMYMR/WNKD3W\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":0,"start":0,"docs":[]}}
-
-'}
-    headers:
-      Access-Control-Allow-Credentials: ['true']
-      Access-Control-Allow-Headers: ['Authorization, Content-Type, Location, Content-Length,
-          x-annotator-auth-token']
-      Access-Control-Allow-Methods: ['POST, GET, OPTIONS, PUT, DELETE']
-      Access-Control-Allow-Origin: ['']
-      Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=UTF-8]
-      Date: ['Thu, 06 Dec 2018 13:18:59 GMT']
-      Keep-Alive: ['timeout=5, max=100']
-      Server: [Apache/2.4.7 (Ubuntu)]
-      Transfer-Encoding: [chunked]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Connection: [close]
-      Host: [dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: GET
     uri: https://dataverse.harvard.edu/api/search?q=filePersistentId:WNKD3W
   response:
-    body: {string: '{"status":"OK","data":{"q":"filePersistentId:WNKD3W","total_count":1,"start":0,"spelling_alternatives":{},"items":[{"name":"Karnataka_DD&FS_Data-1.tab","type":"file","url":"https://dataverse.harvard.edu/api/access/datafile/3315157","file_id":"3315157","description":"Data","published_at":"2018-11-15T16:04:00Z","file_type":"Tab-Delimited","file_content_type":"text/tab-separated-values","size_in_bytes":2321,"md5":"ca9dea905295ac52db4ea3c7c8bf00e9","checksum":{"type":"MD5","value":"ca9dea905295ac52db4ea3c7c8bf00e9"},"unf":"UNF:6:wBvSbRl2RTVRfu9kpjgnrw==","dataset_citation":"Ntandou-Bouzitou,
-        G.D.;Kennedy, G.;Bellon, M.R.;Mathur, P.;Dandin, S.;Patil, H.B., 2016, \"Karnataka
-        Diet Diversity and Food Security for Agricultural Biodiversity Assessment\",
-        https://doi.org/10.7910/DVN/RLMYMR, Harvard Dataverse, V2, UNF:6:wBvSbRl2RTVRfu9kpjgnrw==
-        [fileUNF]"}],"count_in_response":1}}'}
+    body:
+      string: '{"status":"OK","data":{"q":"filePersistentId:WNKD3W","total_count":1,"start":0,"spelling_alternatives":{},"items":[{"name":"Karnataka_DD&FS_Data-1.tab","type":"file","url":"https://dataverse.harvard.edu/api/access/datafile/3315157","file_id":"3315157","description":"Data","published_at":"2018-11-15T16:04:00Z","file_type":"Tab-Delimited","file_content_type":"text/tab-separated-values","size_in_bytes":2321,"md5":"ca9dea905295ac52db4ea3c7c8bf00e9","checksum":{"type":"MD5","value":"ca9dea905295ac52db4ea3c7c8bf00e9"},"unf":"UNF:6:wBvSbRl2RTVRfu9kpjgnrw==","file_persistent_id":"doi:10.7910/DVN/RLMYMR/WNKD3W","dataset_name":"Karnataka
+        Diet Diversity and Food Security for Agricultural Biodiversity Assessment","dataset_id":"2966297","dataset_persistent_id":"doi:10.7910/DVN/RLMYMR","dataset_citation":"Ntandou-Bouzitou,
+        G.D.; Kennedy, G.; Bellon, M.R.; Mathur, P.; Dandin, S.; Patil, H.B., 2016,
+        \"Karnataka Diet Diversity and Food Security for Agricultural Biodiversity
+        Assessment\", https://doi.org/10.7910/DVN/RLMYMR, Harvard Dataverse, V2, UNF:6:wBvSbRl2RTVRfu9kpjgnrw==
+        [fileUNF]"}],"count_in_response":1}}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-control: [no-cache="set-cookie"]
-      Connection: [Close]
-      Content-Length: ['881']
-      Content-Type: [application/json]
-      Date: ['Thu, 06 Dec 2018 13:19:00 GMT']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3FE010BDBAE7AE7E438B31BFA0246B9F2DBD3EC37C4E69D8B958E3FBF8CF814030B5CB9749AB70FE33A8BB5BB36A149CB;PATH=/;MAX-AGE=28800]
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Headers:
+      - Accept, Content-Type, X-Dataverse-Key
+      Access-Control-Allow-Methods:
+      - PUT, GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1112'
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 15:15:57 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=uFBkQl0m/T/dC9kRG3FLoYeHF6PG7h0CQNmvianx/+gUN/CXnsz3KHVfcFeFpgrspsW5y8xBTjaHej5VfEHvcvYTWm1wmO9zBw6zKcK6/x0CyXF2FG/GaOP0AAR5;
+        Expires=Tue, 29 Jun 2021 15:15:54 GMT; Path=/
+      - AWSALBCORS=uFBkQl0m/T/dC9kRG3FLoYeHF6PG7h0CQNmvianx/+gUN/CXnsz3KHVfcFeFpgrspsW5y8xBTjaHej5VfEHvcvYTWm1wmO9zBw6zKcK6/x0CyXF2FG/GaOP0AAR5;
+        Expires=Tue, 29 Jun 2021 15:15:54 GMT; Path=/; SameSite=None; Secure
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.19.1]
-    method: GET
-    uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22https%3A%2F%2Fdataverse.harvard.edu%2Fapi%2Faccess%2Fdatafile%2F3040230%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
-  response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"https://dataverse.harvard.edu/api/access/datafile/3040230\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":0,"start":0,"docs":[]}}
-
-'}
-    headers:
-      Access-Control-Allow-Credentials: ['true']
-      Access-Control-Allow-Headers: ['Authorization, Content-Type, Location, Content-Length,
-          x-annotator-auth-token']
-      Access-Control-Allow-Methods: ['POST, GET, OPTIONS, PUT, DELETE']
-      Access-Control-Allow-Origin: ['']
-      Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=UTF-8]
-      Date: ['Thu, 06 Dec 2018 13:19:00 GMT']
-      Keep-Alive: ['timeout=5, max=100']
-      Server: [Apache/2.4.7 (Ubuntu)]
-      Transfer-Encoding: [chunked]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Connection: [close]
-      Host: [dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
-    method: GET
-    uri: https://dataverse.harvard.edu/api/search?q=entityId:3040230
-  response:
-    body: {string: '{"status":"OK","data":{"q":"entityId:3040230","total_count":1,"start":0,"spelling_alternatives":{},"items":[{"name":"2017-07-31.tab","type":"file","url":"https://dataverse.harvard.edu/api/access/datafile/3040230","file_id":"3040230","published_at":"2017-07-31T22:27:23Z","file_type":"Tab-Delimited","file_content_type":"text/tab-separated-values","size_in_bytes":12025,"md5":"e7dd2f725941b978d45fed3f33ff640c","checksum":{"type":"MD5","value":"e7dd2f725941b978d45fed3f33ff640c"},"unf":"UNF:6:6wGE3C5ragT8A0qkpGaEaQ==","dataset_citation":"Durbin,
-        Philip, 2017, \"Open Source at Harvard\", https://doi.org/10.7910/DVN/TJCLKP,
-        Harvard Dataverse, V2, UNF:6:6wGE3C5ragT8A0qkpGaEaQ== [fileUNF]"}],"count_in_response":1}}'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-control: [no-cache="set-cookie"]
-      Connection: [Close]
-      Content-Length: ['714']
-      Content-Type: [application/json]
-      Date: ['Thu, 06 Dec 2018 13:19:01 GMT']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3FE010BDBAE7AE7E438B31BFA0246B9F2DBD3EC37C4E69D8B958E3FBF8CF814030B5CB9749AB70FE33A8BB5BB36A149CB;PATH=/;MAX-AGE=28800]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Connection: [close]
-      Host: [doi.org]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: HEAD
     uri: https://doi.org/10.7910/DVN/RLMYMR
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      CF-RAY: [484f0ab2ba6142dc-ATL]
-      Connection: [close]
-      Content-Length: ['233']
-      Content-Type: [text/html;charset=utf-8]
-      Date: ['Thu, 06 Dec 2018 13:19:01 GMT']
-      Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-      Expires: ['Thu, 06 Dec 2018 14:02:04 GMT']
-      Location: ['https://dataverse.harvard.edu/citation?persistentId=doi:10.7910/DVN/RLMYMR']
-      Server: [cloudflare]
-      Set-Cookie: ['__cfduid=db337e099d540d05b2aa87699169176391544102341; expires=Fri,
-          06-Dec-19 13:19:01 GMT; path=/; domain=.doi.org; HttpOnly']
-      Vary: [Accept]
-    status: {code: 302, message: ''}
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 66366f60af0e2c44-ORD
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '233'
+      Content-Type:
+      - text/html;charset=utf-8
+      Date:
+      - Tue, 22 Jun 2021 15:15:58 GMT
+      Expect-CT:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Expires:
+      - Tue, 22 Jun 2021 15:41:44 GMT
+      Location:
+      - https://dataverse.harvard.edu/citation?persistentId=doi:10.7910/DVN/RLMYMR
+      NEL:
+      - '{"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v2?s=yV%2BexXV7Osg6Nb3ECihSBOS%2B9AzCpjbPysulN9ueHNeDcvEIpJaS%2Bk7cMihpuBgVNx7tbM1kYF9eO8UeJedkUzMeshkXoTeuQIxzntls1fcnKduDd0cjDDvL5qHdx3Cz"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept
+      alt-svc:
+      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
+        ma=86400
+      cf-request-id:
+      - 0ad5e3f06700002c44f3387000000001
+    status:
+      code: 302
+      message: ''
 - request:
     body: null
     headers:
-      Connection: [close]
-      Host: [dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: HEAD
     uri: https://dataverse.harvard.edu/citation?persistentId=doi:10.7910/DVN/RLMYMR
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      Cache-control: [no-cache="set-cookie"]
-      Connection: [Close]
-      Content-Language: [en-US]
-      Content-Type: [text/html;charset=ISO-8859-1]
-      Date: ['Thu, 06 Dec 2018 13:19:01 GMT']
-      Location: ['https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/RLMYMR']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3CF6A1B0A2CD5F2F144400DE0E06A10F0DBD3EC37C4E69D8B958E3FBF8CF81403222DF6AABE0F6509EF79AB1D548B7265;PATH=/;MAX-AGE=28800]
-    status: {code: 302, message: Found}
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en-US
+      Content-Type:
+      - text/html;charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 15:15:58 GMT
+      Location:
+      - https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/RLMYMR
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=SOngHKYg36ppyRT0BqB5gxYB/GY3qkxckxfJZoAzqtNXdQdjMwuptz/Gu3oHIY0kgwHcAjuWwmuzU5Q67b9RXVNDNz3NTZeTfN9Qez2kGUrYasPA75SMB+f419tg;
+        Expires=Tue, 29 Jun 2021 15:15:58 GMT; Path=/
+      - AWSALBCORS=SOngHKYg36ppyRT0BqB5gxYB/GY3qkxckxfJZoAzqtNXdQdjMwuptz/Gu3oHIY0kgwHcAjuWwmuzU5Q67b9RXVNDNz3NTZeTfN9Qez2kGUrYasPA75SMB+f419tg;
+        Expires=Tue, 29 Jun 2021 15:15:58 GMT; Path=/; SameSite=None; Secure
+    status:
+      code: 302
+      message: Found
 - request:
     body: null
     headers:
-      Connection: [close]
-      Host: [dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - AWSALB=SOngHKYg36ppyRT0BqB5gxYB/GY3qkxckxfJZoAzqtNXdQdjMwuptz/Gu3oHIY0kgwHcAjuWwmuzU5Q67b9RXVNDNz3NTZeTfN9Qez2kGUrYasPA75SMB+f419tg;
+        AWSALBCORS=SOngHKYg36ppyRT0BqB5gxYB/GY3qkxckxfJZoAzqtNXdQdjMwuptz/Gu3oHIY0kgwHcAjuWwmuzU5Q67b9RXVNDNz3NTZeTfN9Qez2kGUrYasPA75SMB+f419tg
+      User-Agent:
+      - python-requests/2.25.1
     method: HEAD
     uri: https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/RLMYMR
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      Cache-control: [no-cache="set-cookie"]
-      Connection: [Close]
-      Content-Type: [text/html;charset=UTF-8]
-      Date: ['Thu, 06 Dec 2018 13:19:02 GMT']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [JSESSIONID=3abed8b30aad9194827eda3c64f5; Path=/; Secure; HttpOnly,
-        AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3FE010BDBAE7AE7E438B31BFA0246B9F2DBD3EC37C4E69D8B958E3FBF8CF814030B5CB9749AB70FE33A8BB5BB36A149CB;PATH=/;MAX-AGE=28800]
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html;charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 15:16:00 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=maZ1tjxbp+J0ZuxUtuSECePHNLclLyBqKL+Bm3o2qB83SHqUrAWA+f1QnGxsjacss7xvCPafsGYXUUYVVOwi5Hy2ahtGbI1eNYDi4Fp+P1IgfNbBgFpxrVsI0Bqm;
+        Expires=Tue, 29 Jun 2021 15:15:58 GMT; Path=/
+      - AWSALBCORS=maZ1tjxbp+J0ZuxUtuSECePHNLclLyBqKL+Bm3o2qB83SHqUrAWA+f1QnGxsjacss7xvCPafsGYXUUYVVOwi5Hy2ahtGbI1eNYDi4Fp+P1IgfNbBgFpxrVsI0Bqm;
+        Expires=Tue, 29 Jun 2021 15:15:58 GMT; Path=/; SameSite=None; Secure
+      - JSESSIONID=44ad987717647d08dc9b18b87e8d; Path=/; Secure; HttpOnly
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.19.1]
-    method: GET
-    uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.7910%2FDVN%2FRLMYMR%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
-  response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":2,"params":{"q":"identifier:\"doi:10.7910/DVN/RLMYMR\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":0,"start":0,"docs":[]}}
-
-'}
-    headers:
-      Access-Control-Allow-Credentials: ['true']
-      Access-Control-Allow-Headers: ['Authorization, Content-Type, Location, Content-Length,
-          x-annotator-auth-token']
-      Access-Control-Allow-Methods: ['POST, GET, OPTIONS, PUT, DELETE']
-      Access-Control-Allow-Origin: ['']
-      Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=UTF-8]
-      Date: ['Thu, 06 Dec 2018 13:19:03 GMT']
-      Keep-Alive: ['timeout=5, max=100']
-      Server: [Apache/2.4.7 (Ubuntu)]
-      Transfer-Encoding: [chunked]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Connection: [close]
-      Host: [dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: GET
     uri: https://dataverse.harvard.edu/api/datasets/:persistentId?persistentId=doi:10.7910/DVN/RLMYMR
   response:
-    body: {string: '{"status":"OK","data":{"id":2966297,"identifier":"DVN/RLMYMR","persistentUrl":"https://doi.org/10.7910/DVN/RLMYMR","protocol":"doi","authority":"10.7910","publisher":"Harvard
-        Dataverse","publicationDate":"2016-12-20","storageIdentifier":"s3://10.7910/DVN/RLMYMR","latestVersion":{"id":147203,"storageIdentifier":"s3://10.7910/DVN/RLMYMR","versionNumber":2,"versionMinorNumber":0,"versionState":"RELEASED","productionDate":"Production
-        Date","UNF":"UNF:6:wBvSbRl2RTVRfu9kpjgnrw==","lastUpdateTime":"2018-11-15T16:04:00Z","releaseTime":"2018-11-15T16:04:00Z","createTime":"2018-11-15T16:00:10Z","license":"NONE","termsOfUse":"Attribution
+    body:
+      string: '{"status":"OK","data":{"id":2966297,"identifier":"DVN/RLMYMR","persistentUrl":"https://doi.org/10.7910/DVN/RLMYMR","protocol":"doi","authority":"10.7910","publisher":"Harvard
+        Dataverse","publicationDate":"2016-12-20","storageIdentifier":"s3://10.7910/DVN/RLMYMR","latestVersion":{"id":147203,"datasetId":2966297,"datasetPersistentId":"doi:10.7910/DVN/RLMYMR","storageIdentifier":"s3://10.7910/DVN/RLMYMR","versionNumber":2,"versionMinorNumber":0,"versionState":"RELEASED","UNF":"UNF:6:wBvSbRl2RTVRfu9kpjgnrw==","lastUpdateTime":"2018-11-15T16:04:00Z","releaseTime":"2018-11-15T16:04:00Z","createTime":"2018-11-15T16:00:10Z","license":"NONE","termsOfUse":"Attribution
         is required","disclaimer":"These datasets are provided \"as is\" and in no
         event shall Bioversity International be liable for any damages resulting from
         use of the data. While great effort was taken to obtain high quality data,
@@ -649,7 +509,8 @@ interactions:
         all information which would allow individuals to be identified has been deleted
         from the files. For some of the datasets, the user will need to take care
         in handling missing observations, outlier values and violations of logical
-        consistency. ","metadataBlocks":{"citation":{"displayName":"Citation Metadata","fields":[{"typeName":"title","multiple":false,"typeClass":"primitive","value":"Karnataka
+        consistency. ","fileAccessRequest":false,"metadataBlocks":{"citation":{"displayName":"Citation
+        Metadata","fields":[{"typeName":"title","multiple":false,"typeClass":"primitive","value":"Karnataka
         Diet Diversity and Food Security for Agricultural Biodiversity Assessment"},{"typeName":"author","multiple":true,"typeClass":"compound","value":[{"authorName":{"typeName":"authorName","multiple":false,"typeClass":"primitive","value":"Ntandou-Bouzitou,
         G.D."},"authorAffiliation":{"typeName":"authorAffiliation","multiple":false,"typeClass":"primitive","value":"Bioversity
         International"}},{"authorName":{"typeName":"authorName","multiple":false,"typeClass":"primitive","value":"Kennedy,
@@ -682,8 +543,8 @@ interactions:
         of  August and 30 September 2014 (2 cases 30, 31 of October). For the household
         food security data refer to the previous 30 days of the day of the interview.
         For the infant and child feeding practices, they are in general.\r\nThree
-        villages in the Bijapur District: Mannur, Nandyal, Balaganur were surveyed."}}]},{"typeName":"subject","multiple":true,"typeClass":"controlledVocabulary","value":["Social
-        Sciences","Agricultural Sciences"]},{"typeName":"keyword","multiple":true,"typeClass":"compound","value":[{"keywordValue":{"typeName":"keywordValue","multiple":false,"typeClass":"primitive","value":"DIET"}},{"keywordValue":{"typeName":"keywordValue","multiple":false,"typeClass":"primitive","value":"DIVERSIFICATION"}},{"keywordValue":{"typeName":"keywordValue","multiple":false,"typeClass":"primitive","value":"FOOD
+        villages in the Bijapur District: Mannur, Nandyal, Balaganur were surveyed."}}]},{"typeName":"subject","multiple":true,"typeClass":"controlledVocabulary","value":["Agricultural
+        Sciences","Social Sciences"]},{"typeName":"keyword","multiple":true,"typeClass":"compound","value":[{"keywordValue":{"typeName":"keywordValue","multiple":false,"typeClass":"primitive","value":"DIET"}},{"keywordValue":{"typeName":"keywordValue","multiple":false,"typeClass":"primitive","value":"DIVERSIFICATION"}},{"keywordValue":{"typeName":"keywordValue","multiple":false,"typeClass":"primitive","value":"FOOD
         SECURITY"}},{"keywordValue":{"typeName":"keywordValue","multiple":false,"typeClass":"primitive","value":"FEEDING
         HABITS"}},{"keywordValue":{"typeName":"keywordValue","multiple":false,"typeClass":"primitive","value":"HOUSEHOLDS"}},{"keywordValue":{"typeName":"keywordValue","multiple":false,"typeClass":"primitive","value":"CHILDREN"}}]},{"typeName":"topicClassification","multiple":true,"typeClass":"compound","value":[{"topicClassValue":{"typeName":"topicClassValue","multiple":false,"typeClass":"primitive","value":"SURVEYS"},"topicClassVocab":{"typeName":"topicClassVocab","multiple":false,"typeClass":"primitive","value":"AGROVOC"},"topicClassVocabURI":{"typeName":"topicClassVocabURI","multiple":false,"typeClass":"primitive","value":"http://aims.fao.org/aos/agrovoc/c_7537"}}]},{"typeName":"language","multiple":true,"typeClass":"controlledVocabulary","value":["English"]},{"typeName":"distributor","multiple":true,"typeClass":"compound","value":[{"distributorName":{"typeName":"distributorName","multiple":false,"typeClass":"primitive","value":"Bioversity
         International"},"distributorURL":{"typeName":"distributorURL","multiple":false,"typeClass":"primitive","value":"http://www.bioversityinternational.org/"}}]},{"typeName":"depositor","multiple":false,"typeClass":"primitive","value":"Bioversity
@@ -692,292 +553,796 @@ interactions:
         1.1: CGIAR Research Program on Dryland Agricultural Production Systems"]}]},"geospatial":{"displayName":"Geospatial
         Metadata","fields":[{"typeName":"geographicCoverage","multiple":true,"typeClass":"compound","value":[{"country":{"typeName":"country","multiple":false,"typeClass":"controlledVocabulary","value":"India"},"state":{"typeName":"state","multiple":false,"typeClass":"primitive","value":"Karnataka"},"otherGeographicCoverage":{"typeName":"otherGeographicCoverage","multiple":false,"typeClass":"primitive","value":"Bijapur
         District"}}]}]}},"files":[{"description":"Data","label":"Karnataka_DD&FS_Data-1.tab","restricted":false,"version":2,"datasetVersionId":147203,"dataFile":{"id":3315157,"persistentId":"doi:10.7910/DVN/RLMYMR/WNKD3W","pidURL":"https://doi.org/10.7910/DVN/RLMYMR/WNKD3W","filename":"Karnataka_DD&FS_Data-1.tab","contentType":"text/tab-separated-values","filesize":2321,"description":"Data","storageIdentifier":"s3://dvn-cloud:167181b3a0e-b7e18f26cfad","originalFileFormat":"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet","originalFormatLabel":"MS
-        Excel (XLSX)","UNF":"UNF:6:wBvSbRl2RTVRfu9kpjgnrw==","rootDataFileId":2966302,"previousDataFileId":2966302,"md5":"ca9dea905295ac52db4ea3c7c8bf00e9","checksum":{"type":"MD5","value":"ca9dea905295ac52db4ea3c7c8bf00e9"}}},{"label":"Karnataka_DD&FS_Questionnaire.pdf","restricted":false,"version":1,"datasetVersionId":147203,"dataFile":{"id":2966301,"persistentId":"doi:10.7910/DVN/RLMYMR/UKYKS9","pidURL":"https://doi.org/10.7910/DVN/RLMYMR/UKYKS9","filename":"Karnataka_DD&FS_Questionnaire.pdf","contentType":"application/pdf","filesize":493564,"storageIdentifier":"s3://dvn-cloud:1591ccfc017-1eeea525e902","originalFormatLabel":"UNKNOWN","rootDataFileId":-1,"md5":"d9de390c8f132916b4bb97d6ea0c8ed6","checksum":{"type":"MD5","value":"d9de390c8f132916b4bb97d6ea0c8ed6"}}}]}}}'}
+        Excel Spreadsheet","originalFileSize":700840,"originalFileName":"Karnataka_DD&FS_Data-1.xlsx","UNF":"UNF:6:wBvSbRl2RTVRfu9kpjgnrw==","rootDataFileId":2966302,"previousDataFileId":2966302,"md5":"ca9dea905295ac52db4ea3c7c8bf00e9","checksum":{"type":"MD5","value":"ca9dea905295ac52db4ea3c7c8bf00e9"},"creationDate":"2018-11-15"}},{"label":"Karnataka_DD&FS_Questionnaire.pdf","restricted":false,"version":1,"datasetVersionId":147203,"dataFile":{"id":2966301,"persistentId":"doi:10.7910/DVN/RLMYMR/UKYKS9","pidURL":"https://doi.org/10.7910/DVN/RLMYMR/UKYKS9","filename":"Karnataka_DD&FS_Questionnaire.pdf","contentType":"application/pdf","filesize":493564,"storageIdentifier":"s3://dvn-cloud:1591ccfc017-1eeea525e902","rootDataFileId":-1,"md5":"d9de390c8f132916b4bb97d6ea0c8ed6","checksum":{"type":"MD5","value":"d9de390c8f132916b4bb97d6ea0c8ed6"},"creationDate":"2016-12-20"}}]}}}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-control: [no-cache="set-cookie"]
-      Connection: [Close]
-      Content-Type: [application/json]
-      Date: ['Thu, 06 Dec 2018 13:19:04 GMT']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3FE010BDBAE7AE7E438B31BFA0246B9F2DBD3EC37C4E69D8B958E3FBF8CF814030B5CB9749AB70FE33A8BB5BB36A149CB;PATH=/;MAX-AGE=28800]
-      transfer-encoding: [chunked]
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Headers:
+      - Accept, Content-Type, X-Dataverse-Key
+      Access-Control-Allow-Methods:
+      - PUT, GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 15:16:00 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=dKdJ25GxRkgijCHy4yylJ5ZJti/fMY8j9seM1X+5bBxhrPXqcCnqU4W7ehk9I4zZdYnigE4VcG33JMaJEw25sDdjvL4txZSCB1L9pxWzJ6HSfDIMBsebxx+FKulS;
+        Expires=Tue, 29 Jun 2021 15:16:00 GMT; Path=/
+      - AWSALBCORS=dKdJ25GxRkgijCHy4yylJ5ZJti/fMY8j9seM1X+5bBxhrPXqcCnqU4W7ehk9I4zZdYnigE4VcG33JMaJEw25sDdjvL4txZSCB1L9pxWzJ6HSfDIMBsebxx+FKulS;
+        Expires=Tue, 29 Jun 2021 15:16:00 GMT; Path=/; SameSite=None; Secure
+      - JSESSIONID=44ae1fcd1ae2e8ce2df5f702fdd9; Path=/; Secure; HttpOnly
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Connection: [close]
-      Host: [dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: HEAD
     uri: https://dataverse.harvard.edu/api/access/datafile/3315157?format=original
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-control: [no-cache="set-cookie"]
-      Connection: [Close]
-      Content-Length: ['700840']
-      Content-Type: [application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;
-          name="Karnataka_DD&FS_Data-1.xlsx"]
-      Content-disposition: [attachment; filename="Karnataka_DD&FS_Data-1.xlsx"]
-      Date: ['Thu, 06 Dec 2018 13:19:05 GMT']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [JSESSIONID=3abfa60fc213432900ffa86c4d91; Path=/; Secure; HttpOnly,
-        AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3CF6A1B0A2CD5F2F144400DE0E06A10F0DBD3EC37C4E69D8B958E3FBF8CF81403222DF6AABE0F6509EF79AB1D548B7265;PATH=/;MAX-AGE=28800]
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Headers:
+      - Accept, Content-Type, X-Dataverse-Key
+      Access-Control-Allow-Methods:
+      - PUT, GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml;charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 15:16:01 GMT
+      Location:
+      - https://dvn-cloud.s3.amazonaws.com/10.7910/DVN/RLMYMR/167181b3a0e-b7e18f26cfad.orig?response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%27Karnataka_DD%2526FS_Data-1.xlsx&response-content-type=application%2Fvnd.openxmlformats-officedocument.spreadsheetml.sheet&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20210622T151601Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Credential=AKIAIEJ3NV7UYCSRJC7A%2F20210622%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=da650599ac940cc1c549bb374e7b841010fd3ab965a39d5d01e3418e7fe83eb5
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=lSnSmBfdrBu/4kRaNY267IaQ9wosMqP9l298IyfD+kdln8xrfziFl4y7aKfCpRk6DGQRgRaxTbMsbfMKioFWn9qgO8oUg8Yj/NeYWSEEBfpeP44RjbNpLUYrRueK;
+        Expires=Tue, 29 Jun 2021 15:16:01 GMT; Path=/
+      - AWSALBCORS=lSnSmBfdrBu/4kRaNY267IaQ9wosMqP9l298IyfD+kdln8xrfziFl4y7aKfCpRk6DGQRgRaxTbMsbfMKioFWn9qgO8oUg8Yj/NeYWSEEBfpeP44RjbNpLUYrRueK;
+        Expires=Tue, 29 Jun 2021 15:16:01 GMT; Path=/; SameSite=None; Secure
+      - JSESSIONID=44ae3d4d15bf7363aae686a399e2; Path=/; Secure; HttpOnly
+    status:
+      code: 303
+      message: See Other
 - request:
     body: null
     headers:
-      Connection: [close]
-      Host: [dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: HEAD
+    uri: https://dvn-cloud.s3.amazonaws.com/10.7910/DVN/RLMYMR/167181b3a0e-b7e18f26cfad.orig?response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%27Karnataka_DD%2526FS_Data-1.xlsx&response-content-type=application%2Fvnd.openxmlformats-officedocument.spreadsheetml.sheet&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20210622T151601Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Credential=AKIAIEJ3NV7UYCSRJC7A%2F20210622%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=da650599ac940cc1c549bb374e7b841010fd3ab965a39d5d01e3418e7fe83eb5
+  response:
+    body:
+      string: ''
+    headers:
+      Content-Type:
+      - application/xml
+      Date:
+      - Tue, 22 Jun 2021 15:16:00 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - itPGnEoCRbOxxc/bcMer3qISBy6ajOAmHQSr4HtDwTEJU9VDbu7THcR6w7b5dXoFG4tIzsNHqA8=
+      x-amz-request-id:
+      - D1SFS40ND42KSFZ6
+    status:
+      code: 403
+      message: Forbidden
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Range:
+      - bytes=0-100
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dataverse.harvard.edu/api/access/datafile/3315157?format=original
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept, Content-Type, X-Dataverse-Key
+      Access-Control-Allow-Methods:
+      - PUT, GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Tue, 22 Jun 2021 15:16:02 GMT
+      Location:
+      - https://dvn-cloud.s3.amazonaws.com/10.7910/DVN/RLMYMR/167181b3a0e-b7e18f26cfad.orig?response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%27Karnataka_DD%2526FS_Data-1.xlsx&response-content-type=application%2Fvnd.openxmlformats-officedocument.spreadsheetml.sheet&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20210622T151602Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Credential=AKIAIEJ3NV7UYCSRJC7A%2F20210622%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=290d0a3a0f9d0506b433e50d7e24ecc7a72ebb1238013d8410d73ca09c000427
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=97natyCJEeAfK/LaPm3OpZyq9Ycd1ed8oEGqoslZs4T94YkPAZD8dqOti4m52BkSN8aim72TDR5hkhgLUk33qiI4LDJwaWmtq4jdIXkTdGFr+2s3CdtHEmT6kbr2;
+        Expires=Tue, 29 Jun 2021 15:16:01 GMT; Path=/
+      - AWSALBCORS=97natyCJEeAfK/LaPm3OpZyq9Ycd1ed8oEGqoslZs4T94YkPAZD8dqOti4m52BkSN8aim72TDR5hkhgLUk33qiI4LDJwaWmtq4jdIXkTdGFr+2s3CdtHEmT6kbr2;
+        Expires=Tue, 29 Jun 2021 15:16:01 GMT; Path=/; SameSite=None; Secure
+      - JSESSIONID=44ae753ef62ef0790fa17ed120f8; Path=/; Secure; HttpOnly
+    status:
+      code: 303
+      message: See Other
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Range:
+      - bytes=0-100
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dvn-cloud.s3.amazonaws.com/10.7910/DVN/RLMYMR/167181b3a0e-b7e18f26cfad.orig?response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%27Karnataka_DD%2526FS_Data-1.xlsx&response-content-type=application%2Fvnd.openxmlformats-officedocument.spreadsheetml.sheet&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20210622T151602Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Credential=AKIAIEJ3NV7UYCSRJC7A%2F20210622%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=290d0a3a0f9d0506b433e50d7e24ecc7a72ebb1238013d8410d73ca09c000427
+  response:
+    body:
+      string: !!binary |
+        UEsDBBQABgAIAAAAIQDA14IQxQEAAMUKAAATAL4BW0NvbnRlbnRfVHlwZXNdLnhtbCCiugEooAAC
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Disposition:
+      - attachment; filename*=UTF-8''Karnataka_DD%26FS_Data-1.xlsx
+      Content-Length:
+      - '101'
+      Content-Range:
+      - bytes 0-100/700840
+      Content-Type:
+      - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+      Date:
+      - Tue, 22 Jun 2021 15:16:03 GMT
+      ETag:
+      - '"ca9dea905295ac52db4ea3c7c8bf00e9"'
+      Last-Modified:
+      - Thu, 15 Nov 2018 16:01:47 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - fuVauVbtd/1wC2FqFWcBnILRgqi68o3QAPvpZftm334s0b33LreI1KsdWTm0uD5WMGXgOPHXjF0=
+      x-amz-replication-status:
+      - COMPLETED
+      x-amz-request-id:
+      - EKFPH89F8E9RX2J4
+      x-amz-version-id:
+      - 8Uv3Yrd.dfBXa57kWF6KNDwyWs06bgpF
+    status:
+      code: 206
+      message: Partial Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: HEAD
     uri: https://dataverse.harvard.edu/api/access/datafile/3315157
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-control: [no-cache="set-cookie"]
-      Connection: [Close]
-      Content-Length: ['2408']
-      Content-Type: [text/tab-separated-values; name="Karnataka_DD&FS_Data-1.tab"]
-      Content-disposition: [attachment; filename="Karnataka_DD&FS_Data-1.tab"]
-      Date: ['Thu, 06 Dec 2018 13:19:05 GMT']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [JSESSIONID=3abfcce6df61b79659943f6c8438; Path=/; Secure; HttpOnly,
-        AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3FE010BDBAE7AE7E438B31BFA0246B9F2DBD3EC37C4E69D8B958E3FBF8CF814030B5CB9749AB70FE33A8BB5BB36A149CB;PATH=/;MAX-AGE=28800]
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Headers:
+      - Accept, Content-Type, X-Dataverse-Key
+      Access-Control-Allow-Methods:
+      - PUT, GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2408'
+      Content-Type:
+      - text/tab-separated-values; name="Karnataka_DD%26FS_Data-1.tab";charset=UTF-8
+      Content-disposition:
+      - attachment; filename="Karnataka_DD%26FS_Data-1.tab"
+      Date:
+      - Tue, 22 Jun 2021 15:16:03 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=xo4hSrFmrnsEzcKjwtiLszzsD04gTy2gkPPJTLBnmEBj/Jy5luHXnDfbMHZinAB2EaxTmzb0mrAI6nq69nruMk1f3BSfraLykTnWb+KIBNOPU7YCeZCojUqAvi+6;
+        Expires=Tue, 29 Jun 2021 15:16:02 GMT; Path=/
+      - AWSALBCORS=xo4hSrFmrnsEzcKjwtiLszzsD04gTy2gkPPJTLBnmEBj/Jy5luHXnDfbMHZinAB2EaxTmzb0mrAI6nq69nruMk1f3BSfraLykTnWb+KIBNOPU7YCeZCojUqAvi+6;
+        Expires=Tue, 29 Jun 2021 15:16:02 GMT; Path=/; SameSite=None; Secure
+      - JSESSIONID=44aeab4aec09b9e1036ad49e38f1; Path=/; Secure; HttpOnly
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Connection: [close]
-      Host: [doi.org]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: HEAD
     uri: https://doi.org/10.7910/DVN/RLMYMR/WNKD3W
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      CF-RAY: [484f0ad04e41ba12-ATL]
-      Connection: [close]
-      Content-Length: ['251']
-      Content-Type: [text/html;charset=utf-8]
-      Date: ['Thu, 06 Dec 2018 13:19:06 GMT']
-      Expect-CT: ['max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"']
-      Expires: ['Thu, 06 Dec 2018 14:02:04 GMT']
-      Location: ['https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/RLMYMR/WNKD3W']
-      Server: [cloudflare]
-      Set-Cookie: ['__cfduid=de3a93d1fe3ea0a14986089303ede70a11544102346; expires=Fri,
-          06-Dec-19 13:19:06 GMT; path=/; domain=.doi.org; HttpOnly']
-      Vary: [Accept]
-    status: {code: 302, message: ''}
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 66366f805f7b2be3-ORD
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '251'
+      Content-Type:
+      - text/html;charset=utf-8
+      Date:
+      - Tue, 22 Jun 2021 15:16:03 GMT
+      Expect-CT:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Expires:
+      - Tue, 22 Jun 2021 15:41:44 GMT
+      Location:
+      - https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/RLMYMR/WNKD3W
+      NEL:
+      - '{"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v2?s=pzDz73lesyZven37q%2FWLQzSshX82jIg7NAL1EVLMbJc37BZj7okGeHyBeaIRdNtxU6Rn9YXDioRXT2WGwRAcaLjPuel5zB1506acRSDwRblSGiVqHUKKlVRpvBE2aEXm"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept
+      alt-svc:
+      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
+        ma=86400
+      cf-request-id:
+      - 0ad5e4043900002be31625d000000001
+    status:
+      code: 302
+      message: ''
 - request:
     body: null
     headers:
-      Connection: [close]
-      Host: [dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: HEAD
     uri: https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/RLMYMR/WNKD3W
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      Cache-control: [no-cache="set-cookie"]
-      Connection: [Close]
-      Content-Type: [text/html;charset=UTF-8]
-      Date: ['Thu, 06 Dec 2018 13:19:06 GMT']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [JSESSIONID=3abff28b4f8cbdd6839a03156aef; Path=/; Secure; HttpOnly,
-        AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3FE010BDBAE7AE7E438B31BFA0246B9F2DBD3EC37C4E69D8B958E3FBF8CF814030B5CB9749AB70FE33A8BB5BB36A149CB;PATH=/;MAX-AGE=28800]
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html;charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 15:16:04 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=I8MWyvBkEspAsImQkP+iHJCt335C4gXloqe+oqaTbjaSdrZ14GqgBpmw7+Lg0v9ihqKUvIX2s0BHxgO+7+Eg/eCXYsPsASktIW5ccaDR/t9KK/UpPoKMp1dZEV1c;
+        Expires=Tue, 29 Jun 2021 15:16:03 GMT; Path=/
+      - AWSALBCORS=I8MWyvBkEspAsImQkP+iHJCt335C4gXloqe+oqaTbjaSdrZ14GqgBpmw7+Lg0v9ihqKUvIX2s0BHxgO+7+Eg/eCXYsPsASktIW5ccaDR/t9KK/UpPoKMp1dZEV1c;
+        Expires=Tue, 29 Jun 2021 15:16:03 GMT; Path=/; SameSite=None; Secure
+      - JSESSIONID=44aed29b7e4a21768b9c9282d196; Path=/; Secure; HttpOnly
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.19.1]
-    method: GET
-    uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22doi%3A10.7910%2FDVN%2FRLMYMR%2FWNKD3W%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
-  response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"doi:10.7910/DVN/RLMYMR/WNKD3W\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":0,"start":0,"docs":[]}}
-
-'}
-    headers:
-      Access-Control-Allow-Credentials: ['true']
-      Access-Control-Allow-Headers: ['Authorization, Content-Type, Location, Content-Length,
-          x-annotator-auth-token']
-      Access-Control-Allow-Methods: ['POST, GET, OPTIONS, PUT, DELETE']
-      Access-Control-Allow-Origin: ['']
-      Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=UTF-8]
-      Date: ['Thu, 06 Dec 2018 13:19:07 GMT']
-      Keep-Alive: ['timeout=5, max=100']
-      Server: [Apache/2.4.7 (Ubuntu)]
-      Transfer-Encoding: [chunked]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Connection: [close]
-      Host: [dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: GET
     uri: https://dataverse.harvard.edu/api/search?q=filePersistentId:WNKD3W
   response:
-    body: {string: '{"status":"OK","data":{"q":"filePersistentId:WNKD3W","total_count":1,"start":0,"spelling_alternatives":{},"items":[{"name":"Karnataka_DD&FS_Data-1.tab","type":"file","url":"https://dataverse.harvard.edu/api/access/datafile/3315157","file_id":"3315157","description":"Data","published_at":"2018-11-15T16:04:00Z","file_type":"Tab-Delimited","file_content_type":"text/tab-separated-values","size_in_bytes":2321,"md5":"ca9dea905295ac52db4ea3c7c8bf00e9","checksum":{"type":"MD5","value":"ca9dea905295ac52db4ea3c7c8bf00e9"},"unf":"UNF:6:wBvSbRl2RTVRfu9kpjgnrw==","dataset_citation":"Ntandou-Bouzitou,
-        G.D.;Kennedy, G.;Bellon, M.R.;Mathur, P.;Dandin, S.;Patil, H.B., 2016, \"Karnataka
-        Diet Diversity and Food Security for Agricultural Biodiversity Assessment\",
-        https://doi.org/10.7910/DVN/RLMYMR, Harvard Dataverse, V2, UNF:6:wBvSbRl2RTVRfu9kpjgnrw==
-        [fileUNF]"}],"count_in_response":1}}'}
+    body:
+      string: '{"status":"OK","data":{"q":"filePersistentId:WNKD3W","total_count":1,"start":0,"spelling_alternatives":{},"items":[{"name":"Karnataka_DD&FS_Data-1.tab","type":"file","url":"https://dataverse.harvard.edu/api/access/datafile/3315157","file_id":"3315157","description":"Data","published_at":"2018-11-15T16:04:00Z","file_type":"Tab-Delimited","file_content_type":"text/tab-separated-values","size_in_bytes":2321,"md5":"ca9dea905295ac52db4ea3c7c8bf00e9","checksum":{"type":"MD5","value":"ca9dea905295ac52db4ea3c7c8bf00e9"},"unf":"UNF:6:wBvSbRl2RTVRfu9kpjgnrw==","file_persistent_id":"doi:10.7910/DVN/RLMYMR/WNKD3W","dataset_name":"Karnataka
+        Diet Diversity and Food Security for Agricultural Biodiversity Assessment","dataset_id":"2966297","dataset_persistent_id":"doi:10.7910/DVN/RLMYMR","dataset_citation":"Ntandou-Bouzitou,
+        G.D.; Kennedy, G.; Bellon, M.R.; Mathur, P.; Dandin, S.; Patil, H.B., 2016,
+        \"Karnataka Diet Diversity and Food Security for Agricultural Biodiversity
+        Assessment\", https://doi.org/10.7910/DVN/RLMYMR, Harvard Dataverse, V2, UNF:6:wBvSbRl2RTVRfu9kpjgnrw==
+        [fileUNF]"}],"count_in_response":1}}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-control: [no-cache="set-cookie"]
-      Connection: [Close]
-      Content-Length: ['881']
-      Content-Type: [application/json]
-      Date: ['Thu, 06 Dec 2018 13:19:08 GMT']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3CF6A1B0A2CD5F2F144400DE0E06A10F0DBD3EC37C4E69D8B958E3FBF8CF81403222DF6AABE0F6509EF79AB1D548B7265;PATH=/;MAX-AGE=28800]
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Headers:
+      - Accept, Content-Type, X-Dataverse-Key
+      Access-Control-Allow-Methods:
+      - PUT, GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1112'
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 15:16:07 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=lG9pEe/YxIF0JYz+5TiS6+RtBG//dTWcBSCU6b39qZrYfrBZYeF8nGU1iByvlQVT8pIpw3wercaVMa6473CQ7TifYwfJze/QFzZqvEcsWF9sQqbTNkdKPfhhH4na;
+        Expires=Tue, 29 Jun 2021 15:16:04 GMT; Path=/
+      - AWSALBCORS=lG9pEe/YxIF0JYz+5TiS6+RtBG//dTWcBSCU6b39qZrYfrBZYeF8nGU1iByvlQVT8pIpw3wercaVMa6473CQ7TifYwfJze/QFzZqvEcsWF9sQqbTNkdKPfhhH4na;
+        Expires=Tue, 29 Jun 2021 15:16:04 GMT; Path=/; SameSite=None; Secure
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Connection: [close]
-      Host: [dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: HEAD
     uri: https://dataverse.harvard.edu/api/access/datafile/3315157?format=original
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-control: [no-cache="set-cookie"]
-      Connection: [Close]
-      Content-Length: ['700840']
-      Content-Type: [application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;
-          name="Karnataka_DD&FS_Data-1.xlsx"]
-      Content-disposition: [attachment; filename="Karnataka_DD&FS_Data-1.xlsx"]
-      Date: ['Thu, 06 Dec 2018 13:19:08 GMT']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [JSESSIONID=3ac070742c2b0e47958144f26d00; Path=/; Secure; HttpOnly,
-        AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3FE010BDBAE7AE7E438B31BFA0246B9F2DBD3EC37C4E69D8B958E3FBF8CF814030B5CB9749AB70FE33A8BB5BB36A149CB;PATH=/;MAX-AGE=28800]
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Headers:
+      - Accept, Content-Type, X-Dataverse-Key
+      Access-Control-Allow-Methods:
+      - PUT, GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml;charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 15:16:07 GMT
+      Location:
+      - https://dvn-cloud.s3.amazonaws.com/10.7910/DVN/RLMYMR/167181b3a0e-b7e18f26cfad.orig?response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%27Karnataka_DD%2526FS_Data-1.xlsx&response-content-type=application%2Fvnd.openxmlformats-officedocument.spreadsheetml.sheet&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20210622T151607Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Credential=AKIAIEJ3NV7UYCSRJC7A%2F20210622%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=d315f8e613b1caa2295a19655fc9447e7c06d9fb40d384bdfd8b49723a4d218c
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=lw8aX5g1Kzd6G49BtBEPrBWL5h1PbwUvtTAob+ohACTbxxNuVBQF6imCouGyJLPqPBhvcGsO/NRN8+Zswvi783DFGuRLZKgRVHBTI3+3iM/m/vn1o7cFH50clT5L;
+        Expires=Tue, 29 Jun 2021 15:16:07 GMT; Path=/
+      - AWSALBCORS=lw8aX5g1Kzd6G49BtBEPrBWL5h1PbwUvtTAob+ohACTbxxNuVBQF6imCouGyJLPqPBhvcGsO/NRN8+Zswvi783DFGuRLZKgRVHBTI3+3iM/m/vn1o7cFH50clT5L;
+        Expires=Tue, 29 Jun 2021 15:16:07 GMT; Path=/; SameSite=None; Secure
+      - JSESSIONID=44afcb5eb5431565b7a5fce6dd0f; Path=/; Secure; HttpOnly
+    status:
+      code: 303
+      message: See Other
 - request:
     body: null
     headers:
-      Connection: [close]
-      Host: [dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: HEAD
+    uri: https://dvn-cloud.s3.amazonaws.com/10.7910/DVN/RLMYMR/167181b3a0e-b7e18f26cfad.orig?response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%27Karnataka_DD%2526FS_Data-1.xlsx&response-content-type=application%2Fvnd.openxmlformats-officedocument.spreadsheetml.sheet&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20210622T151607Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Credential=AKIAIEJ3NV7UYCSRJC7A%2F20210622%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=d315f8e613b1caa2295a19655fc9447e7c06d9fb40d384bdfd8b49723a4d218c
+  response:
+    body:
+      string: ''
+    headers:
+      Content-Type:
+      - application/xml
+      Date:
+      - Tue, 22 Jun 2021 15:16:07 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - 8at401IHIK5mcvJKP1S04DI3gxJuH1P1zCpVrW8K7QjY2hKP77mnmrl0Ph7WeV4AiqmZOoWxilE=
+      x-amz-request-id:
+      - MJ10TY3MC8FADRZP
+    status:
+      code: 403
+      message: Forbidden
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Range:
+      - bytes=0-100
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dataverse.harvard.edu/api/access/datafile/3315157?format=original
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept, Content-Type, X-Dataverse-Key
+      Access-Control-Allow-Methods:
+      - PUT, GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Tue, 22 Jun 2021 15:16:08 GMT
+      Location:
+      - https://dvn-cloud.s3.amazonaws.com/10.7910/DVN/RLMYMR/167181b3a0e-b7e18f26cfad.orig?response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%27Karnataka_DD%2526FS_Data-1.xlsx&response-content-type=application%2Fvnd.openxmlformats-officedocument.spreadsheetml.sheet&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20210622T151608Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Credential=AKIAIEJ3NV7UYCSRJC7A%2F20210622%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=d962b03efbdb108d2c4f7f70e480a0ec93fde3cc9eefe98cbccebf094283a714
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=DdEFcOi3b3Z09yvI5o8VFgKxpK5ib6nQFzMos0z6tcyEN87tCoo3Iv8bzI9Ds7Dyw267NGdPbHRiC0iBuybelqx0AFR8cMnvHwQ6fucvv4I70BYyIskATie3844x;
+        Expires=Tue, 29 Jun 2021 15:16:08 GMT; Path=/
+      - AWSALBCORS=DdEFcOi3b3Z09yvI5o8VFgKxpK5ib6nQFzMos0z6tcyEN87tCoo3Iv8bzI9Ds7Dyw267NGdPbHRiC0iBuybelqx0AFR8cMnvHwQ6fucvv4I70BYyIskATie3844x;
+        Expires=Tue, 29 Jun 2021 15:16:08 GMT; Path=/; SameSite=None; Secure
+      - JSESSIONID=44b000477d1a92dc502bfe77245f; Path=/; Secure; HttpOnly
+    status:
+      code: 303
+      message: See Other
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Range:
+      - bytes=0-100
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dvn-cloud.s3.amazonaws.com/10.7910/DVN/RLMYMR/167181b3a0e-b7e18f26cfad.orig?response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%27Karnataka_DD%2526FS_Data-1.xlsx&response-content-type=application%2Fvnd.openxmlformats-officedocument.spreadsheetml.sheet&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20210622T151608Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Credential=AKIAIEJ3NV7UYCSRJC7A%2F20210622%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=d962b03efbdb108d2c4f7f70e480a0ec93fde3cc9eefe98cbccebf094283a714
+  response:
+    body:
+      string: !!binary |
+        UEsDBBQABgAIAAAAIQDA14IQxQEAAMUKAAATAL4BW0NvbnRlbnRfVHlwZXNdLnhtbCCiugEooAAC
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Disposition:
+      - attachment; filename*=UTF-8''Karnataka_DD%26FS_Data-1.xlsx
+      Content-Length:
+      - '101'
+      Content-Range:
+      - bytes 0-100/700840
+      Content-Type:
+      - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+      Date:
+      - Tue, 22 Jun 2021 15:16:09 GMT
+      ETag:
+      - '"ca9dea905295ac52db4ea3c7c8bf00e9"'
+      Last-Modified:
+      - Thu, 15 Nov 2018 16:01:47 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - kPgnTJVuOxKvy4oXYsomvWW5XvXi1w93QORrnkVFYYpiZOkkc6wtbg1ey3pWgPtJP8fUKaQW9ao=
+      x-amz-replication-status:
+      - COMPLETED
+      x-amz-request-id:
+      - MJ102H67W1DRK0GX
+      x-amz-version-id:
+      - 8Uv3Yrd.dfBXa57kWF6KNDwyWs06bgpF
+    status:
+      code: 206
+      message: Partial Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: HEAD
     uri: https://dataverse.harvard.edu/api/access/datafile/3315157
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-control: [no-cache="set-cookie"]
-      Connection: [Close]
-      Content-Length: ['2408']
-      Content-Type: [text/tab-separated-values; name="Karnataka_DD&FS_Data-1.tab"]
-      Content-disposition: [attachment; filename="Karnataka_DD&FS_Data-1.tab"]
-      Date: ['Thu, 06 Dec 2018 13:19:09 GMT']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [JSESSIONID=3ac09766d4c834a0e920f643c2ac; Path=/; Secure; HttpOnly,
-        AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3CF6A1B0A2CD5F2F144400DE0E06A10F0DBD3EC37C4E69D8B958E3FBF8CF81403222DF6AABE0F6509EF79AB1D548B7265;PATH=/;MAX-AGE=28800]
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Headers:
+      - Accept, Content-Type, X-Dataverse-Key
+      Access-Control-Allow-Methods:
+      - PUT, GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2408'
+      Content-Type:
+      - text/tab-separated-values; name="Karnataka_DD%26FS_Data-1.tab";charset=UTF-8
+      Content-disposition:
+      - attachment; filename="Karnataka_DD%26FS_Data-1.tab"
+      Date:
+      - Tue, 22 Jun 2021 15:16:09 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=7m9lN9/l2OQedlOEs5v8TrhpR96/tok9P+B2oH3XNpKgUmw40QT8i8kjtquZ6lrXklvKPCfUalP0oWJfpqzk+yIzlw+IQi5BB/x8fyQmzr1mMsjNYCLUaPm+9XM7;
+        Expires=Tue, 29 Jun 2021 15:16:09 GMT; Path=/
+      - AWSALBCORS=7m9lN9/l2OQedlOEs5v8TrhpR96/tok9P+B2oH3XNpKgUmw40QT8i8kjtquZ6lrXklvKPCfUalP0oWJfpqzk+yIzlw+IQi5BB/x8fyQmzr1mMsjNYCLUaPm+9XM7;
+        Expires=Tue, 29 Jun 2021 15:16:09 GMT; Path=/; SameSite=None; Secure
+      - JSESSIONID=44b038800631504a425138af9217; Path=/; Secure; HttpOnly
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.19.1]
-    method: GET
-    uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22https%3A%2F%2Fdataverse.harvard.edu%2Fapi%2Faccess%2Fdatafile%2F3040230%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
-  response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"https://dataverse.harvard.edu/api/access/datafile/3040230\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":0,"start":0,"docs":[]}}
-
-'}
-    headers:
-      Access-Control-Allow-Credentials: ['true']
-      Access-Control-Allow-Headers: ['Authorization, Content-Type, Location, Content-Length,
-          x-annotator-auth-token']
-      Access-Control-Allow-Methods: ['POST, GET, OPTIONS, PUT, DELETE']
-      Access-Control-Allow-Origin: ['']
-      Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=UTF-8]
-      Date: ['Thu, 06 Dec 2018 13:19:09 GMT']
-      Keep-Alive: ['timeout=5, max=100']
-      Server: [Apache/2.4.7 (Ubuntu)]
-      Transfer-Encoding: [chunked]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Connection: [close]
-      Host: [dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
-    method: GET
-    uri: https://dataverse.harvard.edu/api/search?q=entityId:3040230
-  response:
-    body: {string: '{"status":"OK","data":{"q":"entityId:3040230","total_count":1,"start":0,"spelling_alternatives":{},"items":[{"name":"2017-07-31.tab","type":"file","url":"https://dataverse.harvard.edu/api/access/datafile/3040230","file_id":"3040230","published_at":"2017-07-31T22:27:23Z","file_type":"Tab-Delimited","file_content_type":"text/tab-separated-values","size_in_bytes":12025,"md5":"e7dd2f725941b978d45fed3f33ff640c","checksum":{"type":"MD5","value":"e7dd2f725941b978d45fed3f33ff640c"},"unf":"UNF:6:6wGE3C5ragT8A0qkpGaEaQ==","dataset_citation":"Durbin,
-        Philip, 2017, \"Open Source at Harvard\", https://doi.org/10.7910/DVN/TJCLKP,
-        Harvard Dataverse, V2, UNF:6:6wGE3C5ragT8A0qkpGaEaQ== [fileUNF]"}],"count_in_response":1}}'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-control: [no-cache="set-cookie"]
-      Connection: [Close]
-      Content-Length: ['714']
-      Content-Type: [application/json]
-      Date: ['Thu, 06 Dec 2018 13:19:09 GMT']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3FE010BDBAE7AE7E438B31BFA0246B9F2DBD3EC37C4E69D8B958E3FBF8CF814030B5CB9749AB70FE33A8BB5BB36A149CB;PATH=/;MAX-AGE=28800]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Connection: [close]
-      Host: [dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: HEAD
     uri: https://dataverse.harvard.edu/api/access/datafile/3040230?format=original
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-control: [no-cache="set-cookie"]
-      Connection: [Close]
-      Content-Length: ['11684']
-      Content-Type: [text/csv; name="2017-07-31.csv"]
-      Content-disposition: [attachment; filename="2017-07-31.csv"]
-      Date: ['Thu, 06 Dec 2018 13:19:10 GMT']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [JSESSIONID=3ac0e9ec9b71f3f2deeaff7ea1d7; Path=/; Secure; HttpOnly,
-        AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3CF6A1B0A2CD5F2F144400DE0E06A10F0DBD3EC37C4E69D8B958E3FBF8CF81403222DF6AABE0F6509EF79AB1D548B7265;PATH=/;MAX-AGE=28800]
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Headers:
+      - Accept, Content-Type, X-Dataverse-Key
+      Access-Control-Allow-Methods:
+      - PUT, GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml;charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 15:16:09 GMT
+      Location:
+      - https://dvn-cloud.s3.amazonaws.com/10.7910/DVN/TJCLKP/15d9aaf2757-ed846fe49d13.orig?response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%272017-07-31.csv&response-content-type=text%2Fcsv&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20210622T151609Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3599&X-Amz-Credential=AKIAIEJ3NV7UYCSRJC7A%2F20210622%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=3bd033976719f99a64e63ce5246a8202bfa99434060afd47f3ca39671aafc53a
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=2snTKLv6Ch8ZNRS117bglqpygKE/7lpSF+QG6M4BWMTMZ/xSb8TjEsCj3wBt7nHZ+e0jA1P04Gdd0Pv67ewixfs1kP1HdAXkZSc0qLOhWI4VnIN90I6YUtMg/+X5;
+        Expires=Tue, 29 Jun 2021 15:16:09 GMT; Path=/
+      - AWSALBCORS=2snTKLv6Ch8ZNRS117bglqpygKE/7lpSF+QG6M4BWMTMZ/xSb8TjEsCj3wBt7nHZ+e0jA1P04Gdd0Pv67ewixfs1kP1HdAXkZSc0qLOhWI4VnIN90I6YUtMg/+X5;
+        Expires=Tue, 29 Jun 2021 15:16:09 GMT; Path=/; SameSite=None; Secure
+      - JSESSIONID=44b059355df094fc31cf9dfc6c3b; Path=/; Secure; HttpOnly
+    status:
+      code: 303
+      message: See Other
 - request:
     body: null
     headers:
-      Connection: [close]
-      Host: [dataverse.harvard.edu]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: HEAD
+    uri: https://dvn-cloud.s3.amazonaws.com/10.7910/DVN/TJCLKP/15d9aaf2757-ed846fe49d13.orig?response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%272017-07-31.csv&response-content-type=text%2Fcsv&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20210622T151609Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3599&X-Amz-Credential=AKIAIEJ3NV7UYCSRJC7A%2F20210622%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=3bd033976719f99a64e63ce5246a8202bfa99434060afd47f3ca39671aafc53a
+  response:
+    body:
+      string: ''
+    headers:
+      Content-Type:
+      - application/xml
+      Date:
+      - Tue, 22 Jun 2021 15:16:09 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - jI1JlOfxvQum6E7Jmk5muWKmOXvg9xH5JFLzm6zGOajH53YE3o36a0XGTNZJrkCg/iW7W8DmxGI=
+      x-amz-request-id:
+      - H8WYF9QP17CX7P3C
+    status:
+      code: 403
+      message: Forbidden
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Range:
+      - bytes=0-100
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dataverse.harvard.edu/api/access/datafile/3040230?format=original
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept, Content-Type, X-Dataverse-Key
+      Access-Control-Allow-Methods:
+      - PUT, GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Tue, 22 Jun 2021 15:16:10 GMT
+      Location:
+      - https://dvn-cloud.s3.amazonaws.com/10.7910/DVN/TJCLKP/15d9aaf2757-ed846fe49d13.orig?response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%272017-07-31.csv&response-content-type=text%2Fcsv&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20210622T151610Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Credential=AKIAIEJ3NV7UYCSRJC7A%2F20210622%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=08db7a91c80b9556959ebdc0f500e7bb41609acc4c6544e02c8c1585a3753dfd
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=CwNwaxK9CnOozv/wGYcWvLm0hMaSS6wXMsvEuiBKqq2wxO6k1PvnBDEpvxZmEnhZJXBijla3Z9TN8rI97bCJ0WHi4Nq0rZJc+u4yQSlk/oBx5EWoS8aSXgSytDvZ;
+        Expires=Tue, 29 Jun 2021 15:16:10 GMT; Path=/
+      - AWSALBCORS=CwNwaxK9CnOozv/wGYcWvLm0hMaSS6wXMsvEuiBKqq2wxO6k1PvnBDEpvxZmEnhZJXBijla3Z9TN8rI97bCJ0WHi4Nq0rZJc+u4yQSlk/oBx5EWoS8aSXgSytDvZ;
+        Expires=Tue, 29 Jun 2021 15:16:10 GMT; Path=/; SameSite=None; Secure
+      - JSESSIONID=44b08e1b2c7396f5d1cd72a913db; Path=/; Secure; HttpOnly
+    status:
+      code: 303
+      message: See Other
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Range:
+      - bytes=0-100
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dvn-cloud.s3.amazonaws.com/10.7910/DVN/TJCLKP/15d9aaf2757-ed846fe49d13.orig?response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%272017-07-31.csv&response-content-type=text%2Fcsv&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20210622T151610Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Credential=AKIAIEJ3NV7UYCSRJC7A%2F20210622%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=08db7a91c80b9556959ebdc0f500e7bb41609acc4c6544e02c8c1585a3753dfd
+  response:
+    body:
+      string: 'stars,language,updated,issues,size,forks,watchers,repo,created,description
+
+        196,Java,2017-07-31,692,53'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Disposition:
+      - attachment; filename*=UTF-8''2017-07-31.csv
+      Content-Length:
+      - '101'
+      Content-Range:
+      - bytes 0-100/11684
+      Content-Type:
+      - text/csv
+      Date:
+      - Tue, 22 Jun 2021 15:16:12 GMT
+      ETag:
+      - '"e7dd2f725941b978d45fed3f33ff640c"'
+      Last-Modified:
+      - Tue, 13 Feb 2018 10:29:39 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - H0y2WpL5heyLWeutuU7BZ7EpQw/DBSFUXW3p0JRioXsK9a6C/mf/mvPQf7WshiNJTC2unYKCQIE=
+      x-amz-meta-touched:
+      - 'true'
+      x-amz-replication-status:
+      - COMPLETED
+      x-amz-request-id:
+      - BE1D0BN548VWGHHM
+      x-amz-version-id:
+      - a21WUb4tKN1QOmLladm_DSqEFmWTanqm
+    status:
+      code: 206
+      message: Partial Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: HEAD
     uri: https://dataverse.harvard.edu/api/access/datafile/3040230
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-control: [no-cache="set-cookie"]
-      Connection: [Close]
-      Content-Length: ['12100']
-      Content-Type: [text/tab-separated-values; name="2017-07-31.tab"]
-      Content-disposition: [attachment; filename="2017-07-31.tab"]
-      Date: ['Thu, 06 Dec 2018 13:19:10 GMT']
-      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips]
-      Set-Cookie: [JSESSIONID=3ac10d17a89af26e6f1deb61f395; Path=/; Secure; HttpOnly,
-        AWSELB=EB1179591E49E298C6825A3028F74991071DEE12D3FE010BDBAE7AE7E438B31BFA0246B9F2DBD3EC37C4E69D8B958E3FBF8CF814030B5CB9749AB70FE33A8BB5BB36A149CB;PATH=/;MAX-AGE=28800]
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Headers:
+      - Accept, Content-Type, X-Dataverse-Key
+      Access-Control-Allow-Methods:
+      - PUT, GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '12100'
+      Content-Type:
+      - text/tab-separated-values; name="2017-07-31.tab";charset=UTF-8
+      Content-disposition:
+      - attachment; filename="2017-07-31.tab"
+      Date:
+      - Tue, 22 Jun 2021 15:16:11 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - AWSALB=zAi3js0go+YxAxdeWhBnpicAMvVM/XPsFX/PICK7ucjVuCRGru1g3Nn1t9NMNYV2mdkf2yy6MfSwpQv8o89NsTfZvA2SMW/KFPcbtaP+iwS5sAKu2LPbb1aNz7Mj;
+        Expires=Tue, 29 Jun 2021 15:16:11 GMT; Path=/
+      - AWSALBCORS=zAi3js0go+YxAxdeWhBnpicAMvVM/XPsFX/PICK7ucjVuCRGru1g3Nn1t9NMNYV2mdkf2yy6MfSwpQv8o89NsTfZvA2SMW/KFPcbtaP+iwS5sAKu2LPbb1aNz7Mj;
+        Expires=Tue, 29 Jun 2021 15:16:11 GMT; Path=/; SameSite=None; Secure
+      - JSESSIONID=44b0bf945cc6975f86f4d8eb6c14; Path=/; Secure; HttpOnly
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/plugin_tests/data/dataverse_single.txt
+++ b/plugin_tests/data/dataverse_single.txt
@@ -2,149 +2,111 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.19.1]
-    method: GET
-    uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22https%3A%2F%2Fdemo.dataverse.org%2Fapi%2Faccess%2Fdatafile%2F300662%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
-  response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"https://demo.dataverse.org/api/access/datafile/300662\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":0,"start":0,"docs":[]}}
-
-'}
-    headers:
-      Access-Control-Allow-Credentials: ['true']
-      Access-Control-Allow-Headers: ['Authorization, Content-Type, Location, Content-Length,
-          x-annotator-auth-token']
-      Access-Control-Allow-Methods: ['POST, GET, OPTIONS, PUT, DELETE']
-      Access-Control-Allow-Origin: ['']
-      Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=UTF-8]
-      Date: ['Fri, 23 Nov 2018 17:15:12 GMT']
-      Keep-Alive: ['timeout=5, max=100']
-      Server: [Apache/2.4.7 (Ubuntu)]
-      Transfer-Encoding: [chunked]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Connection: [close]
-      Host: [demo.dataverse.org]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: GET
     uri: https://demo.dataverse.org/api/info/version
   response:
-    body: {string: '{"status":"OK","data":{"version":"4.9.4","build":"1058-57b3b7e"}}'}
+    body:
+      string: '{"status":"OK","data":{"version":"5.5","build":"477-5fc0150"}}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Connection: [close]
-      Content-Length: ['65']
-      Content-Type: [application/json]
-      Date: ['Fri, 23 Nov 2018 17:15:13 GMT']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Headers:
+      - Accept, Content-Type, X-Dataverse-Key
+      Access-Control-Allow-Methods:
+      - PUT, GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 15:18:12 GMT
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Connection: [close]
-      Host: [demo.dataverse.org]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: GET
-    uri: https://demo.dataverse.org/api/search?q=entityId:300662
+    uri: https://demo.dataverse.org/api/search?q=entityId:1849559
   response:
-    body: {string: '{"status":"OK","data":{"q":"entityId:300662","total_count":1,"start":0,"spelling_alternatives":{},"items":[{"name":"citation.tab","type":"file","url":"https://demo.dataverse.org/api/access/datafile/300662","file_id":"300662","published_at":"2018-11-15T18:03:39Z","file_type":"Tab-Delimited","file_content_type":"text/tab-separated-values","size_in_bytes":36843,"md5":"de6b320f891115ce23d7a4b28727ebdb","checksum":{"type":"MD5","value":"de6b320f891115ce23d7a4b28727ebdb"},"unf":"UNF:6:TKPMHywLQ/mUjLTNYTskAQ==","dataset_citation":"Gautier,
-        Julian, 2018, \"Variable-level metadata always accessible\", https://doi.org/10.5072/FK2/N7YHEY,
-        Demo Dataverse, V2, UNF:6:TKPMHywLQ/mUjLTNYTskAQ== [fileUNF]"}],"count_in_response":1}}'}
+    body:
+      string: '{"status":"OK","data":{"q":"entityId:1849559","total_count":1,"start":0,"spelling_alternatives":{},"items":[{"name":"images.jpg","type":"file","url":"https://demo.dataverse.org/api/access/datafile/1849559","file_id":"1849559","published_at":"2021-05-10T15:27:01Z","file_type":"JPEG
+        Image","file_content_type":"image/jpeg","size_in_bytes":4750,"md5":"539aed1a281c58fa736e21b9d77fda70","checksum":{"type":"MD5","value":"539aed1a281c58fa736e21b9d77fda70"},"file_persistent_id":"doi:10.70122/FK2/H60OIK/NIZROI","dataset_name":"test
+        file access by version","dataset_id":"1849558","dataset_persistent_id":"doi:10.70122/FK2/H60OIK","dataset_citation":"Admin,
+        Dataverse, 2021, \"test file access by version\", https://doi.org/10.70122/FK2/H60OIK,
+        Demo Dataverse, V1"}],"count_in_response":1}}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Connection: [close]
-      Content-Length: ['723']
-      Content-Type: [application/json]
-      Date: ['Fri, 23 Nov 2018 17:15:13 GMT']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Headers:
+      - Accept, Content-Type, X-Dataverse-Key
+      Access-Control-Allow-Methods:
+      - PUT, GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '784'
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 15:18:13 GMT
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.19.1]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
     method: GET
-    uri: https://cn.dataone.org/cn/v2/query/solr/?q=identifier:%22https%3A%2F%2Fdemo.dataverse.org%2Fapi%2Faccess%2Fdatafile%2F300662%22&fl=identifier,formatType,formatId,resourceMap&rows=1000&start=0&wt=json
+    uri: https://demo.dataverse.org/api/search?q=entityId:1849559
   response:
-    body: {string: '{"responseHeader":{"status":0,"QTime":3,"params":{"q":"identifier:\"https://demo.dataverse.org/api/access/datafile/300662\"","fl":"identifier,formatType,formatId,resourceMap","start":"0","rows":"1000","wt":"json"}},"response":{"numFound":0,"start":0,"docs":[]}}
-
-'}
+    body:
+      string: '{"status":"OK","data":{"q":"entityId:1849559","total_count":1,"start":0,"spelling_alternatives":{},"items":[{"name":"images.jpg","type":"file","url":"https://demo.dataverse.org/api/access/datafile/1849559","file_id":"1849559","published_at":"2021-05-10T15:27:01Z","file_type":"JPEG
+        Image","file_content_type":"image/jpeg","size_in_bytes":4750,"md5":"539aed1a281c58fa736e21b9d77fda70","checksum":{"type":"MD5","value":"539aed1a281c58fa736e21b9d77fda70"},"file_persistent_id":"doi:10.70122/FK2/H60OIK/NIZROI","dataset_name":"test
+        file access by version","dataset_id":"1849558","dataset_persistent_id":"doi:10.70122/FK2/H60OIK","dataset_citation":"Admin,
+        Dataverse, 2021, \"test file access by version\", https://doi.org/10.70122/FK2/H60OIK,
+        Demo Dataverse, V1"}],"count_in_response":1}}'
     headers:
-      Access-Control-Allow-Credentials: ['true']
-      Access-Control-Allow-Headers: ['Authorization, Content-Type, Location, Content-Length,
-          x-annotator-auth-token']
-      Access-Control-Allow-Methods: ['POST, GET, OPTIONS, PUT, DELETE']
-      Access-Control-Allow-Origin: ['']
-      Access-Control-Expose-Headers: ['Content-Length, Content-Type, Location']
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=UTF-8]
-      Date: ['Fri, 23 Nov 2018 17:15:13 GMT']
-      Keep-Alive: ['timeout=5, max=100']
-      Server: [Apache/2.4.7 (Ubuntu)]
-      Transfer-Encoding: [chunked]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Connection: [close]
-      Host: [demo.dataverse.org]
-      User-Agent: [Python-urllib/3.6]
-    method: GET
-    uri: https://demo.dataverse.org/api/search?q=entityId:300662
-  response:
-    body: {string: '{"status":"OK","data":{"q":"entityId:300662","total_count":1,"start":0,"spelling_alternatives":{},"items":[{"name":"citation.tab","type":"file","url":"https://demo.dataverse.org/api/access/datafile/300662","file_id":"300662","published_at":"2018-11-15T18:03:39Z","file_type":"Tab-Delimited","file_content_type":"text/tab-separated-values","size_in_bytes":36843,"md5":"de6b320f891115ce23d7a4b28727ebdb","checksum":{"type":"MD5","value":"de6b320f891115ce23d7a4b28727ebdb"},"unf":"UNF:6:TKPMHywLQ/mUjLTNYTskAQ==","dataset_citation":"Gautier,
-        Julian, 2018, \"Variable-level metadata always accessible\", https://doi.org/10.5072/FK2/N7YHEY,
-        Demo Dataverse, V2, UNF:6:TKPMHywLQ/mUjLTNYTskAQ== [fileUNF]"}],"count_in_response":1}}'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Connection: [close]
-      Content-Length: ['723']
-      Content-Type: [application/json]
-      Date: ['Fri, 23 Nov 2018 17:15:14 GMT']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Connection: [close]
-      Host: [demo.dataverse.org]
-      User-Agent: [Python-urllib/3.6]
-    method: HEAD
-    uri: https://demo.dataverse.org/api/access/datafile/300662?format=original
-  response:
-    body: {string: ''}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Connection: [close]
-      Content-Length: ['26465']
-      Content-Type: [application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;
-          name="citation.xlsx"]
-      Content-disposition: [attachment; filename="citation.xlsx"]
-      Date: ['Fri, 23 Nov 2018 17:15:14 GMT']
-      Set-Cookie: [JSESSIONID=191825fa1098e1cdd88c950d43cd; Path=/; Secure; HttpOnly]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Connection: [close]
-      Host: [demo.dataverse.org]
-      User-Agent: [Python-urllib/3.6]
-    method: HEAD
-    uri: https://demo.dataverse.org/api/access/datafile/300662
-  response:
-    body: {string: ''}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Connection: [close]
-      Content-Length: ['36920']
-      Content-Type: [text/tab-separated-values; name="citation.tab"]
-      Content-disposition: [attachment; filename="citation.tab"]
-      Date: ['Fri, 23 Nov 2018 17:15:14 GMT']
-      Set-Cookie: [JSESSIONID=191835a87513fc1725fddf3cbec4; Path=/; Secure; HttpOnly]
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Headers:
+      - Accept, Content-Type, X-Dataverse-Key
+      Access-Control-Allow-Methods:
+      - PUT, GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '784'
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 22 Jun 2021 15:18:13 GMT
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/server/lib/http_provider.py
+++ b/server/lib/http_provider.py
@@ -8,7 +8,6 @@ from girder.utility.model_importer import ModelImporter
 from girder.models.folder import Folder
 
 from .import_providers import ImportProvider
-from .resolvers import DOIResolver
 from .entity import Entity
 from .data_map import DataMap
 from .file_map import FileMap
@@ -22,7 +21,7 @@ class HTTPImportProvider(ImportProvider):
         return re.compile(r'^http(s)?://.*')
 
     def lookup(self, entity: Entity) -> DataMap:
-        pid = DOIResolver.follow_redirects(entity.getValue())
+        pid = requests.head(entity.getValue(), allow_redirects=True).url
         url = urlparse(pid)
         if url.scheme not in ('http', 'https'):
             # This should be redundant. This should only be called if matches()


### PR DESCRIPTION
Multiple issue related to registering data from DV crept up. Mostly due to the fact that we are using "prerecorded" request responses in our test suite. Some of the issues can be solved on our end:

1. Urlib requests to DV result in 403 for some reason. Solution: switch to requests
2. DV started to encode filenames in `Content-Disposition` headers, but they're doing it in two different ways (see https://github.com/IQSS/dataverse/issues/7962). Solution: decode...

Remaining issue causing breakage is isolated to Harvard's DV instance. Namely, search with query parameter `entityId` is not working there properly. I filed a ticket about it but unfortunately it's on a private tracker.