### PR TITLE
grab ORCID from DV meta more defensively

### DIFF
--- a/server/lib/dataverse/provider.py
+++ b/server/lib/dataverse/provider.py
@@ -376,12 +376,11 @@ class DataverseImportProvider(ImportProvider):
                         lastName, firstName = raw_author.split(",", 1)
                     else:
                         firstName, lastName = raw_author.split(" ", 1)
-                    if (
-                        "authorIdentifierScheme" in author
-                        and author["authorIdentifierScheme"]["value"] == "ORCID"  # noqa
-                    ):
+                    try:
+                        if author["authorIdentifierScheme"]["value"] != "ORCID":
+                            raise ValueError
                         orcid = author["authorIdentifier"]["value"]
-                    else:
+                    except (KeyError, ValueError):
                         orcid = "0000-0000-0000-0000"
                     authors.append(
                         dict(


### PR DESCRIPTION
Fixes issue identified during live demo!

### How to test?
1. Navigate to https://wholetale.readthedocs.io/en/latest/ainwt.html
2. Select: Dataverse, https://dataverse.harvard.edu/, doi:10.7910/DVN/NYPOQD
3. Click Launch Tale
4. Tale should import properly.