### PR TITLE
Change staging cn to cn-stage

### DIFF
--- a/plugin_tests/constants_test.py
+++ b/plugin_tests/constants_test.py
@@ -25,4 +25,4 @@ class TestDataONEUtils(base.TestCase):
 
         self.assertEqual(DataONELocations.prod_cn, 'https://cn.dataone.org/cn/v2')
         self.assertEqual(DataONELocations.dev_mn, 'https://dev.nceas.ucsb.edu/knb/d1/mn/v2')
-        self.assertEqual(DataONELocations.dev_cn, 'https://cn-stage-2.test.dataone.org/cn/v2')
+        self.assertEqual(DataONELocations.dev_cn, 'https://cn-stage.test.dataone.org/cn/v2')

--- a/plugin_tests/dataone_register_test.py
+++ b/plugin_tests/dataone_register_test.py
@@ -64,12 +64,12 @@ class TestDataONERegister(base.TestCase):
         self.assertEqual(res, 'urn:uuid:6f5533ab-6508-4ac7-82a3-1df88ed4580e')
 
         # Test that the regex works for the test coordinating node
-        pid = 'https://cn-stage-2.test.dataone.org/cn/v2/resolve/abcdefg'
+        pid = 'https://cn-stage.test.dataone.org/cn/v2/resolve/abcdefg'
         res = find_initial_pid(pid)
         self.assertEqual(res, 'abcdefg')
 
         # Test that the regex works for the test coordinating node V1
-        pid = 'https://cn-stage-2.test.dataone.org/cn/v1/resolve/abcdefg'
+        pid = 'https://cn-stage.test.dataone.org/cn/v1/resolve/abcdefg'
         res = find_initial_pid(pid)
         self.assertEqual(res, 'abcdefg')
 

--- a/plugin_tests/publish_test.py
+++ b/plugin_tests/publish_test.py
@@ -127,7 +127,7 @@ class PublishTestCase(base.TestCase):
             token = {
                 "access_token": "dataone_token",
                 "provider": "dataone",
-                "resource_server": "cn-stage-2.dataone.org",
+                "resource_server": "cn-stage.dataone.org",
                 "token_type": "apikey",
             }
             self.user["otherTokens"] = [token]

--- a/plugin_tests/repository_test.py
+++ b/plugin_tests/repository_test.py
@@ -83,7 +83,7 @@ class RepositoryTestCase(base.TestCase):
             {
                 "provider": "dataone",
                 "access_token": "dataone_token",
-                "resource_server": "cn-stage-2.test.dataone.org",
+                "resource_server": "cn-stage.test.dataone.org",
                 "token_type": "dataone",
             }
         ]

--- a/server/constants.py
+++ b/server/constants.py
@@ -104,7 +104,7 @@ class SettingDefault:
             {
                 "name": "dataone",
                 "targets": [
-                    "cn-stage-2.test.dataone.org",
+                    "cn-stage.test.dataone.org",
                     "cn.dataone.org",
                 ]
             },

--- a/server/lib/__init__.py
+++ b/server/lib/__init__.py
@@ -55,7 +55,6 @@ Verificators = {
     "dataoneprod": DataONEVerificator,
     "dataonedev": DataONEVerificator,
     "dataonestage": DataONEVerificator,
-    "dataonestage2": DataONEVerificator,
     "deriva": DerivaVerificator
 }
 

--- a/server/lib/dataone/__init__.py
+++ b/server/lib/dataone/__init__.py
@@ -13,10 +13,9 @@ class DataONELocations:
     # Development member node
     dev_mn = "https://dev.nceas.ucsb.edu/knb/d1/mn/v2"
     # Development coordinating node
-    dev_cn = "https://cn-stage-2.test.dataone.org/cn/v2"
+    dev_cn = "https://cn-stage.test.dataone.org/cn/v2"
 
 
 addProvider(type("DataONEDev", (FakeDataONE,), {}))
 addProvider(type("DataONEProd", (FakeDataONE,), {}))
 addProvider(type("DataONEStage", (FakeDataONE,), {}))
-addProvider(type("DataONEStage2", (FakeDataONE,), {}))

--- a/server/lib/dataone/fakeoauth.py
+++ b/server/lib/dataone/fakeoauth.py
@@ -4,9 +4,6 @@ from d1_common.env import D1_ENV_DICT
 from girder.api.rest import getApiUrl
 from girder.plugins.oauth.providers.base import ProviderBase
 
-# Because, why would they keep up to date list of CNs and deployments?
-D1_ENV_DICT["stage"] = dict(base_url="https://cn-stage.test.dataone.org/cn")
-
 
 class FakeDataONE(ProviderBase):
     @classmethod

--- a/server/lib/dataone/fakeoauth.py
+++ b/server/lib/dataone/fakeoauth.py
@@ -5,7 +5,7 @@ from girder.api.rest import getApiUrl
 from girder.plugins.oauth.providers.base import ProviderBase
 
 # Because, why would they keep up to date list of CNs and deployments?
-D1_ENV_DICT["stage2"] = dict(base_url="https://cn-stage-2.test.dataone.org/cn")
+D1_ENV_DICT["stage"] = dict(base_url="https://cn-stage.test.dataone.org/cn")
 
 
 class FakeDataONE(ProviderBase):


### PR DESCRIPTION
~~D1 has renamed `cn-stage-2.test.dataone.org` to `cn-sandbox.test.dataone.org`. The hostname is redirecting and the cert is only valid on cn-sandbox.test.dataone.org.~~

See comment below. D1 has consolidated cn-stage-2 and cn-stage, of which dev.nceas.ucsb.edu is now a member node.

**To Test:**
* Requires https://github.com/whole-tale/gwvolman/pull/168
* Create a simple tale
* Go to Settings, connect cn-stage.test.dataone.org
* Publish your tale to https://dev.nceas.ucsb.edu/
* Confirm that the resulting published dataset looks sensible
* For grins, change something and publish again


