### PR TITLE
fix: compute imageInfo dynamically based on workspace

### DIFF
--- a/plugin_tests/dataverse_test.py
+++ b/plugin_tests/dataverse_test.py
@@ -1,4 +1,5 @@
 import json
+import mock
 import os
 import responses
 import time
@@ -385,7 +386,12 @@ class DataverseHarversterTestCase(base.TestCase):
         tale = Tale().createTale(
             image, dataSet, creator=self.user, title="Blah", public=True
         )
-        manifest = Manifest(tale, self.user, expand_folders=True).manifest
+        with mock.patch("server.lib.manifest.ImageBuilder") as mock_builder:
+            mock_builder.return_value.container_config.repo2docker_version = \
+                "craigwillis/repo2docker:latest"
+            mock_builder.return_value.get_tag.return_value = "some_digest"
+            manifest = Manifest(tale, self.user, expand_folders=True).manifest
+
         restored_dataset = ManifestParser(manifest).get_dataset()
         self.assertEqual(restored_dataset, dataSet)
 
@@ -419,7 +425,7 @@ class DataverseHarversterTestCase(base.TestCase):
         self.assertEqual(tale["authors"][0]["lastName"], "Tesler")
 
         # dataverse.icrisat.org failing as of 8/15/2022
-        #datamap = {
+        # datamap = {
         #    "dataId": (
         #        "http://dataverse.icrisat.org/dataset.xhtml?"
         #        "persistentId=doi:10.21421/D2/TCCVS7"
@@ -432,9 +438,9 @@ class DataverseHarversterTestCase(base.TestCase):
         #    "repository": "Dataverse",
         #    "size": 99504,
         #    "tale": False,
-        #}
-        #tale = provider.proto_tale_from_datamap(DataMap.fromDict(datamap), self.user, True)
-        #self.assertEqual(tale["authors"][0]["firstName"], "Pooran")
+        # }
+        # tale = provider.proto_tale_from_datamap(DataMap.fromDict(datamap), self.user, True)
+        # self.assertEqual(tale["authors"][0]["firstName"], "Pooran")
 
     def tearDown(self):
         self.model('user').remove(self.user)

--- a/plugin_tests/import_test.py
+++ b/plugin_tests/import_test.py
@@ -319,7 +319,12 @@ class ImportTaleTestCase(base.TestCase):
         self.model("image", "wholetale").remove(image)
 
     @vcr.use_cassette(os.path.join(DATA_PATH, "tale_import_zip.txt"))
-    def testTaleImportZip(self):
+    @mock.patch("girder.plugins.wholetale.lib.manifest.ImageBuilder")
+    def testTaleImportZip(self, mock_builder):
+        mock_builder.return_value.container_config.repo2docker_version = \
+            "craigwillis/repo2docker:latest"
+        mock_builder.return_value.get_tag.return_value = \
+            "some_image_digest"
         image = self.model("image", "wholetale").createImage(
             name="Jupyter Notebook",
             creator=self.user,
@@ -363,13 +368,16 @@ class ImportTaleTestCase(base.TestCase):
             job = Job().load(job["_id"], force=True)
         self.assertEqual(job["status"], JobStatus.SUCCESS)
         # TODO: make it more extensive...
-        tale = Tale().findOne({"title": "Water Tale"})
+        tale = Tale().load(tale["_id"], force=True)
         self.assertTrue(tale is not None)
         self.assertEqual(
             [(obj["_modelType"], obj["mountPath"]) for obj in tale["dataSet"]],
             [("item", "usco2005.xls")],
         )
-        self.assertEqual(tale["imageInfo"]["repo2docker_version"], "wholetale/repo2docker_wholetale:latest")
+        self.assertEqual(
+            tale["imageInfo"]["repo2docker_version"],
+            "wholetale/repo2docker_wholetale:latest"
+        )
 
         events = get_events(self, since)
         self.assertEqual(
@@ -384,7 +392,12 @@ class ImportTaleTestCase(base.TestCase):
         self.model("image", "wholetale").remove(image)
 
     @vcr.use_cassette(os.path.join(DATA_PATH, "tale_import_rrzip.txt"))
-    def testTaleImportZipWithRuns(self):
+    @mock.patch("girder.plugins.wholetale.lib.manifest.ImageBuilder")
+    def testTaleImportZipWithRuns(self, mock_builder):
+        mock_builder.return_value.container_config.repo2docker_version = \
+            "craigwillis/repo2docker:latest"
+        mock_builder.return_value.get_tag.return_value = \
+            "some_image_digest"
         image = self.model("image", "wholetale").createImage(
             name="Jupyter Notebook",
             creator=self.user,

--- a/plugin_tests/manifest_test.py
+++ b/plugin_tests/manifest_test.py
@@ -1,3 +1,4 @@
+import mock
 import copy
 import json
 from operator import itemgetter
@@ -194,7 +195,11 @@ class ManifestTestCase(base.TestCase):
             authors=self.tale_info["authors"],
         )
 
-    def testManifest(self):
+    @mock.patch("gwvolman.build_utils.ImageBuilder")
+    def testManifest(self, mock_builder):
+        mock_builder.return_value.container_config.repo2docker_version = "craigwillis/repo2docker:latest"
+        mock_builder.return_value.get_tag.return_value = \
+            self.tale['imageInfo']['digest'].replace('registry', 'images', 1)
         self._testCreateBasicAttributes()
         self._testAddTaleCreator()
         self._testCreateContext()
@@ -208,7 +213,7 @@ class ManifestTestCase(base.TestCase):
         self._test_create_image_info()
 
     def _testRelatedIdentifiers(self):
-        from girder.plugins.wholetale.lib.manifest import Manifest
+        from server.lib.manifest import Manifest
         from girder.plugins.wholetale.models.tale import Tale
 
         tale = copy.deepcopy(self.tale)

--- a/plugin_tests/publish_test.py
+++ b/plugin_tests/publish_test.py
@@ -95,8 +95,12 @@ class PublishTestCase(base.TestCase):
     def testPublishDataONE(self):
         with mock.patch("gwvolman.tasks.publish.apply_async"), mock.patch(
             "gwvolman.tasks.publish.delay"
-        ) as dl:
-
+        ) as dl, mock.patch(
+            "girder.plugins.wholetale.lib.manifest.ImageBuilder"
+        ) as mock_builder:
+            mock_builder.return_value.container_config.repo2docker_version = \
+                "craigwillis/repo2docker:latest"
+            mock_builder.return_value.get_tag.return_value = "images.local.wholetale.org/digest123"
             dl.return_value = FakeJob()
 
             remoteMemberNode = "nowhere"  # non exisiting repository
@@ -151,8 +155,12 @@ class PublishTestCase(base.TestCase):
     def testPublishZenodo(self):
         with mock.patch("gwvolman.tasks.publish.apply_async"), mock.patch(
             "gwvolman.tasks.publish.delay"
-        ) as dl:
-
+        ) as dl, mock.patch(
+            "girder.plugins.wholetale.lib.manifest.ImageBuilder"
+        ) as mock_builder:
+            mock_builder.return_value.container_config.repo2docker_version = \
+                "craigwillis/repo2docker:latest"
+            mock_builder.return_value.get_tag.return_value = "images.local.wholetale.org/digest123"
             dl.return_value = FakeJob()
 
             repository = "sandbox.zenodo.org"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ jsonpickle==1.5.2  # see #447
 python-magic
 requests
 redis==3.5.3
-git+https://github.com/whole-tale/girderfs@v1.2rc1#egg=girderfs
-git+https://github.com/whole-tale/gwvolman@v1.2rc1#egg=gwvolman
+git+https://github.com/whole-tale/girderfs@master#egg=girderfs
+git+https://github.com/whole-tale/gwvolman@master#egg=gwvolman
 dataone.common==3.4.7
 dataone.libclient==3.4.7
 dataone.cli==3.4.7

--- a/server/lib/dataverse/provider.py
+++ b/server/lib/dataverse/provider.py
@@ -56,7 +56,7 @@ def _get_attrs_via_head(obj, url, headers=None):
     # see https://github.com/IQSS/dataverse/issues/5322
     req = requests.head(url, allow_redirects=True, headers=headers)
     if req.ok:
-        size = int(req.headers.get("Content-Length", obj["size"]))
+        size = int(req.headers.get("Content-Length", default=obj.get("size", "-1")))
     else:
         # Now the magic, since S3 accepts range request, we cheat the system
         # by requesting only 100 bytes to get the headers we want.


### PR DESCRIPTION
During manifest creation compute `imageInfo` tag/image name using the state of workspace, rather than whatever is dangling off the Tale object.