### PR TITLE
fix: respect exisiting version during manifest generation

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -4,4 +4,5 @@ version: "1.2.dev0"
 dependencies:
     - jobs
     - worker
+    - virtual_resources
     - globus_handler

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ validators
 html2markdown
 GitPython
 httpio>=0.3.0
+fs


### PR DESCRIPTION
Turns out we were ignoring `versionId` in manifest generation, which resulted in a) wrong metadata (current instead of version specific) b) wrong files in workspace (current instead of version specific). Sadly this was affecting functionalities like export and copyTale...

### How to test?
1. Depends on https://github.com/whole-tale/wt_versioning/pull/47
2. Create a Tale, upload something to workspace.
3. Create a version.
4. Modify Tale's metadata (title, keywords, authors, or build it to get imageInfo) and workspace.
5. Save a version. 
6. Export the first version. Confirm that manifest.json contains proper metadata. Confirm that workspace contains proper files
7. Repeat 6. but copy the Tale from the first version instead, using "shallow=True".