### PR TITLE
Remove unused Globus scope to overcome ORCID 500

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -496,6 +496,9 @@ def store_other_globus_tokens(event):
 
 def load(info):
     from girder.plugins.oauth.providers.globus import Globus
+
+    # Remove unnecessary scope https://github.com/whole-tale/girder_wholetale/issues/534
+    Globus._AUTH_SCOPES.remove("urn:globus:auth:scope:auth.globus.org:view_identities")
     deriva_scopes = Setting().get(PluginSettings.DERIVA_SCOPES)
     Globus.addScopes(list(deriva_scopes.values()))
     info['apiRoot'].wholetale = wholeTale()


### PR DESCRIPTION
Fixes (for now) https://github.com/whole-tale/girder_wholetale/issues/534

**Problem**
ORCID limits the size of the `state` param to 2000 characters, otherwise returning 500.   This happens on *.local now. 

**Approach**
Removed the unused scope to reduce state param size

**Test**
* Login to https://dashboard.local.wholetale.org via ORCID
* Confirm login is OK.