### PR TITLE
Only add new globus scopes during plugin load

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -19,6 +19,7 @@ from girder.constants import AccessType, TokenScope
 from girder.exceptions import GirderException
 from girder.models.model_base import ValidationException
 from girder.models.notification import Notification, ProgressState
+from girder.models.setting import Setting
 from girder.models.user import User
 from girder.plugins.jobs.constants import JobStatus
 from girder.plugins.jobs.models.job import Job as JobModel
@@ -494,6 +495,9 @@ def store_other_globus_tokens(event):
 
 
 def load(info):
+    from girder.plugins.oauth.providers.globus import Globus
+    deriva_scopes = Setting().get(PluginSettings.DERIVA_SCOPES)
+    Globus.addScopes(list(deriva_scopes.values()))
     info['apiRoot'].wholetale = wholeTale()
     info['apiRoot'].instance = Instance()
     tale = Tale()

--- a/server/lib/deriva/auth.py
+++ b/server/lib/deriva/auth.py
@@ -1,11 +1,6 @@
 from girder.models.setting import Setting
-from ...constants import PluginSettings, DEFAULT_DERIVA_SCOPE
+from ...constants import PluginSettings
 from ..verificator import Verificator
-
-from girder.plugins.oauth.providers.globus import Globus
-
-
-Globus.addScopes([DEFAULT_DERIVA_SCOPE])
 
 
 class DerivaVerificator(Verificator):


### PR DESCRIPTION
Fixes #534 (for now...). Avoids doubling deriva scope in oauth requests. I'll note that a better solution would be to use `set()` for scopes in oauth provider, but I don't want to mess with girder proper for now.

### How to test?
1. See #534 
2. Alternatively:
    ```
    $ docker exec -ti -u root $(docker ps --filter=name=girder -q) gosu girder:girder girder-shell
    > from girder.plugins.oauth.providers.globus import Globus
    > Globus._AUTH_SCOPES
    ```
    verify that there are no duplicates.