### PR TITLE
Allow user to relinquish access to a Tale. Fixes #503

### DIFF
--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -17,6 +17,7 @@ import shutil
 from tests import base
 
 from .tests_helpers import mockOtherRequest, get_events
+from girder.constants import AccessType
 from girder.models.item import Item
 from girder.exceptions import ValidationException
 from girder.models.folder import Folder
@@ -262,8 +263,6 @@ class TaleTestCase(base.TestCase):
             )
             self.assertStatusOk(resp)
             tale_admin_image = resp.json
-
-        from girder.constants import AccessType
 
         # Retrieve access control list for the newly created tale
         resp = self.request(
@@ -566,8 +565,6 @@ class TaleTestCase(base.TestCase):
         self.assertStatus(resp, 200)
 
     def testExport(self):
-        from server.lib.license import WholeTaleLicense
-
         resp = self.request(
             path='/tale', method='POST', user=self.user,
             type='application/json',
@@ -1137,6 +1134,63 @@ class TaleWithWorkspaceTestCase(base.TestCase):
             else:
                 self.assertEqual(tale[key], restored_tale[key])
         Tale().remove(tale)
+
+    def test_relinquish(self):
+        resp = self.request(
+            path='/tale', method='POST', user=self.admin,
+            type='application/json',
+            body=json.dumps({
+                'imageId': str(self.image['_id']),
+                'dataSet': []
+            })
+        )
+        self.assertStatusOk(resp)
+        tale = resp.json
+
+        # get ACL
+        resp = self.request(
+            path=f"/tale/{tale['_id']}/access", method="GET", user=self.admin,
+        )
+        self.assertStatusOk(resp)
+        acls = resp.json
+
+        # add user
+        user_acl = {
+            "flags": [],
+            "id": str(self.user["_id"]),
+            "level": AccessType.READ,
+            "login": self.user["login"],
+            "name": f"{self.user['firstName']} {self.user['lastName']}"
+        }
+        acls["users"].append(user_acl)
+        resp = self.request(
+            path=f"/tale/{tale['_id']}/access", method="PUT", user=self.admin,
+            params={"access": json.dumps(acls)}
+        )
+
+        resp = self.request(
+            path=f"/tale/{tale['_id']}", method="GET", user=self.user,
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json["_accessLevel"], AccessType.READ)
+
+        # I don't want it!
+        resp = self.request(
+            path=f"/tale/{tale['_id']}/relinquish", method="PUT", user=self.user,
+            isJson=False,
+        )
+        self.assertStatus(resp, 204)
+
+        resp = self.request(
+            path=f"/tale/{tale['_id']}", method="GET", user=self.user,
+        )
+        self.assertStatus(resp, 403)
+
+        # Drop it
+        resp = self.request(
+            path=f"/tale/{tale['_id']}", method="DELETE", user=self.admin,
+        )
+        self.assertStatusOk(resp)
 
     def tearDown(self):
         self.model('user').remove(self.user)

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -326,6 +326,30 @@ class Tale(AccessControlledModel):
 
         return doc
 
+    def setUserAccess(
+        self, doc, user, level, save=False, flags=None, currentUser=None, force=False
+    ):
+        if level is None:
+            event_type = "wt_tale_unshared"
+        else:
+            event_type = "wt_tale_shared"
+
+        if "_id" in doc:  # During creation of Tale it's not there yet.
+            notify_event([user["_id"]], event_type, {"taleId": str(doc["_id"])})
+            for folder in Folder().find({"meta.taleId": str(doc["_id"])}):
+                Folder().setUserAccess(
+                    folder,
+                    user,
+                    level,
+                    save=save,
+                    flags=flags,
+                    currentUser=currentUser,
+                    force=force
+                )
+        return super().setUserAccess(
+            doc, user, level, save=save, flags=flags, currentUser=currentUser, force=force
+        )
+
     def buildImage(self, tale, user, force=False):
         """
         Build the image for the tale


### PR DESCRIPTION
### How to test?

1. Create 2 users.
2. [user1] Create a tale and share it with `user2` (access level doesn't matter)
3. [user2] Login to dashboard and confirm you have access to the tale in "shared with me"
4. [user2] Using swagger call `PUT /tale/:id/relinquish`
5. [user2] Confirm the Tale is gone from "Shared with me"
6. [user1] Confirm that `user2` is no longer in *Collaborators* in Tale view > share panel. 