### PR TITLE
[globus] don't assume prefix during import

### DIFF
--- a/server/lib/globus/globus_provider.py
+++ b/server/lib/globus/globus_provider.py
@@ -97,7 +97,7 @@ class GlobusImportProvider(ImportProvider):
 
     def _listRecursive(self, user, pid: str, name: str, base_url: str = None, progress=None):
         endpoint, path, doi, title = self._extractMeta(pid)
-        yield ImportItem(ImportItem.FOLDER, name=title, identifier='doi:' + doi)
+        yield ImportItem(ImportItem.FOLDER, name=title, identifier=doi)
         tc = self.clients.getUserTransferClient(user)
         yield from self._listRecursive2(tc, endpoint, path, progress)
         yield ImportItem(ImportItem.END_FOLDER)


### PR DESCRIPTION
Fix wrong (`"doi:doi:10.18126/M2301J"`) identifiers on imported globus data.

### How to test?
1. Register doi:10.18126/M2301J
2. Confirm that `identifier` on all imported data looks sane.