### PR TITLE
Annotate registered data with location labels

### DIFF
--- a/plugin_tests/harvester_test.py
+++ b/plugin_tests/harvester_test.py
@@ -197,7 +197,8 @@ class DataONEHarversterTestCase(base.TestCase):
         for i in range(len(items)):
             self.assertEqual(items[i]['name'], source[i]['fileName'])
             self.assertEqual(items[i]['size'], source[i]['size'])
-            self.assertEqual(items[i]['meta']['identifier'],
+            self.assertEqual(items[i]['meta']['identifier'], "doi:10.18739/A2ND53")
+            self.assertEqual(items[i]['meta']['directIdentifier'],
                              source[i]['identifier'])
 
         # TODO: check if it's that method is still used anywhere

--- a/server/lib/dataone/provider.py
+++ b/server/lib/dataone/provider.py
@@ -93,17 +93,29 @@ class DataOneImportProvider(ImportProvider):
         if not name:
             name = primary_metadata[0]['title']
 
-        yield ImportItem(ImportItem.FOLDER, name, identifier=primary_identifier)
+        yield ImportItem(
+            ImportItem.FOLDER,
+            name,
+            identifier=primary_identifier,
+            meta={
+                "dsRelPath": "/",
+            }
+        )
 
         for fileObj in data:
+            name = fileObj.get("fileName", fileObj["identifier"])
             yield ImportItem(
                 ImportItem.FILE,
-                fileObj.get("fileName", fileObj["identifier"]),
-                identifier=fileObj["identifier"],
+                name,
+                identifier=primary_identifier,
                 url=fileObj["url"],
                 size=int(fileObj["size"]),
                 mimeType=fileObj["formatId"],
-                meta={"checksum": {fileObj["checksumAlgorithm"].lower(): fileObj["checksum"]}},
+                meta={
+                    "checksum": {fileObj["checksumAlgorithm"].lower(): fileObj["checksum"]},
+                    "dsRelPath": f"/{name}",  # D1 packages are flat...
+                    "directIdentifier": fileObj["identifier"],
+                },
             )
 
         # Recurse and add child packages if any exist

--- a/server/lib/dataverse/provider.py
+++ b/server/lib/dataverse/provider.py
@@ -329,26 +329,36 @@ class DataverseImportProvider(ImportProvider):
     def _listRecursive(self, user, pid: str, name: str, base_url: str = None,
                        progress=None):
 
-        def _recurse_hierarchy(hierarchy):
+        def _recurse_hierarchy(hierarchy, prefix="/"):
             files = hierarchy.pop('+files+')
             for obj in files:
                 alg, checksum = obj["checksum"].split(":")
+                rel_path = os.path.join(prefix, obj["filename"])
+                meta = {"checksum": {alg: checksum}, "dsRelPath": rel_path}
+                if obj.get("doi") and obj["doi"] != doi:
+                    meta["directIdentifier"] = obj["doi"]
                 yield ImportItem(
                     ImportItem.FILE, obj['filename'],
                     size=obj['filesize'],
                     mimeType=obj.get('mimeType', 'application/octet-stream'),
                     url=obj['url'],
-                    identifier=obj.get('doi') or doi,
-                    meta={"checksum": {alg: checksum}},
+                    identifier=doi,
+                    meta=meta,
                 )
             for folder in hierarchy.keys():
-                yield ImportItem(ImportItem.FOLDER, name=folder)
-                yield from _recurse_hierarchy(hierarchy[folder])
+                rel_path = os.path.join(prefix, folder)
+                yield ImportItem(
+                    ImportItem.FOLDER,
+                    name=folder,
+                    identifier=doi,
+                    meta={"dsRelPath": rel_path}
+                )
+                yield from _recurse_hierarchy(hierarchy[folder], prefix=rel_path)
                 yield ImportItem(ImportItem.END_FOLDER)
 
         title, files, doi = self.parse_pid(pid, sanitize=True, user=user)
         hierarchy = self._files_to_hierarchy(files)
-        yield ImportItem(ImportItem.FOLDER, name=title, identifier=doi)
+        yield ImportItem(ImportItem.FOLDER, name=title, identifier=doi, meta={"dsRelPath": "/"})
         yield from _recurse_hierarchy(hierarchy)
         yield ImportItem(ImportItem.END_FOLDER)
 

--- a/server/lib/zenodo/provider.py
+++ b/server/lib/zenodo/provider.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import re
 import requests
@@ -192,10 +193,12 @@ class ZenodoImportProvider(ImportProvider):
         self, user, pid: str, name: str, base_url: str = None, progress=None
     ):
         record = self._get_record(pid)
+        doi = self._get_doi_from_record(record)
 
-        def _recurse_hierarchy(hierarchy):
+        def _recurse_hierarchy(hierarchy, prefix="/"):
             files = hierarchy.pop("+files+")
             for obj in files:
+                rel_path = os.path.join(prefix, obj["name"])
                 alg, checksum = obj["checksum"].split(":")
                 yield ImportItem(
                     ImportItem.FILE,
@@ -203,11 +206,14 @@ class ZenodoImportProvider(ImportProvider):
                     size=obj["size"],
                     mimeType=obj["mimeType"],
                     url=obj["url"],
-                    meta={"checksum": {alg: checksum}},
+                    identifier=doi,
+                    meta={"checksum": {alg: checksum}, "dsRelPath": rel_path},
                 )
             for folder in hierarchy.keys():
-                yield ImportItem(ImportItem.FOLDER, name=folder)
-                yield from _recurse_hierarchy(hierarchy[folder])
+                rel_path = os.path.join(prefix, folder)
+                meta = {"dsRelPath": rel_path}
+                yield ImportItem(ImportItem.FOLDER, name=folder, identifier=doi, meta=meta)
+                yield from _recurse_hierarchy(hierarchy[folder], prefix=rel_path)
                 yield ImportItem(ImportItem.END_FOLDER)
 
         meta = {k: record.get(k, "") for k in ["conceptdoi", "conceptrecid"]}
@@ -216,7 +222,7 @@ class ZenodoImportProvider(ImportProvider):
         yield ImportItem(
             ImportItem.FOLDER,
             name=self._get_title_from_record(record),
-            identifier=self._get_doi_from_record(record),
+            identifier=doi,
             meta=meta,
         )
         yield from _recurse_hierarchy(self._files_to_hierarchy(record["files"]))

--- a/server/rest/dataset.py
+++ b/server/rest/dataset.py
@@ -127,7 +127,12 @@ class Dataset(Resource):
 
         if identifiers:
             filters.update(
-                {'meta.identifier': {'$in': identifiers}}
+                {
+                    "$or": [
+                        {"meta.directIdentifier": {"$in": identifiers}},
+                        {"meta.identifier": {"$in": identifiers}},
+                    ]
+                }
             )
 
             for modelType in ('folder', 'item'):


### PR DESCRIPTION
### What's new?

For Zenodo, Dataverse, DataONE and Globus providers this PR annotates registered data with a) location of a file/folder relative to the original dataset root b) identifier of root dataset (in case there's a specific file/folder identifier it's added as `directIdentifer` to metadata)

### Why?

Currently this information is derived ad hoc from the structure of WholeTale Catalog using a lot of implicit assumptions regarding how registering works for a given provider. With this PR it's going to be easy to export / import external data regardless of its location in girder.

### How to test?
1. Register some data. I used:
   1. https://zenodo.org/record/3463499 (nested zenodo)
   2. doi:10.7910/DVN/5WTSUZ (nested DV)
   3. https://search.dataone.org/view/urn:uuid:6f5533ab-6508-4ac7-82a3-1df88ed4580e
   4. doi:10.18126/M2301J (globus)
1. Inspect registered data in girder. Look for `dsRelPath` in item/folder metadata.

### TODO
- [x] Update tests.  