### PR TITLE
Add a toggle to filter WT specific collections in Collections View

### DIFF
--- a/web_client/main.js
+++ b/web_client/main.js
@@ -2,3 +2,4 @@ import './routes';
 import './views/HierarchyWidget';
 import './views/FooterView';
 import './views/HeaderUserView';
+import './views/CollectionsView';

--- a/web_client/stylesheets/collectionsView.styl
+++ b/web_client/stylesheets/collectionsView.styl
@@ -1,0 +1,9 @@
+.g-hidden-collections-switch
+  margin-right 10px
+  display inline-block
+
+  label
+    font-weight normal
+
+  .bootstrap-switch
+    margin-left 5px

--- a/web_client/templates/collectionsView.pug
+++ b/web_client/templates/collectionsView.pug
@@ -1,0 +1,3 @@
+.g-hidden-collections-switch
+  label(for="g-plugin-switch") System Collections
+  input.g-plugin-switch(type="checkbox", checked=undefined, data-size="mini", data-on-color="primary")

--- a/web_client/views/CollectionsView.js
+++ b/web_client/views/CollectionsView.js
@@ -1,0 +1,45 @@
+import { wrap } from 'girder/utilities/PluginUtils';
+import CollectionsView from 'girder/views/body/CollectionsView';
+
+import CollectionsViewTemplate from '../templates/collectionsView.pug';
+
+import 'girder/stylesheets/body/plugins.styl';
+import 'bootstrap-switch'; // /dist/js/bootstrap-switch.js',
+import 'bootstrap-switch/dist/css/bootstrap3/bootstrap-switch.css';
+
+import '../stylesheets/collectionsView.styl';
+
+var reFiltered = /^((?!(WholeTale)).)*$/;
+var enableHiddenCollections = false;
+
+wrap(CollectionsView, 'initialize', function (initialize, ...args) {
+    initialize.apply(this, args);
+
+    if (!enableHiddenCollections) {
+        this.collection.filterFunc = function (collection) {
+            return collection.name.match(reFiltered);
+        };
+    }
+});
+
+wrap(CollectionsView, 'render', function (render) {
+    render.call(this);
+    console.log(this.settings);
+    this.$('.g-collection-pagination').before(CollectionsViewTemplate());
+    this.$('.g-plugin-switch')
+        .bootstrapSwitch()
+        .bootstrapSwitch('state', enableHiddenCollections)
+        .off('switchChange.bootstrapSwitch')
+        .on('switchChange.bootstrapSwitch', (event, state) => {
+            if (state === true) {
+                this.collection.filterFunc = null;
+            } else {
+                this.collection.filterFunc = function (collection) {
+                    return collection.name.match(reFiltered);
+                };
+            }
+            enableHiddenCollections = state;
+            this.collection.fetch({}, true);
+        });
+    return this;
+});


### PR DESCRIPTION
### Motivation
On a deployment where WT is not front and center this will allow to avoid confusion while looking at available datasets.

### Approach
Use native `filterFunc` to filter out collections starting with "WholeTale"

### How to test?
1. Deploy this, create a tale and register random data from an external repository (to populate WT collections).
2. Navigate to https://girder.local.wholetale.org/#collections
3. View should be empty
4. Toggle the switch.
5. View should contain WholeTale collections
![colls_on](https://user-images.githubusercontent.com/352673/226439586-31617a58-4545-4d9b-9a79-253dbba5ad41.png)
![colls_off](https://user-images.githubusercontent.com/352673/226439593-038f7523-e693-4255-9d27-688eef87dd78.png)
