### PR TITLE
Add minimal schema validation for containerConfig

### DIFF
--- a/server/schema/misc.py
+++ b/server/schema/misc.py
@@ -158,9 +158,13 @@ containerConfigSchema = {
             "items": {
                 "type": "string",
                 "description": "Environment variable, in the form KEY=val",
+                "pattern": "^[^=]+=.*$",
             },
         },
-        "memLimit": {"type": "string"},
+        "memLimit": {
+            "type": "string",
+            "pattern": "^(\d+)([kmg]?b?)$",
+        },
         "port": {
             "type": "integer",
             "description": (
@@ -174,6 +178,7 @@ containerConfigSchema = {
         },
         "targetMount": {
             "type": "string",
+            "pattern": "^/.*$",
             "description": ("Path where the Whole Tale filesystem " "will be mounted"),
         },
         "urlPath": {
@@ -183,6 +188,7 @@ containerConfigSchema = {
             ),
         },
     },
+    "additionalProperties": False,
 }
 
 containerInfoSchema = {


### PR DESCRIPTION
Schema changes to accompany https://github.com/whole-tale/ngx-dashboard/pull/275

**How to test**
Using this branch with https://github.com/whole-tale/ngx-dashboard/pull/275

These should pass validation:
```
{ 
   "memLimit": "1g",
   "environment": [ "X=Y"],
   "targetMount": "/my/mount"
} 
```
Note: Docker is pretty liberal with env vars.

These should fail validation:
```
{ 
   "memLimit": "argle",
   "environment": [ "=X"],
   "targetMount": "my/mount"
} 
```