### PR TITLE
Expose instance stdout/err via GET /instance/:id/logs

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -153,6 +153,14 @@ def validateDataverseURL(doc):
         raise ValidationException('Invalid Dataverse URL', 'value')
 
 
+@setting_utilities.validator(PluginSettings.LOGGER_URL)
+def validateLoggerURL(doc):
+    if not doc['value']:
+        doc['value'] = defaultLoggerUrl()
+    if not validators.url(doc['value']):
+        raise ValidationException('Invalid Instance Logger URL', 'value')
+
+
 @setting_utilities.default(PluginSettings.INSTANCE_CAP)
 def defaultInstanceCap():
     return SettingDefault.defaults[PluginSettings.INSTANCE_CAP]
@@ -181,6 +189,11 @@ def defaultDerivaExportUrls():
 @setting_utilities.default(PluginSettings.DERIVA_SCOPES)
 def defaultDerivaScopes():
     return SettingDefault.defaults[PluginSettings.DERIVA_SCOPES]
+
+
+@setting_utilities.default(PluginSettings.LOGGER_URL)
+def defaultLoggerUrl():
+    return SettingDefault.defaults[PluginSettings.LOGGER_URL]
 
 
 @access.public(scope=TokenScope.DATA_READ)

--- a/server/constants.py
+++ b/server/constants.py
@@ -37,6 +37,7 @@ class PluginSettings:
     PUBLISHER_REPOS = "wholetale.publisher_repositories"
     DERIVA_EXPORT_URLS = "wholetale.deriva.export_urls"
     DERIVA_SCOPES = "wholetale.deriva.scopes"
+    LOGGER_URL = "wholetale.instance_logger"
 
 
 class SettingDefault:
@@ -138,6 +139,7 @@ class SettingDefault:
         PluginSettings.DERIVA_SCOPES: {
             "pbcconsortium.isrd.isi.edu": DEFAULT_DERIVA_SCOPE
         },
+        PluginSettings.LOGGER_URL: "http://logger:8000/",
     }
 
 

--- a/server/rest/instance.py
+++ b/server/rest/instance.py
@@ -5,7 +5,7 @@ from girder import events
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.api.docs import addModel
-from girder.api.rest import Resource, filtermodel, RestException
+from girder.api.rest import Resource, filtermodel, RestException, setResponseHeader
 from girder.constants import AccessType, SortDir
 from girder.plugins.jobs.constants import JobStatus
 from girder.plugins.worker import getCeleryApp
@@ -87,6 +87,7 @@ class Instance(Resource):
         self.route('GET', (':id',), self.getInstance)
         self.route('DELETE', (':id',), self.deleteInstance)
         self.route('PUT', (':id',), self.updateInstance)
+        self.route('GET', (':id', 'log'), self.getInstanceLog)
         self.route('GET', ('authorize', ), self.authorize)
 
         events.bind('jobs.job.update.after', 'wholetale', self.handleUpdateJob)
@@ -262,3 +263,18 @@ class Instance(Resource):
         now = datetime.datetime.utcnow()
         if instance["lastActivity"] + datetime.timedelta(minutes=5) < now:
             self._model.update({"_id": instance["_id"]}, {"$set": {"lastActivity": now}})
+
+    @access.user
+    @autoDescribeRoute(
+        Description("Fetch Instance logs")
+        .modelParam('id', model='instance', plugin='wholetale', level=AccessType.READ)
+        .param("tail", "Number of lines to show from the end of the logs",
+               default=100, required=False, dataType='int')
+        .errorResponse('ID was invalid.')
+        .errorResponse('Read access was denied for the instance.', 403)
+    )
+    def getInstanceLog(self, instance, tail):
+        if tail < 0:
+            tail = "all"
+        setResponseHeader('Content-Type', "text/plain;charset=UTF-8")
+        return self._model.get_logs(instance, tail)

--- a/server/rest/instance.py
+++ b/server/rest/instance.py
@@ -5,7 +5,13 @@ from girder import events
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.api.docs import addModel
-from girder.api.rest import Resource, filtermodel, RestException, setResponseHeader
+from girder.api.rest import (
+    Resource,
+    filtermodel,
+    RestException,
+    setResponseHeader,
+    setRawResponse
+)
 from girder.constants import AccessType, SortDir
 from girder.plugins.jobs.constants import JobStatus
 from girder.plugins.worker import getCeleryApp
@@ -270,11 +276,13 @@ class Instance(Resource):
         .modelParam('id', model='instance', plugin='wholetale', level=AccessType.READ)
         .param("tail", "Number of lines to show from the end of the logs",
                default=100, required=False, dataType='int')
+        .produces("text/plain")
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the instance.', 403)
     )
     def getInstanceLog(self, instance, tail):
         if tail < 0:
             tail = "all"
-        setResponseHeader('Content-Type', "text/plain;charset=UTF-8")
+        setResponseHeader('Content-Type', "text/plain")
+        setRawResponse()
         return self._model.get_logs(instance, tail)


### PR DESCRIPTION
Allow to fetch instance logs via exposing `service.logs`. Custom http server to do that is available from here: https://github.com/whole-tale/instance_logger

### How to test?
1. Modify your local deploy-dev:
    ```diff
    diff --git a/docker-stack.yml b/docker-stack.yml
    index 9960f28..5dd2425 100644
    --- a/docker-stack.yml
    +++ b/docker-stack.yml
    @@ -72,6 +72,17 @@ services:
             - "traefik.http.middlewares.girder.forwardauth.address=http://girder:8080/api/v1/instance/authorize/"
             - "traefik.http.middlewares.girder.forwardauth.trustforwardheader=true"
     
    +  logger:
    +    image: wholetale/instance_logger:latest
    +    networks:
    +      - celery
    +    volumes:
    +      - /var/run/docker.sock:/var/run/docker.sock:ro
    +    deploy:
    +      replicas: 1
    +      labels:
    +        - "traefik.enable=false"
    +
       redis:
         image: redis:4-stretch
         networks:
    ```
2. Deploy, create a Tale, run instance.
3. Using https://girder.local.wholetale.org/api/v1#!/instance/instance_getInstanceLog try accessing instance's logs.

> **Note**
> On production deployment `logger` needs to be bound to manager node.
