### PR TITLE
Add info how to build image if it's not in registry. Fixes #566

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -92,5 +92,8 @@ add_python_test(openicpsr
   plugins/wholetale/openicpsr_login_flow.txt
   plugins/wholetale/openicpsr_import.txt
 )
+add_python_test(export
+  PLUGIN wholetale
+)
 add_python_style_test(python_static_analysis_wholetale
                       "${PROJECT_SOURCE_DIR}/plugins/wholetale/server")

--- a/plugin_tests/export_test.py
+++ b/plugin_tests/export_test.py
@@ -1,0 +1,145 @@
+import json
+
+import httmock
+import mock
+
+from tests import base
+
+from .tests_helpers import mockOtherRequest
+
+
+def setUpModule():
+    base.enabledPlugins.append("wholetale")
+    base.enabledPlugins.append("wt_home_dir")
+    base.enabledPlugins.append("virtual_resources")
+    base.enabledPlugins.append("wt_versioning")
+    base.startServer()
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class ExportTestCase(base.TestCase):
+    def setUp(self):
+        super(ExportTestCase, self).setUp()
+        users = (
+            {
+                "email": "root@dev.null",
+                "login": "admin",
+                "firstName": "Root",
+                "lastName": "van Klompf",
+                "password": "secret",
+            },
+            {
+                "email": "joe@dev.null",
+                "login": "joeregular",
+                "firstName": "Joe",
+                "lastName": "Regular",
+                "password": "secret",
+            },
+        )
+
+        self.authors = [
+            {
+                "firstName": "Charles",
+                "lastName": "Darwmin",
+                "orcid": "https://orcid.org/000-000",
+            },
+            {
+                "firstName": "Thomas",
+                "lastName": "Edison",
+                "orcid": "https://orcid.org/111-111",
+            },
+        ]
+        self.admin, self.user = [
+            self.model("user").createUser(**user) for user in users
+        ]
+
+        self.image = self.model("image", "wholetale").createImage(
+            name="test image", creator=self.admin, public=True
+        )
+
+    def testExportTemplate(self):
+        resp = self.request(
+            path="/tale",
+            method="POST",
+            user=self.user,
+            type="application/json",
+            body=json.dumps({"imageId": str(self.image["_id"]), "dataSet": []}),
+        )
+        self.assertStatusOk(resp)
+        tale = resp.json
+
+        with mock.patch(
+            "girder.plugins.wholetale.lib.manifest.ImageBuilder"
+        ) as mock_builder:
+            mock_builder.return_value.container_config.repo2docker_version = (
+                "craigwillis/repo2docker:latest"
+            )
+            mock_builder.return_value.get_tag.return_value = (
+                "registry.local.wholetale.org/tale/hash:tag"
+            )
+            resp = self.request(
+                path=f"/tale/{tale['_id']}/manifest",
+                method="GET",
+                user=self.user,
+            )
+            self.assertStatusOk(resp)
+            manifest = resp.json
+
+        from server.lib.exporters.bag import BagTaleExporter
+
+        exporter = BagTaleExporter(self.user, manifest, {})
+
+        @httmock.urlmatch(
+            scheme="https",
+            netloc="images.local.wholetale.org",
+            path="^/v2/tale/hash/tags/list$",
+            method="GET",
+        )
+        def mockImageFoundResponse(url, request):
+            return json.dumps(
+                {
+                    "name": "tale/hash",
+                    "tags": ["tag"],
+                }
+            )
+
+        with httmock.HTTMock(mockImageFoundResponse, mockOtherRequest):
+            tmpl = exporter.format_run_file(
+                {"port": 80, "targetMount": "/srv", "user": "user"},
+                "path?param",
+                "token",
+            )
+            self.assertTrue("jupyter-repo2docker" not in tmpl)
+
+        @httmock.urlmatch(
+            scheme="https",
+            netloc="images.local.wholetale.org",
+            path="^/v2/tale/hash/tags/list$",
+            method="GET",
+        )
+        def mockImageNotFoundResponse(url, request):
+            return httmock.response(
+                status_code=404,
+                content=json.dumps(
+                    {
+                        "errors": [
+                            {
+                                "code": "NAME_UNKNOWN",
+                                "message": "repository name not known to registry",
+                                "detail": {"name": "tale/hash"},
+                            }
+                        ]
+                    }
+                ),
+            )
+
+        with httmock.HTTMock(mockImageNotFoundResponse, mockOtherRequest):
+            tmpl = exporter.format_run_file(
+                {"port": 80, "targetMount": "/srv", "user": "user"},
+                "path?param",
+                "token",
+            )
+            self.assertTrue("jupyter-repo2docker" in tmpl)

--- a/server/lib/exporters/bag.py
+++ b/server/lib/exporters/bag.py
@@ -22,18 +22,18 @@ build_tpl = r"""
 # Use repo2docker to build the image from the workspace
 docker run  \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -v "`pwd`/data/workspace:/WholeTale/workspace" \
-  -v "`pwd`/metadata/environment.json:/WholeTale/workspace/environment.json" \
+  -v "`pwd`/data/workspace:{targetMount}/workspace" \
+  -v "`pwd`/metadata/environment.json:{targetMount}/workspace/environment.json" \
   --privileged=true \
   -e DOCKER_HOST=unix:///var/run/docker.sock \
   {repo2docker} \
   jupyter-repo2docker \
     --config=/wholetale/repo2docker_config.py \
-    --target-repo-dir=/WholeTale/workspace \
+    --target-repo-dir={targetMount}/workspace \
     --user-id=1000 --user-name={user} \
     --no-clean --no-run --debug \
     --image-name {image_name} \
-    /WholeTale/workspace
+    {targetMount}/workspace
 """
 
 run_tpl = r"""#!/bin/sh
@@ -227,6 +227,7 @@ class BagTaleExporter(TaleExporter):
             build_cmd = build_tpl.format(
                 repo2docker=container_config.get('repo2docker_version', REPO2DOCKER_VERSION),
                 user=container_config['user'],
+                targetMount=container_config['targetMount'],
                 image_name=image_digest
             )
 


### PR DESCRIPTION
During export check if image exists in the repository. If not, add blurb about how to build it to `run-local.sh`.

### How to test?

1. Create a Tale
2. Export it
3. Confirm build blurb is in `run-local.sh`
4. Build Tale
5. Export it
6. Confirm build blurb is not in `run-local.sh`

### Note
You'll need to add:
```
@@ -59,6 +59,8 @@ services:
       - "GOSU_CHOWN=/tmp/data"
       - DATAONE_URL=https://cn-stage-2.test.dataone.org/cn
       - HOSTDIR=/
+    extra_hosts:
+      - "images.local.wholetale.org:host-gateway"
     deploy:
       replicas: 1
       labels:
```
to `docker-stack.yml` in deploy-dev.