### PR TITLE
[DataONE] add missing headers prop to DataONEVerificator

### DIFF
--- a/server/lib/dataone/auth.py
+++ b/server/lib/dataone/auth.py
@@ -7,6 +7,12 @@ class DataONEVerificator:
         self.key = key
         self.resource_server = resource_server
 
+    @property
+    def headers(self):
+        if self.key:
+            return {"Authorization": f"Bearer {self.key}"}
+        return {}
+
     def verify(self):
         try:
             jwt.PyJWT().decode(


### PR DESCRIPTION
### Motivation

Trying to access registered DataONE resource with DMS resulted in:

```
Traceback (most recent call last):
  File "/girder/girder/api/rest.py", line 630, in endpointDecorator
    val = fun(self, path, params)
  File "/girder/girder/api/rest.py", line 1230, in POST
    return self.handleRoute(method, path, params)
  File "/girder/girder/api/rest.py", line 970, in handleRoute
    val = handler(**kwargs)
  File "/girder/girder/api/access.py", line 63, in wrapped
    return fun(*args, **kwargs)
  File "/girder/plugins/wt_data_manager/server/resources/lock.py", line 101, in acquireLock
    return self.model('lock', 'wt_data_manager').acquireLock(user, sessionId, itemId, ownerId)
  File "/girder/plugins/wt_data_manager/server/models/lock.py", line 83, in acquireLock
    events.trigger('dm.itemLocked',
  File "/girder/girder/events.py", line 314, in trigger
    handler['handler'](e)
  File "/girder/plugins/wt_data_manager/server/__init__.py", line 94, in itemLocked
    cacheManager.itemLocked(dict['user'], dict['itemId'], dict['sessionId'])
  File "/girder/plugins/wt_data_manager/server/lib/cache_manager.py", line 37, in itemLocked
    self.transferManager.startTransfer(user, itemId, sessionId)
  File "/girder/plugins/wt_data_manager/server/lib/transfer_manager.py", line 144, in startTransfer
    self.actualStartTransfer(user, transfer['_id'], itemId)
  File "/girder/plugins/wt_data_manager/server/lib/transfer_manager.py", line 148, in actualStartTransfer
    transferHandler = self.getTransferHandler(transferId, itemId, user)
  File "/girder/plugins/wt_data_manager/server/lib/transfer_manager.py", line 178, in getTransferHandler
    return self.handlerFactory.getURLTransferHandler(url, transferId, itemId, psPath, user,
  File "/girder/plugins/wt_data_manager/server/lib/handler_factory.py", line 29, in getURLTransferHandler
    return self.newTransferHandler(parsed.scheme, url, transferId, itemId, psPath, user,
  File "/girder/plugins/wt_data_manager/server/lib/handler_factory.py", line 35, in newTransferHandler
    return self.handlers[name](url, transferId, itemId, psPath, user, transferManager)
  File "/girder/plugins/wt_data_manager/server/lib/handlers/common.py", line 38, in __init__
    UrlTransferHandler.__init__(self, url, transferId, itemId, psPath, user, transferManager)
  File "/girder/plugins/wt_data_manager/server/lib/handlers/common.py", line 17, in __init__
    self._headers = verificator(user=user, url=url).headers
AttributeError: 'DataONEVerificator' object has no attribute 'headers'
```

This PR adds missing property.

### How to test?
1. Create a Tale
2. Register [doi:10.5065/D6862DM8](https://doi.org/10.5065/D6862DM8), add any of the file to Tale's external data
3. Run a Tale and try to access the file.

