### PR TITLE
D1 integration redirect fix

### DIFF
--- a/server/lib/dataone/integration.py
+++ b/server/lib/dataone/integration.py
@@ -67,7 +67,15 @@ def dataoneDataImport(self, uri, title, environment, api, apiToken, force):
             )
         )
     except DataONENotATaleError:
-        query = {"uri": uri, "asTale": True, "name": title, "environment": environment, "api": api}
+        query = dict()
+        query['uri'] = uri
+        if title:
+            query['name'] = title
+        if environment:
+            query['environment'] = environment
+        if api:
+            query['api'] = api
+
         location = urlunparse(
             urlparse(dashboard_url)._replace(path="/mine", query=urlencode(query))
         )

--- a/server/lib/dataone/provider.py
+++ b/server/lib/dataone/provider.py
@@ -138,7 +138,7 @@ class DataOneImportProvider(ImportProvider):
             return Tale().load(existing_tale_id["_id"], user=user)
 
         if not data_map.tale:
-            raise DataONENotATaleError(data_map)
+            raise DataONENotATaleError(data_map.dataId, data_map.base_url)
 
         docs = get_documents(data_map.dataId, data_map.base_url)
         for doc in docs:

--- a/server/lib/dataone/provider.py
+++ b/server/lib/dataone/provider.py
@@ -138,7 +138,7 @@ class DataOneImportProvider(ImportProvider):
             return Tale().load(existing_tale_id["_id"], user=user)
 
         if not data_map.tale:
-            raise DataONENotATaleError(data_map.dataId, data_map.base_url)
+            raise DataONENotATaleError(data_map)
 
         docs = get_documents(data_map.dataId, data_map.base_url)
         for doc in docs:


### PR DESCRIPTION
Reverting my invalid change for non-tale case.  D1 integration requires that only the fields that are set on integration request are included on redirect.

**Test case**
* Import dataset as READ-ONLY https://girder.local.wholetale.org/api/v1/integration/dataone?uri=https%3A%2F%2Fsearch.dataone.org%2Fview%2Fdoi%3A10.18739%2FA2VQ2S94D&title=Fire%20influences%20on%20forest%20recovery%20and%20associated%20climate%20feedbacks%20in%20Siberian%20Larch%20Forests%2C%20Russia&environment=RStudio
* Make sure tale is created, data is registered and present. Optionally run tale.
* Import tale https://girder.local.wholetale.org/api/v1/integration/dataone?uri=https://dev.nceas.ucsb.edu/view/urn:uuid:dd6039b1-caa4-492f-968f-1562cc93a363&title=WT%20Recorded%20Run%20Test%20(sans%20DERIVA%20and%20Globus)&environment=RStudio&api=https%3A%2F%2Fdev.nceas.ucsb.edu%2Fknb%2Fd1%2Fmn%2Fv2
* Make sure tale is created, external data registered, version/run present. 