### PR TITLE
Set 'samesite' to None for sign_in cookies

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -304,6 +304,8 @@ def signIn(self, redirect):
         raise cherrypy.HTTPRedirect(oauth_providers["Globus"])
     else:
         self.sendAuthTokenCookie(user=user, token=token)
+        cookie = cherrypy.response.cookie
+        cookie["girderToken"].update({"samesite": None})
         raise cherrypy.HTTPRedirect(redirect)
 
 


### PR DESCRIPTION
To work properly it also requires `secure` attribute (preferably set to True). It's already being handled by girder proper. Just do:

```
PUT /system/setting?key=core.secure_cookie&value=true
```