### PR TITLE
Include repo2docker_version on import

### DIFF
--- a/server/lib/manifest_parser.py
+++ b/server/lib/manifest_parser.py
@@ -273,6 +273,21 @@ class ManifestParser:
             for rel_id in {json.dumps(_, sort_keys=True) for _ in related_ids}
         ]
 
+        imageInfo = {}
+        try:
+            r2d_version = next(
+                iter([
+                    obj["schema:softwareVersion"]
+                    for obj in self.manifest["schema:hasPart"]
+                    if obj["@id"] == "https://github.com/whole-tale/repo2docker_wholetale"
+                ]), None
+            )
+            if (r2d_version):
+                imageInfo["repo2docker_version"] = r2d_version
+
+        except KeyError:
+            pass
+
         return {
             "title": self.manifest["schema:name"],
             "description": self.manifest["schema:description"],
@@ -281,6 +296,7 @@ class ManifestParser:
             "category": self.manifest["schema:keywords"],
             "licenseSPDX": licenseSPDX,
             "relatedIdentifiers": related_ids,
+            "imageInfo": imageInfo,
         }
 
     @staticmethod

--- a/server/models/tale.py
+++ b/server/models/tale.py
@@ -187,7 +187,7 @@ class Tale(AccessControlledModel):
                    icon=None, category=None, illustration=None,
                    licenseSPDX=None,
                    status=TaleStatus.READY, publishInfo=None,
-                   relatedIdentifiers=None):
+                   relatedIdentifiers=None, imageInfo=None):
 
         if creator is None:
             creatorId = None
@@ -217,7 +217,7 @@ class Tale(AccessControlledModel):
             'icon': icon,
             'iframe': image.get('iframe', False),
             'imageId': ObjectId(image['_id']),
-            'imageInfo': {},
+            'imageInfo': imageInfo or {},
             'illustration': illustration,
             'title': title,
             'public': public,


### PR DESCRIPTION
**Problem:**

Importing a tale doesn't include the repo2docker_version used.

**Approach:**

Add support for imageInfo["repo2docker_version"] if present during import.

**Test:**
* Import https://girder.local.wholetale.org/api/v1/integration/zenodo?doi=10.5072%2Fzenodo.1059441&resource_server=sandbox.zenodo.org
*  Confirm:
``` 
  "imageInfo": {
    "repo2docker_version": "wholetale/repo2docker_wholetale:v1.1.post0"
  },
```
* Build the image, if you dare, and see if run.sh still works...