### PR TITLE
Re-purpose GET /folder/:id/listing for passthrough fs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,7 @@
-version: 2.0
+version: 2.1
+orbs:
+  codecov: codecov/codecov@3
+
 jobs:
   build:
     docker:
@@ -34,11 +37,6 @@ jobs:
             mkdir /girder/build
             ctest -VV -S /girder/plugins/wholetale/cmake/circle_continuous.cmake
       - run:
-          name: Install Codecov client
-          command: python3 -m pip install codecov
-      - run:
           name: Collect coverage reports
           command: coverage combine /girder/build/test/coverage/python_temp/
-      - run:
-          name: Uploading Coverage Results
-          command: codecov
+      - codecov/upload

--- a/plugin_tests/instance_test.py
+++ b/plugin_tests/instance_test.py
@@ -487,7 +487,7 @@ class InstanceTestCase(base.TestCase):
                 path='/instance/{_id}'.format(**instance), method='DELETE',
                 user=self.user)
             self.assertStatusOk(resp)
-            mock_apply_async.assert_called_once()
+            self.assertEqual(mock_apply_async.call_count, 2)
 
         resp = self.request(
             path='/instance/{_id}'.format(**instance), method='GET',

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -19,6 +19,7 @@ from girder.api.rest import \
     boundHandler, loadmodel, RestException
 from girder.constants import AccessType, TokenScope
 from girder.exceptions import GirderException
+from girder.models.assetstore import Assetstore
 from girder.models.folder import Folder
 from girder.models.model_base import AccessException, ValidationException
 from girder.models.notification import Notification, ProgressState
@@ -287,13 +288,16 @@ def listFolder(self, folder, params):
         "type": 0,
         "children": [],
     }
+    # We have only one assetstore, so we can use the current one
+    current_assetstore = Assetstore().getCurrent()
+    assetstore_path = current_assetstore["root"]
     for fs_path, fobj in Folder().fileList(
         folder, user=user, data=False, subpath=False, path="",
     ):
-        try:
+        if fobj.get("imported", False):
             host_path = fobj["path"]
-        except KeyError:
-            continue
+        else:
+            host_path = os.path.join(assetstore_path, fobj["path"])
 
         current_level = data
         fs_path_parts = pathlib.Path(fs_path).parts

--- a/server/schema/misc.py
+++ b/server/schema/misc.py
@@ -222,8 +222,9 @@ containerInfoSchema = {
         "nodeId": {"type": "string"},
         "mountPoint": {"type": "string"},
         "volumeName": {"type": "string"},
+        "fscontainerId": {"type": "string"},
     },
-    "required": ["name", "mountPoint", "nodeId", "volumeName"],
+    "required": ["name", "fscontainerId", "nodeId", "volumeName"],
 }
 
 imageInfoSchema = {


### PR DESCRIPTION
This method was used by `girderfs:LocalGirderFS` back in the day, but that hasn't been the case for a very long time. I've re-purposed it to work with https://github.com/data-exp-lab/girderfs_passthrough