### PR TITLE
Export recorded runs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: craigwillis/girder:rrevents
+      - image: wholetale/girder:latest
       - image: mongo:3.4
     steps:
       - checkout

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: wholetale/girder:latest
+      - image: craigwillis/girder:rrevents
       - image: mongo:3.4
     steps:
       - checkout

--- a/plugin_tests/dataverse_test.py
+++ b/plugin_tests/dataverse_test.py
@@ -18,6 +18,7 @@ DATA_PATH = os.path.join(
 def setUpModule():
     base.enabledPlugins.append('wholetale')
     base.enabledPlugins.append('wt_home_dir')
+    base.enabledPlugins.append('wt_versioning')
     base.startServer()
 
 

--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -13,6 +13,7 @@ def setUpModule():
     base.enabledPlugins.append("virtual_resources")
     base.enabledPlugins.append("wholetale")
     base.enabledPlugins.append("wt_home_dir")
+    base.enabledPlugins.append("wt_versioning")
     base.startServer()
 
 

--- a/server/lib/exporters/bag.py
+++ b/server/lib/exporters/bag.py
@@ -97,9 +97,9 @@ class BagTaleExporter(TaleExporter):
         oxum = dict(size=0, num=0)
 
         # Add files from the workspace computing their checksum
-        for fullpath, relpath in self.list_workspace():
+        for fullpath, relpath in self.list_files():
             yield from self.dump_and_checksum(
-                self.bytes_from_file(fullpath), 'data/workspace/' + relpath
+                self.bytes_from_file(fullpath), 'data/' + relpath
             )
             oxum["num"] += 1
             oxum["size"] += os.path.getsize(fullpath)
@@ -115,7 +115,7 @@ class BagTaleExporter(TaleExporter):
         self.append_aggergate_checksums()
 
         # Update manifest with filesizes and mimeTypes for workspace items
-        self.append_aggregate_filesize_mimetypes('./workspace/')
+        self.append_aggregate_filesize_mimetypes()
 
         # Update manifest with filesizes and mimeTypes for extra items
         self.append_extras_filesize_mimetypes(extra_files)

--- a/server/lib/exporters/native.py
+++ b/server/lib/exporters/native.py
@@ -10,9 +10,9 @@ class NativeTaleExporter(TaleExporter):
         }
 
         # Add files from the workspace
-        for fullpath, relpath in self.list_workspace():
+        for fullpath, relpath in self.list_files():
             yield from self.dump_and_checksum(
-                self.bytes_from_file(fullpath), 'workspace/' + relpath
+                self.bytes_from_file(fullpath), relpath
             )
 
         # Compute checksums for extra files
@@ -24,7 +24,7 @@ class NativeTaleExporter(TaleExporter):
         self.append_aggergate_checksums()
 
         # Update manifest with filesizes and mimeTypes
-        self.append_aggregate_filesize_mimetypes('./workspace/')
+        self.append_aggregate_filesize_mimetypes()
 
         # Update manifest with filesizes and mimeTypes for extra items
         self.append_extras_filesize_mimetypes(extra_files)

--- a/server/rest/tale.py
+++ b/server/rest/tale.py
@@ -504,9 +504,12 @@ class Tale(Resource):
     def exportTale(self, tale, taleFormat, versionId):
         user = self.getCurrentUser()
         version = self._get_version(user, tale, versionId)
-        workspace_path = os.path.join(version["fsPath"], "workspace")
-        with open(os.path.join(version["fsPath"], "manifest.json"), "r") as fp:
-            manifest = json.load(fp)
+
+        # Get the manifest for the version, which may contain recorded run information
+        manifest_doc = Manifest(
+            tale, self.getCurrentUser(), expand_folders=True, versionId=version["_id"]
+        )
+
         with open(os.path.join(version["fsPath"], "environment.json"), "r") as fp:
             environment = json.load(fp)
 
@@ -515,7 +518,7 @@ class Tale(Resource):
         elif taleFormat == 'native':
             export_func = NativeTaleExporter
 
-        exporter = export_func(manifest, environment, workspace_path)
+        exporter = export_func(user, manifest_doc.manifest, environment)
         setResponseHeader('Content-Type', 'application/zip')
         setContentDisposition(f"{version['_id']}.zip")
         return exporter.stream


### PR DESCRIPTION
Fixes https://github.com/whole-tale/whole-tale/issues/90

This PR:
* Updates `manifest.py` to include recorded run information and files if one or more runs are present for a version
* Updates exported tales to include updated manifest.json and run files in payload

To test:
* Create a new tale with two entrypoint scripts that create output files
* Execute a recorded run for each entrypoint
* Export tale/version associated with the run
* Confirm that the `manifest.json` includes information for both runs 
* Confirm that payload includes files from both runs