### PR TITLE
Do not fail instance remove if volume doesn't exist

### DIFF
--- a/server/models/instance.py
+++ b/server/models/instance.py
@@ -144,12 +144,15 @@ class Instance(AccessControlledModel):
         notify_event([instance['creatorId']], 'wt_instance_deleting',
                      {'taleId': instance['taleId'], 'instanceId': instance['_id']})
 
-        volumeTask = remove_volume.signature(
-            args=[str(instance['_id'])],
-            girder_client_token=str(token['_id']),
-            queue=instance['containerInfo']['nodeId']
-        ).apply_async()
-        volumeTask.get(timeout=TASK_TIMEOUT)
+        try:
+            volumeTask = remove_volume.signature(
+                args=[str(instance['_id'])],
+                girder_client_token=str(token['_id']),
+                queue=instance['containerInfo']['nodeId']
+            ).apply_async()
+            volumeTask.get(timeout=TASK_TIMEOUT)
+        except KeyError:
+            pass
 
         # TODO: handle error
         self.remove(instance)


### PR DESCRIPTION
If Instance fails during image build, `containerInfo` is not there yet on instance. As result it fails during remove Instance step with:

```
2023-05-23 17:50:24,591] ERROR: 500 Error    
Traceback (most recent call last):    
  File "/girder/girder/api/rest.py", line 630, in endpointDecorator    
    val = fun(self, path, params)    
  File "/girder/girder/api/rest.py", line 1212, in DELETE    
    return self.handleRoute('DELETE', path, params)    
  File "/girder/girder/api/rest.py", line 970, in handleRoute    
    val = handler(**kwargs)    
  File "/girder/girder/api/access.py", line 63, in wrapped    
    return fun(*args, **kwargs)    
  File "/girder/girder/api/describe.py", line 709, in wrapped    
    return fun(*args, **kwargs)    
  File "/girder/plugins/wholetale/server/rest/instance.py", line 173, in deleteInstance    
    self.model('instance', 'wholetale').deleteInstance(    
  File "/girder/plugins/wholetale/server/models/instance.py", line 150, in deleteInstance    
    queue=instance['containerInfo']['nodeId']    
KeyError: 'containerInfo'    
Additional info:    
  Request URL: DELETE https://girder.htmdec.org/api/v1/instance/645ce2bf36f2efb9918c20b3    
  Query string:     
  Remote IP: 10.0.0.2    
```


### How to test?
1. Create a Tale with an ill-defined `requirements.txt` (e.g. package arafglkalfkgh)
2. Run the Tale

### Expected output
Tale fails to build an Instance is cleanly removed

### Actual output
You get stuck with an tale/instance in a stopping state.