### PR TITLE
Wait for instance to return some content before assuming it works

### DIFF
--- a/server/models/instance.py
+++ b/server/models/instance.py
@@ -254,6 +254,8 @@ def _wait_for_server(url, token, timeout=30, wait_time=0.5):
         try:
             r = requests.get(url, cookies={'girderToken': token}, timeout=1)
             r.raise_for_status()
+            if int(r.headers.get("Content-Length", "0")) == 0:
+                raise ValueError("HTTP server returns no content")
         except requests.exceptions.HTTPError as err:
             logger.info(
                 'Booting server at [%s], getting HTTP status [%s]', url, err.response.status_code)
@@ -300,7 +302,7 @@ def finalizeInstance(event):
         ):
             # Get a url to the container
             service = getCeleryApp().AsyncResult(job['celeryTaskId']).get()
-            url = service.get("url", "https://google.com")
+            url = service.get("url", "https://girder.hub.yt/")
 
             # Generate the containerInfo
             valid_keys = set(containerInfoSchema['properties'].keys())


### PR DESCRIPTION
### Problem

As reported by @craig-willis, there's a peculiar issue where Xpra based instances run successfully but iframe in the Interactive view doesn't show anything until you hard refresh the dashboard. It's caused by the fact that our current "health" check only looks for 200 status code, which might happen way before software inside the container actually initiliazes

### Proposed solution

Apart from checking the error code we can check if GET instance_url returns any data.

### How to test?
1. Deploy on .stage (already did that)
2. Run any STATA (desktop) tale and confirm that Xpra comes up without refresh.