### PR TITLE
Add sha1 support to bag export

### DIFF
--- a/server/lib/exporters/__init__.py
+++ b/server/lib/exporters/__init__.py
@@ -66,7 +66,7 @@ class TaleExporter:
         self.environment = environment
 
         if algs is None:
-            self.algs = ["md5", "sha256"]
+            self.algs = ["md5", "sha1", "sha256"]
 
         zipname = os.path.basename(manifest["dct:hasVersion"]["@id"])
         self.zip_generator = ziputil.ZipGenerator(zipname)
@@ -127,8 +127,9 @@ class TaleExporter:
         hash_file_stream = HashFileStream(func)
         for data in self.zip_generator.addFile(hash_file_stream, zip_path):
             yield data
-        for alg in self.algs:
-            self.state[alg].append((zip_path, getattr(hash_file_stream, alg)))
+        # MD5 is the only required alg in profile. See Manifests-Required in
+        # https://raw.githubusercontent.com/fair-research/bdbag/master/profiles/bdbag-ro-profile.json
+        self.state['md5'].append((zip_path, getattr(hash_file_stream, 'md5')))
 
     def _agg_index_by_uri(self, uri):
         aggs = self.manifest["aggregates"]

--- a/server/lib/exporters/bag.py
+++ b/server/lib/exporters/bag.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from hashlib import sha256, md5
+from hashlib import sha1, sha256, md5
 import os
 from urllib.parse import unquote
 from . import TaleExporter
@@ -162,7 +162,7 @@ class BagTaleExporter(TaleExporter):
                     pass
             return dump
 
-        tagmanifest = dict(md5="", sha256="")
+        tagmanifest = dict(md5="", sha1="", sha256="")
         for payload, fname in (
             (lambda: top_readme, 'README.md'),
             (lambda: run_file, 'run-local.sh'),
@@ -170,12 +170,16 @@ class BagTaleExporter(TaleExporter):
             (lambda: bag_info, 'bag-info.txt'),
             (lambda: fetch_file, 'fetch.txt'),
             (lambda: dump_checksums('md5'), 'manifest-md5.txt'),
+            (lambda: dump_checksums('sha1'), 'manifest-sha1.txt'),
             (lambda: dump_checksums('sha256'), 'manifest-sha256.txt'),
             (lambda: self.formated_dump(self.environment, indent=4), 'metadata/environment.json'),
             (lambda: self.formated_dump(self.manifest, indent=4), 'metadata/manifest.json'),
         ):
             tagmanifest['md5'] += "{} {}\n".format(
                 md5(payload().encode()).hexdigest(), fname
+            )
+            tagmanifest['sha1'] += "{} {}\n".format(
+                sha1(payload().encode()).hexdigest(), fname
             )
             tagmanifest['sha256'] += "{} {}\n".format(
                 sha256(payload().encode()).hexdigest(), fname
@@ -184,6 +188,7 @@ class BagTaleExporter(TaleExporter):
 
         for payload, fname in (
             (lambda: tagmanifest['md5'], 'tagmanifest-md5.txt'),
+            (lambda: tagmanifest['sha1'], 'tagmanifest-sha1.txt'),
             (lambda: tagmanifest['sha256'], 'tagmanifest-sha256.txt'),
         ):
             yield from self.zip_generator.addFile(payload, fname)


### PR DESCRIPTION
This PR adds sha1 support in exported bags. sha1 is a possible algorithm used by DataONE for registered datasets (see https://github.com/whole-tale/girder_wholetale/pull/524).
