### PR TITLE
Enable AinWT for non-tale datasets from Zenodo

### DIFF
--- a/plugin_tests/zenodo_test.py
+++ b/plugin_tests/zenodo_test.py
@@ -311,7 +311,27 @@ class ZenodoHarversterTestCase(base.TestCase):
                 "doi:10.5281/zenodo.3463499",
             )
 
-    def test_analyze_in_wt(self):
+    def test_import_binder(self):
+        resp = self.request(
+            path="/integration/zenodo",
+            method="GET",
+            user=self.user,
+            params={
+                "record_id": "5092301",
+                "resource_server": "zenodo.org",
+            },
+            isJson=False,
+        )
+
+        self.assertTrue("Location" in resp.headers)
+        location = urlparse(resp.headers["Location"])
+        self.assertEqual(location.netloc, "dashboard.wholetale.org")
+        qs = parse_qs(location.query)
+        self.assertTrue(qs["asTale"][0])
+        self.assertTrue(qs["name"][0].startswith("antonninkov/ISSI2021"))
+        self.assertEqual(qs["uri"], ["https://zenodo.org/record/5092301"])
+
+    def test_import_tale(self):
         from girder.plugins.wholetale.models.tale import Tale
         from girder.plugins.oauth.constants import PluginSettings as OAuthSettings
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 # dependencies for tests
 vcrpy
 bdbag
+responses

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ jsonpickle==1.5.2  # see #447
 python-magic
 requests
 redis==3.5.3
-git+https://github.com/whole-tale/girderfs@v1.0#egg=girderfs
-git+https://github.com/whole-tale/gwvolman@v1.0#egg=gwvolman
+git+https://github.com/whole-tale/girderfs@master#egg=girderfs
+git+https://github.com/whole-tale/gwvolman@master#egg=gwvolman
 dataone.common==3.4.7
 dataone.libclient==3.4.7
 dataone.cli==3.4.7

--- a/server/lib/dataone/integration.py
+++ b/server/lib/dataone/integration.py
@@ -68,7 +68,7 @@ def dataoneDataImport(self, uri, title, environment, api, apiToken, force):
     dashboard_url = os.environ.get('DASHBOARD_URL', 'https://dashboard.wholetale.org')
     location = urlunparse(
         urlparse(dashboard_url)._replace(
-            path='/browse',
+            path='/mine',
             query=urlencode(query))
     )
     setResponseHeader('Location', location)

--- a/server/lib/dataverse/integration.py
+++ b/server/lib/dataverse/integration.py
@@ -156,7 +156,7 @@ def dataverseExternalTools(
     # TODO: Make base url a plugin setting, defaulting to dashboard.<domain>
     dashboard_url = os.environ.get("DASHBOARD_URL", "https://dashboard.wholetale.org")
     location = urlunparse(
-        urlparse(dashboard_url)._replace(path="/browse", query=urlencode(query))
+        urlparse(dashboard_url)._replace(path="/mine", query=urlencode(query))
     )
     setResponseHeader("Location", location)
     cherrypy.response.status = 303

--- a/server/lib/zenodo/__init__.py
+++ b/server/lib/zenodo/__init__.py
@@ -1,0 +1,13 @@
+class ZenodoNotATaleError(Exception):
+    """Exception raised if Zenodo record is not a Tale.
+
+    Attributes:
+        record - JSON structure describing the Zenodo record
+        message - explanation of the error
+
+    """
+
+    def __init__(self, record, message="Zenodo record ({}) is not a Tale"):
+        self.record = record
+        self.message = message.format(record["links"]["html"])
+        super().__init__(self.message)

--- a/server/lib/zenodo/integration.py
+++ b/server/lib/zenodo/integration.py
@@ -69,7 +69,7 @@ def zenodoDataImport(self, doi, record_id, resource_server, environment, force):
     except ZenodoNotATaleError as exc:
         query = {"uri": url, "asTale": True, "name": exc.record["metadata"]["title"]}
         location = urlunparse(
-            urlparse(dashboard_url)._replace(path="/browse", query=urlencode(query))
+            urlparse(dashboard_url)._replace(path="/mine", query=urlencode(query))
         )
     except Exception as exc:
         raise RestException(

--- a/server/lib/zenodo/integration.py
+++ b/server/lib/zenodo/integration.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 import cherrypy
 import os
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse, urlunparse, urlencode
 
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import boundHandler, RestException
-from girder.exceptions import GirderException
 
+from . import ZenodoNotATaleError
 from .. import IMPORT_PROVIDERS
 from ..integration_utils import autologin
 
@@ -54,21 +54,26 @@ def zenodoDataImport(self, doi, record_id, resource_server, environment, force):
         }
         autologin(args=args)
 
+    # TODO: Make base url a plugin setting, defaulting to dashboard.<domain>
+    dashboard_url = os.environ.get("DASHBOARD_URL", "https://dashboard.wholetale.org")
     url = "https://{}/record/{}".format(resource_server, record_id)
     provider = IMPORT_PROVIDERS.providerMap["Zenodo"]
     try:
         tale = provider.import_tale(url, user, force=force)
-    except GirderException as exc:
+        location = urlunparse(
+            urlparse(dashboard_url)._replace(
+                path="/run/{}".format(tale["_id"]),
+                query="token={}".format(self.getCurrentToken()["_id"]),
+            )
+        )
+    except ZenodoNotATaleError as exc:
+        query = {"uri": url, "asTale": True, "name": exc.record["metadata"]["title"]}
+        location = urlunparse(
+            urlparse(dashboard_url)._replace(path="/browse", query=urlencode(query))
+        )
+    except Exception as exc:
         raise RestException(
             f"Failed to import Tale. Server returned: '{str(exc)}'"
         )
 
-    # TODO: Make base url a plugin setting, defaulting to dashboard.<domain>
-    dashboard_url = os.environ.get("DASHBOARD_URL", "https://dashboard.wholetale.org")
-    location = urlunparse(
-        urlparse(dashboard_url)._replace(
-            path="/run/{}".format(tale["_id"]),
-            query="token={}".format(self.getCurrentToken()["_id"]),
-        )
-    )
     raise cherrypy.HTTPRedirect(location)

--- a/server/lib/zenodo/provider.py
+++ b/server/lib/zenodo/provider.py
@@ -15,6 +15,7 @@ from ..import_item import ImportItem
 from ..entity import Entity
 from ... import constants
 from ...models.tale import Tale
+from . import ZenodoNotATaleError
 
 
 class ZenodoImportProvider(ImportProvider):
@@ -87,9 +88,7 @@ class ZenodoImportProvider(ImportProvider):
             return Tale().load(existing_tale_id["_id"], user=user)
 
         if not self._is_tale(record):
-            raise ValueError(
-                "{} doesn't look like a Tale.".format(record["links"]["record_html"])
-            )
+            raise ZenodoNotATaleError(record)
 
         file_ref = record["files"][0]
         if file_ref["type"] != "zip":

--- a/server/tasks/import_binder.py
+++ b/server/tasks/import_binder.py
@@ -20,7 +20,7 @@ from fs.permissions import Permissions
 from fs.tarfs import ReadTarFS
 from fs.zipfs import ReadZipFS
 from girder import events
-from girderfs.core import WtDmsGirderFS
+from girderfs.dms import WtDmsGirderFS
 from girder_client import GirderClient
 from girder.constants import AccessType
 from girder.models.folder import Folder


### PR DESCRIPTION
Prior to this PR we could only import Tales from Zenodo in AinWT workflow. This PR adds the missing component that triggers `import_binder` for non-tale datasets similarly to DV and DataONE integrations.