### PR TITLE
Expose image on export and publish

### DIFF
--- a/plugin_tests/bdbag_test.py
+++ b/plugin_tests/bdbag_test.py
@@ -74,6 +74,7 @@ class BDBagFullTestCase(base.TestCase):
                 user="someUser",
                 port=8888,
                 urlPath="",
+                targetMount='/mount',
             ),
         )
 

--- a/plugin_tests/bdbag_test.py
+++ b/plugin_tests/bdbag_test.py
@@ -141,16 +141,20 @@ class BDBagFullTestCase(base.TestCase):
                     "_modelType": "item",
                 }
             )
+    
+        # Fake imageInfo
+        imageInfo = {
+            "digest": "registry.local.wholetale.org/digest123"
+        }
 
-        resp = self.request(
-            path="/tale",
-            method="POST",
-            user=self.user,
-            type="application/json",
-            body=json.dumps({"imageId": str(self.image["_id"]), "dataSet": dataSet}),
+        # Create tale (use model directly to set imageInfo)
+        from girder.plugins.wholetale.models.tale import Tale
+        tale = Tale().createTale(
+            image=self.image,
+            data=dataSet,
+            creator=self.user,
+            imageInfo=imageInfo
         )
-        self.assertStatusOk(resp)
-        tale = resp.json
 
         # "Upload" something to workspace
         workspace = Folder().load(tale["workspaceId"], force=True)
@@ -178,6 +182,7 @@ class BDBagFullTestCase(base.TestCase):
                 )
                 version_id = Path(manifest_path).parts[0]
 
+
                 zip_archive.extractall(tmpdirname)
                 zip_archive.close()
 
@@ -186,3 +191,13 @@ class BDBagFullTestCase(base.TestCase):
             self.assertTrue(bdbag.resolve_fetch(bag_path))
             bdbag.validate_bag(bag_path, fast=True)
             bdbag.validate_bag(bag_path, fast=False)
+
+            # Confirm image digest.
+            manifest_fs_path = os.path.join(bag_path, "metadata/manifest.json")
+            with open(manifest_fs_path, 'r') as fp:
+                manifest_json = json.load(fp)
+                self.assertEqual(manifest_json["schema:hasPart"][1]["@id"], "images.local.wholetale.org/digest123")
+
+            from server.lib.manifest_parser import ManifestParser
+            tale_fields = ManifestParser(manifest_fs_path).get_tale_fields()
+            self.assertEqual(tale_fields["imageInfo"]["digest"], "registry.local.wholetale.org/digest123")

--- a/plugin_tests/dataverse_test.py
+++ b/plugin_tests/dataverse_test.py
@@ -418,22 +418,23 @@ class DataverseHarversterTestCase(base.TestCase):
         tale = provider.proto_tale_from_datamap(dataMap, self.user, True)
         self.assertEqual(tale["authors"][0]["lastName"], "Tesler")
 
-        datamap = {
-            "dataId": (
-                "http://dataverse.icrisat.org/dataset.xhtml?"
-                "persistentId=doi:10.21421/D2/TCCVS7"
-            ),
-            "doi": "doi:10.21421/D2/TCCVS7",
-            "name": (
-                "Phenotypic evaluation data of International Chickpea "
-                "Varietal Trials (ICVTs) – Desi for Year 2016-17"
-            ),
-            "repository": "Dataverse",
-            "size": 99504,
-            "tale": False,
-        }
-        tale = provider.proto_tale_from_datamap(DataMap.fromDict(datamap), self.user, True)
-        self.assertEqual(tale["authors"][0]["firstName"], "Pooran")
+        # dataverse.icrisat.org failing as of 8/15/2022
+        #datamap = {
+        #    "dataId": (
+        #        "http://dataverse.icrisat.org/dataset.xhtml?"
+        #        "persistentId=doi:10.21421/D2/TCCVS7"
+        #    ),
+        #    "doi": "doi:10.21421/D2/TCCVS7",
+        #    "name": (
+        #        "Phenotypic evaluation data of International Chickpea "
+        #        "Varietal Trials (ICVTs) – Desi for Year 2016-17"
+        #    ),
+        #    "repository": "Dataverse",
+        #    "size": 99504,
+        #    "tale": False,
+        #}
+        #tale = provider.proto_tale_from_datamap(DataMap.fromDict(datamap), self.user, True)
+        #self.assertEqual(tale["authors"][0]["firstName"], "Pooran")
 
     def tearDown(self):
         self.model('user').remove(self.user)

--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -205,7 +205,7 @@ class ManifestTestCase(base.TestCase):
         self._testWorkspace()
         self._testRelatedIdentifiers()
         self._testValidate()
-        self._test_create_repo2docker_version()
+        self._test_create_image_info()
 
     def _testRelatedIdentifiers(self):
         from girder.plugins.wholetale.lib.manifest import Manifest
@@ -431,17 +431,22 @@ class ManifestTestCase(base.TestCase):
         with self.assertRaises(ValueError):
             Manifest(tale_blank_orcid, self.user)
 
-    def _test_create_repo2docker_version(self):
+    def _test_create_image_info(self):
         from server.lib.manifest import Manifest
 
         manifest = Manifest(self.tale, self.user).manifest
         self.assertTrue(len(manifest['schema:hasPart']))
 
-        version_block = manifest['schema:hasPart'][0]
-        self.assertEqual(version_block['schema:softwareVersion'],
+        r2d_block = manifest['schema:hasPart'][0]
+        self.assertEqual(r2d_block['schema:softwareVersion'],
                              self.tale["imageInfo"]['repo2docker_version'])
-        self.assertEqual(version_block['@id'], 'https://github.com/whole-tale/repo2docker_wholetale')
-        self.assertEqual(version_block['@type'], 'schema:SoftwareApplication')
+        self.assertEqual(r2d_block['@id'], 'https://github.com/whole-tale/repo2docker_wholetale')
+        self.assertEqual(r2d_block['@type'], 'schema:SoftwareApplication')
+
+        digest_block = manifest['schema:hasPart'][1]
+        self.assertEqual(digest_block['@id'], self.tale['imageInfo']['digest'].replace('registry', 'images', 1))
+        self.assertEqual(digest_block['schema:applicationCategory'], 'DockerImage')
+        self.assertEqual(digest_block['@type'], 'schema:SoftwareApplication')
 
     def test_dataset_roundtrip(self):
         from server.lib.manifest_parser import ManifestParser

--- a/plugin_tests/tale_test.py
+++ b/plugin_tests/tale_test.py
@@ -105,7 +105,7 @@ class TaleTestCase(base.TestCase):
         self.image = self.model('image', 'wholetale').createImage(
             name="test my name", creator=self.user, public=True,
             config=dict(template='base.tpl', buildpack='SomeBuildPack',
-                        user='someUser', port=8888, urlPath=''))
+                        user='someUser', port=8888, urlPath='', targetMount='/mount'))
 
     def testTaleFlow(self):
         from server.lib.license import WholeTaleLicense
@@ -889,7 +889,7 @@ class TaleWithWorkspaceTestCase(base.TestCase):
             creator=self.admin,
             public=True,
             config=dict(template='base.tpl', buildpack='SomeBuildPack',
-                        user='someUser', port=8888, urlPath=''),
+                        user='someUser', port=8888, urlPath='', targetMount='/mount'),
         )
 
         from girder.plugins.wt_home_dir import HOME_DIRS_APPS

--- a/server/lib/exporters/bag.py
+++ b/server/lib/exporters/bag.py
@@ -17,9 +17,8 @@ Bagging-Time: {time}
 Payload-Oxum: {oxum}
 """
 
-run_tpl = r"""#!/bin/sh
-
-# Use repo2docker to build the image from the workspace
+build_tpl = r"""
+# Use repo2docker to build the image from the workspace when no image digest
 docker run  \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v "`pwd`/data/workspace:/WholeTale/workspace" \
@@ -32,8 +31,13 @@ docker run  \
     --target-repo-dir=/WholeTale/workspace \
     --user-id=1000 --user-name={user} \
     --no-clean --no-run --debug \
-    --image-name wholetale/tale_{taleId} \
+    --image-name {image_name} \
     /WholeTale/workspace
+"""
+
+run_tpl = r"""#!/bin/sh
+
+{build_cmd}
 
 docker run --rm \
     -v "`pwd`:/bag" \
@@ -45,10 +49,9 @@ echo "========================================================================"
 
 # Run the built image
 docker run -p {port}:{port} \
-  -v "`pwd`/data/data:/WholeTale/data" \
-  -v "`pwd`/data/workspace:/WholeTale/workspace" \
-  wholetale/tale_{taleId} {command}
-
+  -v "`pwd`/data/data:{targetMount}/data" \
+  -v "`pwd`/data/workspace:{targetMount}/workspace" \
+  {image_name} {command}
 """
 
 
@@ -76,13 +79,34 @@ class BagTaleExporter(TaleExporter):
         rendered_command = container_config.get('command', '').format(
             base_path='', port=container_config['port'], ip='0.0.0.0', token=token
         )
+
         urlPath = container_config['urlPath'].format(token=token)
+
+        taleId = self.manifest["wt:identifier"]
+        image_name = None
+        for obj in self.manifest['schema:hasPart']:
+            if ('schema:applicationCategory' in obj
+                    and obj['schema:applicationCategory'] == 'DockerImage'):
+                image_name = obj['@id']
+
+        # If the tale doesn't have a built image, output the command
+        # to build the image with r2d
+        build_cmd = ''
+        if image_name is None:
+            image_name = f"wholetale/tale_{taleId}"
+            build_cmd = build_tpl.format(
+                repo2docker=container_config.get('repo2docker_version', REPO2DOCKER_VERSION),
+                user=container_config['user'],
+                image_name=image_name
+            )
+
         run_file = run_tpl.format(
+            build_cmd=build_cmd,
             repo2docker=container_config.get('repo2docker_version', REPO2DOCKER_VERSION),
-            user=container_config['user'],
             port=container_config['port'],
-            taleId=self.manifest["wt:identifier"],
+            image_name=image_name,
             command=rendered_command,
+            targetMount=container_config['targetMount'],
             urlPath=urlPath,
         )
         top_readme = readme_tpl.format(

--- a/server/lib/manifest.py
+++ b/server/lib/manifest.py
@@ -60,7 +60,7 @@ class Manifest:
         self.add_tale_creator()
         self.manifest.update(self.create_author_record())
         self.manifest.update(self.create_related_identifiers())
-        self.manifest.update(self.create_repo2docker_version())
+        self.manifest.update(self.create_image_info())
         self.add_tale_records()
         # Add any external datasets to the manifest
         self.add_dataset_records()
@@ -156,17 +156,28 @@ class Manifest:
             ]
         }
 
-    def create_repo2docker_version(self):
+    def create_image_info(self):
         # TODO: We shouldn't be publishing a Tale that was never built...
         image_info = self.tale.get("imageInfo", {})
+
         image_info.setdefault("repo2docker_version", REPO2DOCKER_VERSION)
-        return {
+        manifest_part = {
             'schema:hasPart': [{
                 '@id': 'https://github.com/whole-tale/repo2docker_wholetale',
                 '@type': 'schema:SoftwareApplication',
                 'schema:softwareVersion': image_info['repo2docker_version']
             }]
         }
+
+        image_digest = image_info.get("digest")
+        if image_digest is not None:
+            manifest_part['schema:hasPart'].append({
+                '@id': image_digest.replace("registry", "images", 1),
+                '@type': 'schema:SoftwareApplication',
+                'schema:applicationCategory': 'DockerImage'
+            })
+
+        return manifest_part
 
     def create_related_identifiers(self):
         def derive_id_type(identifier):

--- a/server/lib/manifest_parser.py
+++ b/server/lib/manifest_parser.py
@@ -284,7 +284,20 @@ class ManifestParser:
             )
             if (r2d_version):
                 imageInfo["repo2docker_version"] = r2d_version
+        except KeyError:
+            pass
 
+        try:
+            image_digest = next(
+                iter([
+                    obj['@id']
+                    for obj in self.manifest['schema:hasPart']
+                    if 'schema:applicationCategory' in
+                       obj and obj['schema:applicationCategory'] == 'DockerImage'
+                ]), None
+            )
+            if (image_digest):
+                imageInfo['digest'] = image_digest.replace('images', 'registry', 1)
         except KeyError:
             pass
 


### PR DESCRIPTION
**Problems addressed**
* The registry requires authentication so it isn't possible for anyone to access the built image for a tale 
* When publishing or exporting a tale, the image must be built locally with repo2docker, which results in a different image 
* Third-party integrations (e.g., CORE2) can't fetch the image for archiving purposes

**Approach**
* https://github.com/whole-tale/deploy-dev/pull/52/ adds a new public read-only Docker registry at `images.local.wholetale.org` making it possible to pull any built image without authenticating.  Since both `registry` and `images` share the same filesystem, any image can be pulled publicly.
* Adds the public image URL to the manifest on export and publish, handles import (assumes image is present in our registry)
* Updates logic for `run-local.sh` to build the image if no digest is present and otherwise pull.

**To Test**:
* Deploy with https://github.com/whole-tale/deploy-dev/pull/52/
* Create a tale without building the image
  * Export the tale then inspect and execute `run-local.sh`
  * Since image cannot be pulled, script should contain command to build locally with r2d
  * Optionally execute `run-local.sh` and confirm it works
* Run the tale in WT (i.e., build the image)
  * Export the tale and inspect and execute `run-local.sh`
  * There should be no r2d command and image should be pulled from `images.local.wholetale.org`
* Publish the tale to `sandbox.zenodo.org` 
  * Inspect `metadata.json`, note  image digest:
```
       {
            "@id": "images.local.wholetale.org/tale/b3fe3003ade99e0d3b07702430c16712@sha256:4672da847c7e21f39ddbfbcf5b44b8c55926f206640912f4bf5c7d7bd90f8a6d",
            "@type": "schema:SoftwareApplication",
            "schema:applicationCategory": "DockerImage"
        }
```
  * Delete and re-import the tale
  * Confirm that confirm the imageInfo digest matches but references `registry.local.wholetale.org`

**Additional notes**
* Commented out failing DV test
* Moved run-local template logic to new function because flake8 started complaining that stream() was too complex
* I'm not certain about using ManifestParser to convert from public to private registry on import. The idea is that an exported/published tale should reference `images...` but an internal/imported tale should always reference `registry...`
* This does nothing to address the archiving issue (https://github.com/whole-tale/whole-tale/issues/75), it only makes it possible to pull the image as long as we have it. As a separate task, we should consider backing up and migrating the registry on new deployments.
* This PR provides no solution to identifying images that are suitable for GC. We could tag images at certain points in the lifecycle (e.g., tags associated with versions, runs, public, or published tales), but needs more thought.
* There may be some concern about making all images public, but this seems low-risk since we do not include private code or data. For comparison, CO requires the image to be built locally for anything that hasn't been published.
