### PR TITLE
Enable authorization on arbitrary services 

### DIFF
--- a/plugin_tests/basic_test.py
+++ b/plugin_tests/basic_test.py
@@ -213,3 +213,41 @@ class WholeTaleTestCase(base.TestCase):
         self.assertStatus(resp, 303)
         self.assertEqual(resp.headers["Location"],
                          "https://blah.wholetale.org")
+
+    def testAuthorize(self):
+
+        # Note: additional instance specific tests in instance_tests
+        # Non-instance authorization tests
+        resp = self.request(
+            path="/user/authorize",
+            method="GET",
+            isJson=False,
+            user=self.user,
+        )
+        # Assert 400 "Forward auth request required"
+        self.assertStatus(resp, 400)
+
+        # Non-instance host with valid user
+        resp = self.request(
+            user=self.user,
+            path="/user/authorize",
+            method="GET",
+            additionalHeaders=[("X-Forwarded-Host", "docs.wholetale.org"),
+                               ("X-Forwarded_Uri", "/")],
+            isJson=False,
+        )
+        self.assertStatus(resp, 200)
+
+        # No user
+        resp = self.request(
+            path="/user/authorize",
+            method="GET",
+            additionalHeaders=[("X-Forwarded-Host", "blah.wholetale.org"),
+                               ("X-Forwarded-Uri", "/")],
+            isJson=False,
+        )
+        self.assertStatus(resp, 303)
+        # Confirm redirect to https://girder.{domain}/api/v1/user/sign_in
+        self.assertEqual(resp.headers["Location"],
+                         "https://girder.wholetale.org/api/v1/"
+                         "user/sign_in?redirect=https://blah.wholetale.org/")

--- a/plugin_tests/instance_test.py
+++ b/plugin_tests/instance_test.py
@@ -307,7 +307,8 @@ class InstanceTestCase(base.TestCase):
         # Instance authorization checks
         # Missing forward auth headers
         resp = self.request(
-            path="/instance/authorize",
+            path="/user/authorize",
+            params={"instance": True},
             method="GET",
             isJson=False,
             user=self.user,
@@ -318,7 +319,8 @@ class InstanceTestCase(base.TestCase):
         # Valid user, invalid host
         resp = self.request(
             user=self.user,
-            path="/instance/authorize",
+            path="/user/authorize",
+            params={"instance": True},
             method="GET",
             additionalHeaders=[("X-Forwarded-Host", "blah.wholetale.org"),
                                ("X-Forwarded_Uri", "/")],
@@ -330,7 +332,8 @@ class InstanceTestCase(base.TestCase):
         # Valid user, valid host
         resp = self.request(
             user=self.user,
-            path="/instance/authorize",
+            path="/user/authorize",
+            params={"instance": True},
             method="GET",
             additionalHeaders=[("X-Forwarded-Host", "tmp-xxx.wholetale.org"),
                                ("X-Forwarded_Uri", "/")],
@@ -340,7 +343,8 @@ class InstanceTestCase(base.TestCase):
 
         # No user
         resp = self.request(
-            path="/instance/authorize",
+            path="/user/authorize",
+            params={"instance": True},
             method="GET",
             additionalHeaders=[("X-Forwarded-Host", "tmp-xxx.wholetale.org"),
                                ("X-Forwarded-Uri", "/")],


### PR DESCRIPTION
**Problem**
The current forward auth implementation is limited to instances. For the HTMDEC project, we want to be able to deploy a separate service (in this case documentation) and use Girder for authorization.

**Approach**
Move the `/authorize` endpoint to the `user` and add a flag to determine whether to check for instance access. If not an instance, 

**To test**
* clone https://github.com/htmdec/htmdec.github.io unde
* Add the docs service (below) to your `docker-stack.yml` and update
* In a private session, go to https://docs.local.wholetale.org/
* Confirm that you are prompted to sign in. 
* Sign in, confirm that you see the "Welcome to nginx" page
* Go to https://dashboard.local.wholetale.org
* Start and instance and copy the instance URL
* In a new private session, try to access the instance
* Confirm that you are prompted to sign in and that after sign in you can access the instance.


```
  docs:
    image: nginx
    networks:
      - traefik-net
    deploy:
      replicas: 1
      labels:
        - "traefik.enable=true"
        - "traefik.http.routers.docs.rule=Host(`docs.local.wholetale.org`)"
        - "traefik.http.routers.docs.entrypoints=websecure"
        - "traefik.http.routers.docs.tls=true"
        - "traefik.http.services.docs.loadbalancer.server.port=80"
        - "traefik.http.services.docs.loadbalancer.passhostheader=false"
        - "traefik.docker.network=wt_traefik-net"
        - "traefik.http.middlewares.docs.forwardauth.address=http://girder:8080/api/v1/user/authorize/"
        - "traefik.http.middlewares.docs.forwardauth.trustforwardheader=true"
        - "traefik.http.routers.docs.middlewares=docs"
  ```